### PR TITLE
Add continuous integration workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,0 +1,81 @@
+name: Python CI/CD
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+
+  package:
+    name: Package the project
+    runs-on: ubuntu-22.04
+
+    steps:
+
+      - uses: actions/checkout@master
+      - run: git fetch --prune --unshallow
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Python tools
+        run: pip install build twine
+
+      - name: Create distributions
+        run: python -m build -o dist/
+
+      - name: Inspect dist folder
+        run: ls -lah dist/
+
+      - name: Check wheel's abi and platform tag
+        run: test $(find dist/ -name *-none-any.whl | wc -l) -gt 0
+
+      - name: Run twine check
+        run: twine check dist/*
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: dist/*
+          name: dist
+
+  test:
+    name: 'Python${{ matrix.python }}@${{ matrix.os }}'
+    needs: package
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          - macos-latest
+          - windows-latest
+        python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          # - "3.11"
+
+    steps:
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Download Python packages
+        uses: actions/download-artifact@v2
+        with:
+          path: dist
+          name: dist
+
+      - name: Install wheel
+        run: pip install dist/*.whl
+
+      - name: Import the package
+        run: python -c "import jaxsim"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -54,7 +54,8 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-latest
-          - windows-latest
+          # https://github.com/google/jax/issues/5795
+          # - windows-latest
         python:
           - "3.8"
           - "3.9"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -75,6 +75,7 @@ jobs:
           name: dist
 
       - name: Install wheel
+        shell: bash
         run: pip install dist/*.whl
 
       - name: Import the package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [
     "wheel",
     "setuptools>=45",
-    "setuptools_scm[toml]>=6.0",
+    "setuptools_scm[toml]>=6.2",
 ]
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     distrax
     flax
     jax >=0.3.14, <0.3.16
-    jaxlib
+    jaxlib == 0.3.15
     jaxlie
     jax_dataclasses >= 1.2.2, < 1.4.0
     pptree


### PR DESCRIPTION
This PR is the CI part of #23, which is blocked as described in https://github.com/ami-iit/jaxsim/pull/23#issuecomment-1267228971.

Waiting to switch to the new parser [`rod`](https://github.com/ami-iit/rod), I'd like to merge at least the CI pipeline that is currently checking that the project can be installed in all supported platforms and that can be imported without errors.