### PR TITLE
Implement Forward Kinematics with `jax.lax.scan`

### DIFF
--- a/src/jaxsim/physics/algos/forward_kinematics.py
+++ b/src/jaxsim/physics/algos/forward_kinematics.py
@@ -1,3 +1,6 @@
+from typing import Tuple
+
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -21,26 +24,48 @@ def forward_kinematics_model(
     r = jnp.vstack(x_fb[4:7])
     W_X_0 = jnp.linalg.inv(Plucker.from_rot_and_trans(Quaternion.to_dcm(qn), r))
 
+    # This is the 6D velocity transform from i-th link frame to the world frame
     W_X_i = jnp.zeros(shape=[model.NB, 6, 6])
     W_X_i = W_X_i.at[0].set(W_X_0)
 
     i_X_pre = model.joint_transforms(q=q)
     pre_X_λi = model.tree_transforms
+
+    # This is the parent-to-child 6D velocity transforms of all links
     i_X_λi = jnp.zeros_like(i_X_pre)
 
-    for i in np.arange(start=1, stop=model.NB):
+    # Parent array mapping: i -> λ(i).
+    # Exception: λ(0) must not be used, it's initialized to -1.
+    λ = model.parent
+
+    PropagateKinematicsCarry = Tuple[jtp.MatrixJax, jtp.MatrixJax]
+    propagate_kinematics_carry = (i_X_λi, W_X_i)
+
+    def propagate_kinematics(
+        carry: PropagateKinematicsCarry, i: jtp.Int
+    ) -> Tuple[PropagateKinematicsCarry, None]:
+
+        i_X_λi, W_X_i = carry
 
         i_X_λi_i = i_X_pre[i] @ pre_X_λi[i]
         i_X_λi = i_X_λi.at[i].set(i_X_λi_i)
 
-        W_X_i_i = W_X_i[model.parent[i]] @ jnp.linalg.inv(i_X_λi[i])
+        W_X_i_i = W_X_i[λ[i]] @ jnp.linalg.inv(i_X_λi[i])
         W_X_i = W_X_i.at[i].set(W_X_i_i)
+
+        return (i_X_λi, W_X_i), None
+
+    (_, W_X_i), _ = jax.lax.scan(
+        f=propagate_kinematics,
+        init=propagate_kinematics_carry,
+        xs=np.arange(start=1, stop=model.NB),
+    )
 
     return jnp.stack([Plucker.to_transform(X) for X in list(W_X_i)])
 
 
 def forward_kinematics(
-    model: PhysicsModel, body_index: int, q: jtp.Vector, xfb: jtp.Vector
+    model: PhysicsModel, body_index: jtp.Int, q: jtp.Vector, xfb: jtp.Vector
 ) -> jtp.Matrix:
 
     return forward_kinematics_model(model=model, q=q, xfb=xfb)[body_index]


### PR DESCRIPTION
This PR implements the Forward Kinematics algorithm with `jax.lax.scan` (#12), with two main benefits:

- Reduction in JIT compilation time especially for model with many DoF
- Forward and backward AD support (#4)

Here below a summary of the new FK performance compared to the previous implementation:

| Model name | DoFs | JIT time | JIT time speedup | Runtime | Runtime speedup |
| --- | :---: | :---: | :---: | :---: | :---: |
| [`panda`][panda] | 9 | 1.96 s | x2.4 | 528 µs | x1.00 |
| [`iCubGazeboV2_5`][icub] | 32 | 7.83 s | x3.2 | 965 μs | x1.05 |

The JIT time is now much lower than before. Instead, the runtime didn't change noticeably.

[icub]: https://github.com/robotology/gym-ignition-models/blob/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/iCubGazeboV2_5/icub.urdf
[panda]: https://github.com/robotology/gym-ignition-models/blob/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/panda/panda.urdf