### PR TITLE
Switch parser to `ami-iit/rod`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
     jaxlie
     jax_dataclasses >= 1.2.2, < 1.4.0
     pptree
-    python-sdformat @ git+https://github.com/FirefoxMetzger/python-sdformat@51cd5fcb970076f0b64b76938f7923000c8df404
+    rod @ git+https://github.com/ami-iit/rod
     scipy
 
 [options.packages.find]


### PR DESCRIPTION
This PR replaces [`FirefoxMetzger/python-sdformat`](https://github.com/FirefoxMetzger/python-sdformat) with the new [`ami-iit/rod`](https://github.com/ami-iit/rod). In this way, we have full control of the description parser, and we can manage better the future deployment of jaxsim (PyPI, conda, etc).