### PR TITLE
Support coulomb and viscous joint friction

### DIFF
--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -66,6 +66,9 @@ class JointDescription:
 
     index: int = 0
 
+    friction_static: float = 0.0
+    friction_viscous: float = 0.0
+
     position_limit: Tuple[float, float] = (0.0, 0.0)
     initial_position: Union[float, npt.NDArray] = 0.0
 

--- a/src/jaxsim/parsers/sdf/parser.py
+++ b/src/jaxsim/parsers/sdf/parser.py
@@ -184,6 +184,16 @@ def extract_data_from_sdf(
                 if j.axis is not None and j.axis.limit is not None
                 else np.finfo(float).max,
             ),
+            friction_static=j.axis.dynamics.friction
+            if j.axis is not None
+            and j.axis.dynamics is not None
+            and j.axis.dynamics.friction is not None
+            else 0.0,
+            friction_viscous=j.axis.dynamics.damping
+            if j.axis is not None
+            and j.axis.dynamics is not None
+            and j.axis.dynamics.friction is not None
+            else 0.0,
         )
         for j in sdf_tree.model.joints
         if j.type in {"revolute", "prismatic", "fixed"}

--- a/src/jaxsim/physics/model/physics_model.py
+++ b/src/jaxsim/physics/model/physics_model.py
@@ -44,6 +44,9 @@ class PhysicsModel(JaxsimDataclass):
     )
     _link_inertias_dict: Dict[int, jtp.Matrix] = dataclasses.field(default_factory=dict)
 
+    _joint_friction_static: Dict[int, float] = dataclasses.field(default_factory=dict)
+    _joint_friction_viscous: Dict[int, float] = dataclasses.field(default_factory=dict)
+
     def __post_init__(self):
 
         if self.initial_state is None:
@@ -88,6 +91,15 @@ class PhysicsModel(JaxsimDataclass):
         # Note: the joint index is equal to its child link index.
         joint_types_dict = {
             joint.index: joint.jtype for joint in model_description.joints
+        }
+
+        # Dicts from the joint index to the static and viscous friction.
+        # Note: the joint index is equal to its child link index.
+        joint_friction_static = {
+            joint.index: joint.friction_static for joint in model_description.joints
+        }
+        joint_friction_viscous = {
+            joint.index: joint.friction_viscous for joint in model_description.joints
         }
 
         # Transform between model's root and model's base link
@@ -146,6 +158,8 @@ class PhysicsModel(JaxsimDataclass):
             _jtype_dict=joint_types_dict,
             _tree_transforms_dict=tree_transforms_dict,
             _link_inertias_dict=link_spatial_inertias_dict,
+            _joint_friction_static=joint_friction_static,
+            _joint_friction_viscous=joint_friction_viscous,
             gravity=jnp.hstack([gravity.squeeze(), np.zeros(3)]),
             is_floating_base=True,
             gc=GroundContact.build_from(model_description=model_description),


### PR DESCRIPTION
This PR introduces the support of coulomb and viscous joint friction.

The friction model used by physics is the following:

$$
\begin{align}
& M(\mathbf{q}) \dot{\boldsymbol{\nu}} + h(\mathbf{q}, \boldsymbol{\nu}) = B \boldsymbol{\tau}\_{references} + B \boldsymbol{\tau}\_{friction} + J^{\top}\_{\mathcal{L}} \mathbf{f}\_{\mathcal{L}} \\
& \boldsymbol{\tau}\_{friction} = -K_c \operatorname{sign}(\mathbf{s}) - K_v \dot{\mathbf{s}}
\end{align}
$$

where

$$
\begin{align}
K_c &= \operatorname{diag}(\mathbf{k}_c) \\
K_v &= \operatorname{diag}(\mathbf{k}_v)
\end{align}
$$

are the _static_ and _viscous_ joint friction parameters, and $\mathbf{q} = ({}^W H_B, \mathbf{s}) \in SE(3) \times \mathbb{R}^n$.

Note that in presence of joint friction, the joint torque actuated by the physics engine differs from the torque reference specified by the user. This is historically a delicate subject in many physics engines. In order to simplify the implementation of torque/impedance controllers that require in their feedback term the knowledge of the real joint torques, our high-level classes already return this value in the `StepData` object returned by [`Model.integrate`](https://github.com/ami-iit/jaxsim/blob/74b57e8d8c69082d2d2e8eb07472b03cb5087731/src/jaxsim/high_level/model.py#L858-L867):

https://github.com/ami-iit/jaxsim/blob/74b57e8d8c69082d2d2e8eb07472b03cb5087731/src/jaxsim/high_level/model.py#L60-L62