### PR TITLE
Implement Jacobian with `jax.lax.scan`

### DIFF
--- a/src/jaxsim/physics/algos/jacobian.py
+++ b/src/jaxsim/physics/algos/jacobian.py
@@ -1,3 +1,6 @@
+from typing import Tuple
+
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -7,11 +10,7 @@ from jaxsim.physics.model.physics_model import PhysicsModel
 from . import utils
 
 
-def jacobian(
-    model: PhysicsModel,
-    body_index: int,
-    q: jtp.Vector,
-) -> jtp.Matrix:
+def jacobian(model: PhysicsModel, body_index: jtp.Int, q: jtp.Vector) -> jtp.Matrix:
 
     _, q, _, _, _, _ = utils.process_inputs(physics_model=model, q=q)
 
@@ -23,27 +22,78 @@ def jacobian(
     i_X_0 = jnp.zeros_like(i_X_pre)
     i_X_0 = i_X_0.at[0].set(jnp.eye(6))
 
-    for i in np.arange(start=1, stop=model.NB):
+    # Parent array mapping: i -> λ(i).
+    # Exception: λ(0) must not be used, it's initialized to -1.
+    λ = model.parent
+
+    # ====================
+    # Propagate kinematics
+    # ====================
+
+    PropagateKinematicsCarry = Tuple[jtp.MatrixJax, jtp.MatrixJax]
+    propagate_kinematics_carry = (i_X_λi, i_X_0)
+
+    def propagate_kinematics(
+        carry: PropagateKinematicsCarry, i: jtp.Int
+    ) -> Tuple[PropagateKinematicsCarry, None]:
+
+        i_X_λi, i_X_0 = carry
 
         i_X_λi_i = i_X_pre[i] @ pre_X_λi[i]
         i_X_λi = i_X_λi.at[i].set(i_X_λi_i)
 
-        i_X_0_i = i_X_λi[i] @ i_X_0[model.parent[i]]
+        i_X_0_i = i_X_λi[i] @ i_X_0[λ[i]]
         i_X_0 = i_X_0.at[i].set(i_X_0_i)
+
+        return (i_X_λi, i_X_0), None
+
+    (i_X_λi, i_X_0), _ = jax.lax.scan(
+        f=propagate_kinematics,
+        init=propagate_kinematics_carry,
+        xs=np.arange(start=1, stop=model.NB),
+    )
+
+    # ============================
+    # Compute doubly-left Jacobian
+    # ============================
 
     J = jnp.zeros(shape=(6, 6 + model.dofs()))
 
     Jb = i_X_0[body_index]
     J = J.at[0:6, 0:6].set(Jb)
 
-    for i in reversed(model.support_body_array(body_index=body_index)):
+    ComputeJacobianCarry = jtp.MatrixJax
+    compute_jacobian_carry = J
 
-        ii = i - 1
+    def compute_jacobian(
+        carry: ComputeJacobianCarry, i: jtp.Int
+    ) -> Tuple[ComputeJacobianCarry, None]:
+        def update_jacobian(
+            carry: Tuple[ComputeJacobianCarry, jtp.Int]
+        ) -> ComputeJacobianCarry:
 
-        if i == 0:
-            break
+            J, i = carry
 
-        Js_i = i_X_0[body_index] @ jnp.linalg.inv(i_X_0[i]) @ S[i]
-        J = J.at[0:6, 6 + ii].set(Js_i.squeeze())
+            ii = i - 1
+
+            Js_i = i_X_0[body_index] @ jnp.linalg.inv(i_X_0[i]) @ S[i]
+            J = J.at[0:6, 6 + ii].set(Js_i.squeeze())
+
+            return J
+
+        carry = jax.lax.cond(
+            pred=(jnp.any(i == model.support_body_array(body_index=body_index))),
+            true_fun=update_jacobian,
+            false_fun=lambda carry_i: carry_i[0],
+            operand=(carry, i),
+        )
+
+        return carry, None
+
+    J, _ = jax.lax.scan(
+        f=compute_jacobian,
+        init=compute_jacobian_carry,
+        xs=np.arange(start=1, stop=model.NB),
+    )
 
     return J


### PR DESCRIPTION
This PR implements the doubly-left Jacobian algorithm with `jax.lax.scan` (#12), with two main benefits:

- Reduction in JIT compilation time especially for model with many DoF
- Forward and backward AD support (#4)

<details>
<summary>Doubly-left Jacobian Algorithm</summary>

![Screenshot_20220920_165342](https://user-images.githubusercontent.com/469199/191291619-199768cc-e185-4074-a3ce-9ee3df6fbe39.png)

</details>

Here below a summary of the new Jacobian performance compared to the previous implementation, referring to the computation of the jacobian of the link with `index = high_level_model.nr_of_links() - 1`.

| Model name | DoFs | JIT time | JIT time speedup | Runtime | Runtime speedup |
| --- | :---: | :---: | :---: | :---: | :---: |
| [`panda`][panda] | 9 | 1.13 s | x2.7 | 532 µs | x1.03 |
| [`iCubGazeboV2_5`][icub] | 32 | 5.26 s | x3.3 | 925 μs | x1.00 |

The JIT time is now much lower than before. Instead, the runtime didn't change noticeably.

[icub]: https://github.com/robotology/gym-ignition-models/blob/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/iCubGazeboV2_5/icub.urdf
[panda]: https://github.com/robotology/gym-ignition-models/blob/088a81c55970ca5eec51108d249b8ce3dfd09e7a/src/gym_ignition_models/panda/panda.urdf