### PR TITLE
Implement joint position limits

### DIFF
--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -69,6 +69,9 @@ class JointDescription:
     friction_static: float = 0.0
     friction_viscous: float = 0.0
 
+    position_limit_damper: float = 0.0
+    position_limit_spring: float = 0.0
+
     position_limit: Tuple[float, float] = (0.0, 0.0)
     initial_position: Union[float, npt.NDArray] = 0.0
 

--- a/src/jaxsim/parsers/sdf/parser.py
+++ b/src/jaxsim/parsers/sdf/parser.py
@@ -194,6 +194,16 @@ def extract_data_from_sdf(
             and j.axis.dynamics is not None
             and j.axis.dynamics.friction is not None
             else 0.0,
+            position_limit_damper=j.axis.limit.dissipation
+            if j.axis is not None
+            and j.axis.limit is not None
+            and j.axis.limit.dissipation is not None
+            else 0.0,
+            position_limit_spring=j.axis.limit.stiffness
+            if j.axis is not None
+            and j.axis.limit is not None
+            and j.axis.limit.stiffness is not None
+            else 0.0,
         )
         for j in sdf_tree.model.joints
         if j.type in {"revolute", "prismatic", "fixed"}

--- a/src/jaxsim/physics/model/physics_model.py
+++ b/src/jaxsim/physics/model/physics_model.py
@@ -47,6 +47,9 @@ class PhysicsModel(JaxsimDataclass):
     _joint_friction_static: Dict[int, float] = dataclasses.field(default_factory=dict)
     _joint_friction_viscous: Dict[int, float] = dataclasses.field(default_factory=dict)
 
+    _joint_limit_spring: Dict[int, float] = dataclasses.field(default_factory=dict)
+    _joint_limit_damper: Dict[int, float] = dataclasses.field(default_factory=dict)
+
     def __post_init__(self):
 
         if self.initial_state is None:
@@ -100,6 +103,17 @@ class PhysicsModel(JaxsimDataclass):
         }
         joint_friction_viscous = {
             joint.index: joint.friction_viscous for joint in model_description.joints
+        }
+
+        # Dicts from the joint index to the spring and damper joint limits parameters.
+        # Note: the joint index is equal to its child link index.
+        joint_limit_spring = {
+            joint.index: joint.position_limit_spring
+            for joint in model_description.joints
+        }
+        joint_limit_damper = {
+            joint.index: joint.position_limit_damper
+            for joint in model_description.joints
         }
 
         # Transform between model's root and model's base link
@@ -160,6 +174,8 @@ class PhysicsModel(JaxsimDataclass):
             _link_inertias_dict=link_spatial_inertias_dict,
             _joint_friction_static=joint_friction_static,
             _joint_friction_viscous=joint_friction_viscous,
+            _joint_limit_spring=joint_limit_spring,
+            _joint_limit_damper=joint_limit_damper,
             gravity=jnp.hstack([gravity.squeeze(), np.zeros(3)]),
             is_floating_base=True,
             gc=GroundContact.build_from(model_description=model_description),


### PR DESCRIPTION
This PR implements joint position limits by reading the following fields from a parsed SDF model:

- [`joint/axis/limit/stiffness`](http://sdformat.org/spec?ver=1.9&elem=joint#limit_stiffness)
- [`joint/axis/limit/dissipation`](http://sdformat.org/spec?ver=1.9&elem=joint#limit_dissipation)

Despite we read both parameters, the model used by the physics just uses the `dissipation` parameter as $k\_{limit}$. This is because the stiffness/dissipation parameters could be mapped respectively to a spring/damper model, and the implemented model is equivalent to a pure damper. This means that the joint velocity is not used, and the torque is computed just as a term proportional to the joint position error wrt the limit.

I've tried also two different spring/damper models:

$$
\tau_{limit}^{(1)} =
\begin{cases}
k_{damper} (s_{min} - s) + k\_{spring} \dot{s}, \quad \text{if } s < s_{min} \\
k_{damper} (s_{max} - s) - k\_{spring} \dot{s}, \quad \text{if } s > s_{max} \\
\end{cases}
$$

and

$$
\tau_{limit}^{(2)} =
\begin{cases}
k_{damper} (s_{min} - s) + k\_{spring} \operatorname{abs}(s_{min} - s) \dot{s}, \quad \text{if } s < s_{min} \\
k_{damper} (s_{max} - s) - k\_{spring} \operatorname{abs}(s_{max} - s) \dot{s}, \quad \text{if } s > s_{max} \\
\end{cases}
$$

Beyond requiring to tune an additional $k\_{spring}$ parameter, both models do not give interesting additions. Particularly, $\tau_{limit}^{(1)}$ produces very often `NaNs` due to the discontinuous behavior (that would also affect differentiability #4). Instead, $\tau_{limit}^{(2)}$ enforces linearity by smoothing the spring gain with the position error, but beyond being having a less physical explanation, it works only with small $k\_{spring}$ in order to prevent `NaNs`.

For the time being, I prefer keeping things simple. More advanced models can be introduced in the future. Note that a more advanced methodology exploits a [constraint solver](https://mujoco.readthedocs.io/en/latest/computation.html#constraint-solver) for [joint limits](https://mujoco.readthedocs.io/en/latest/computation.html#limit), based on the [Gauss principle of least constraint](https://en.wikipedia.org/wiki/Gauss's_principle_of_least_constraint). Since it would make the forward step of the simulation much heavier, let's begin supporting the simple model of this PR.

Here below an example with a simple pendulum. GIFs are recorded with a real-time factor of 0.2.

| w/o limits | w/ limits |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/469199/192508995-da6b0635-d81d-42e2-9ea0-660cd59b1d36.png" height="250"> | <img src="https://user-images.githubusercontent.com/469199/192508989-16b45c1f-14bb-43d0-925a-147db029b41c.png" height="250"> |

Closes #20.