### PR TITLE
Implement CRBA with `jax.lax.scan`

### DIFF
--- a/src/jaxsim/physics/algos/crba.py
+++ b/src/jaxsim/physics/algos/crba.py
@@ -1,3 +1,6 @@
+from typing import Tuple
+
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -22,24 +25,55 @@ def crba(model: PhysicsModel, q: jtp.Vector) -> jtp.Matrix:
     i_X_0 = jnp.zeros_like(Xtree)
     i_X_0 = i_X_0.at[0].set(jnp.eye(6))
 
-    for i in np.arange(start=1, stop=model.NB):
+    # Parent array mapping: i -> λ(i).
+    # Exception: λ(0) must not be used, it's initialized to -1.
+    λ = model.parent
+
+    # ====================
+    # Propagate kinematics
+    # ====================
+
+    ForwardPassCarry = Tuple[jtp.MatrixJax, jtp.MatrixJax]
+    forward_pass_carry = (Xup, i_X_0)
+
+    def propagate_kinematics(
+        carry: ForwardPassCarry, i: jtp.Int
+    ) -> Tuple[ForwardPassCarry, None]:
+
+        Xup, i_X_0 = carry
 
         Xup_i = Xj[i] @ Xtree[i]
         Xup = Xup.at[i].set(Xup_i)
 
-        i_X_0_i = Xup[i] @ i_X_0[model.parent[i]]
+        i_X_0_i = Xup[i] @ i_X_0[λ[i]]
         i_X_0 = i_X_0.at[i].set(i_X_0_i)
+
+        return (Xup, i_X_0), None
+
+    (Xup, i_X_0), _ = jax.lax.scan(
+        f=propagate_kinematics,
+        init=forward_pass_carry,
+        xs=np.arange(start=1, stop=model.NB),
+    )
+
+    # ===================
+    # Compute mass matrix
+    # ===================
 
     M = jnp.zeros(shape=(6 + model.dofs(), 6 + model.dofs()))
 
-    for i in reversed(np.arange(start=1, stop=model.NB)):
+    BackwardPassCarry = Tuple[jtp.MatrixJax, jtp.MatrixJax]
+    backward_pass_carry = (Mc, M)
 
-        Mc_λi = Mc[model.parent[i]] + Xup[i].T @ Mc[i] @ Xup[i]
-        Mc = Mc.at[model.parent[i]].set(Mc_λi)
-
-    for i in reversed(np.arange(start=1, stop=model.NB)):
+    def backward_pass(
+        carry: BackwardPassCarry, i: jtp.Int
+    ) -> Tuple[BackwardPassCarry, None]:
 
         ii = i - 1
+        Mc, M = carry
+
+        Mc_λi = Mc[λ[i]] + Xup[i].T @ Mc[i] @ Xup[i]
+        Mc = Mc.at[λ[i]].set(Mc_λi)
 
         Fi = Mc[i] @ S[i]
         M_ii = S[i].T @ Fi
@@ -47,10 +81,15 @@ def crba(model: PhysicsModel, q: jtp.Vector) -> jtp.Matrix:
 
         j = i
 
-        while model._parent_array_dict[j] > 0:
+        CarryInnerFn = Tuple[jtp.Int, jtp.MatrixJax, jtp.MatrixJax]
+        carry_inner_fn = (j, Fi, M)
+
+        def while_loop_body(carry: CarryInnerFn) -> CarryInnerFn:
+
+            j, Fi, M = carry
 
             Fi = Xup[j].T @ Fi
-            j = model._parent_array_dict[j]
+            j = λ[j]
             jj = j - 1
 
             M_ij = Fi.T @ S[j]
@@ -58,11 +97,51 @@ def crba(model: PhysicsModel, q: jtp.Vector) -> jtp.Matrix:
             M = M.at[ii + 6, jj + 6].set(M_ij.squeeze())
             M = M.at[jj + 6, ii + 6].set(M_ij.squeeze())
 
+            return j, Fi, M
+
+        # The following functions are part of a (rather messy) workaround for computing
+        # a while loop using a for loop with fixed number of iterations.
+        def inner_fn(carry: CarryInnerFn, k: jtp.Int) -> Tuple[CarryInnerFn, None]:
+            def compute_inner(carry: CarryInnerFn) -> Tuple[CarryInnerFn, None]:
+                j, Fi, M = carry
+                out = jax.lax.cond(
+                    pred=(λ[j] > 0),
+                    true_fun=while_loop_body,
+                    false_fun=lambda carry: carry,
+                    operand=carry,
+                )
+                return out, None
+
+            j, Fi, M = carry
+            return jax.lax.cond(
+                pred=(k == j),
+                true_fun=compute_inner,
+                false_fun=lambda carry: (carry, None),
+                operand=carry,
+            )
+
+        (j, Fi, M), _ = jax.lax.scan(
+            f=inner_fn,
+            init=carry_inner_fn,
+            xs=np.flip(np.arange(start=1, stop=model.NB)),
+        )
+
         Fi = i_X_0[j].T @ Fi
 
         M = M.at[0:6, ii + 6].set(Fi.squeeze())
         M = M.at[ii + 6, 0:6].set(Fi.squeeze())
 
+        return (Mc, M), None
+
+    # This scan performs the backward pass to compute Mbj, Mjb and Mjj, that
+    # also includes a fake while loop implemented with a scan and two cond.
+    (Mc, M), _ = jax.lax.scan(
+        f=backward_pass,
+        init=backward_pass_carry,
+        xs=np.flip(np.arange(start=1, stop=model.NB)),
+    )
+
+    # Store the locked 6D rigid-body inertia matrix Mbb ∈ ℝ⁶ˣ⁶
     M = M.at[0:6, 0:6].set(Mc[0])
 
     return M


### PR DESCRIPTION
This PR implements the CRBA algorithm with `jax.lax.scan`, with two main benefits:

- Reduction in JIT compilation time especially for model with many DoF(#5)
- Forward and backward AD support (#4)

This goes also in the direction of #12. Unfortunately, as it was already clear, the readability of the algorithm is affected by the switch.

<details>
<summary>CRBA Algorithm</summary>

![Screenshot_20220920_153145](https://user-images.githubusercontent.com/469199/191271239-0ebcb9ad-97d0-457d-b832-b25b146f259d.png)

</details>

Here below a summary of the new CRBA performance compared to the previous implementation:

| Model name | DoFs | JIT time | JIT time speedup | Runtime | Runtime speedup |
| --- | :---: | :---: | :---: | :---: | :---: |
| [`panda`][panda] | 9 | 1.35 s | x3.7 | 569 µs | x1.01 |
| [`iCubGazeboV2_5`][icub] | 32 | 5.67 s | x7 | 1.17 ms | x1.01 |

The JIT time is now much lower than before. Instead, the runtime didn't change.

[icub]: https://github.com/robotology/gym-ignition-models/blob/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/iCubGazeboV2_5/icub.urdf
[panda]: https://github.com/robotology/gym-ignition-models/blob/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/panda/panda.urdf