### PR TITLE
Step the simulator over horizon

### DIFF
--- a/src/jaxsim/simulation/simulator_callbacks.py
+++ b/src/jaxsim/simulation/simulator_callbacks.py
@@ -1,0 +1,55 @@
+import abc
+from typing import Callable, Dict, Tuple
+
+import jaxsim.typing as jtp
+from jaxsim.high_level.model import StepData
+from jaxsim.simulation.simulator import JaxSim
+
+ConfigureCallbackSignature = Callable[[JaxSim], JaxSim]
+PreStepCallbackSignature = Callable[[JaxSim], JaxSim]
+PostStepCallbackSignature = Callable[
+    [JaxSim, Dict[str, StepData]], Tuple[JaxSim, jtp.PyTree]
+]
+
+
+class SimulatorCallback(abc.ABC):
+    pass
+
+
+class ConfigureCallback(SimulatorCallback):
+    @property
+    def configure_cb(self) -> ConfigureCallbackSignature:
+
+        return lambda sim: self.configure(sim=sim)
+
+    @abc.abstractmethod
+    def configure(self, sim: JaxSim) -> JaxSim:
+        pass
+
+
+class PreStepCallback(SimulatorCallback):
+    @property
+    def pre_step_cb(self) -> PreStepCallbackSignature:
+
+        return lambda sim: self.pre_step(sim=sim)
+
+    @abc.abstractmethod
+    def pre_step(self, sim: JaxSim) -> JaxSim:
+        pass
+
+
+class PostStepCallback(SimulatorCallback):
+    @property
+    def post_step_cb(self) -> PostStepCallbackSignature:
+
+        return lambda sim, step_data: self.post_step(sim=sim, step_data=step_data)
+
+    @abc.abstractmethod
+    def post_step(
+        self, sim: JaxSim, step_data: Dict[str, StepData]
+    ) -> Tuple[JaxSim, jtp.PyTree]:
+        pass
+
+
+class CallbackHandler(ConfigureCallback, PreStepCallback, PostStepCallback):
+    pass


### PR DESCRIPTION
This PR adds the possibility to step the simulator over a time horizon instead of being stepped over only a single $\Delta t$.

Two modalities are supported:

1. Pure open loop stepping. All the simulated models are integrated over the horizon in open-loop, i.e. their input (joint torques and link external forces) could either be either kept constant or just applied in the first step.
2. Closed loop stepping. In this case, this PR introduces _experimental_ callbacks that, for example, could include logic of robot controllers. The callback object could be a generic PyTree and could have an internal state.

Callbacks could be useful in any case to extract data from the entire horizon for logging purpose.

Note that this kind of integration over horizon is mostly beneficial when it is combined with `jax.jit`. In this way, the simulator can maximize runtime performance by compiling together a possibly long forward simulation.

**Note:** We do not support integrating in parallel multiple cloned models belonging to a single simulation instance. Integration parallelism is performed by creating multiple [`simulator.JaxSim`](https://github.com/ami-iit/jaxsim/blob/1a89f433f0c22034636db07fa7dd387647b01a50/src/jaxsim/simulation/simulator.py#L42-L43) objects with only one model. The overhead of the simulator instance is almost negligible, and this approach makes calling `jax.vmap` explicit from the user point-of-view.

**Note:** The new `JaxSim.step_over_horizon` method, contrarily to all the other methods that can be either called in an object-oriented or a functional way thanks to [`JaxsimDataclass`](https://github.com/ami-iit/jaxsim/blob/1a89f433f0c22034636db07fa7dd387647b01a50/src/jaxsim/utils.py#L28), is purely functional. This is due to the logic related to the callbacks.