### PR TITLE
Rewrite soft-contacts algorithm

### DIFF
--- a/src/jaxsim/high_level/link.py
+++ b/src/jaxsim/high_level/link.py
@@ -241,4 +241,4 @@ class Link(JaxsimDataclass):
         )
 
     def in_contact(self) -> jtp.Bool:
-        return not jnp.allclose(self.external_force(), 0)
+        return self.parent_model.in_contact()[self.index()]

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -476,6 +476,14 @@ class Model(JaxsimDataclass):
             self._joint_indices(joint_names=joint_names)
         ]
 
+    def joint_generalized_forces_targets(
+        self, joint_names: List[str] = None
+    ) -> jtp.Vector:
+        if self.dofs() == 0 and (joint_names is None or len(joint_names) == 0):
+            return jnp.array([])
+
+        return self.data.model_input.tau[self._joint_indices(joint_names=joint_names)]
+
     def joint_limits(
         self, joint_names: List[str] = None
     ) -> Tuple[jtp.Vector, jtp.Vector]:

--- a/src/jaxsim/physics/algos/soft_contacts.py
+++ b/src/jaxsim/physics/algos/soft_contacts.py
@@ -1,4 +1,5 @@
 from typing import NamedTuple, Tuple
+import dataclasses
 
 import jax
 import jax.experimental.loops
@@ -124,9 +125,21 @@ def collidable_points_pos_vel(
 
 @jax_dataclasses.pytree_dataclass
 class SoftContactsParams:
-    K: float = jnp.array(1e6, dtype=float)
-    D: float = jnp.array(2000, dtype=float)
-    mu: float = jnp.array(0.5, dtype=float)
+    """"""
+
+    K: float = dataclasses.field(default=jnp.array(1e6, dtype=float))
+    D: float = dataclasses.field(default=jnp.array(2000, dtype=float))
+    mu: float = dataclasses.field(default=jnp.array(0.5, dtype=float))
+
+    @staticmethod
+    def build(K: float = 1e6, D: float = 2_000, mu: float= 0.5) -> "SoftContactsParams":
+        """"""
+
+        return SoftContactsParams(
+            K=jnp.array(K, dtype=float),
+            D=jnp.array(D, dtype=float),
+            mu=jnp.array(mu, dtype=float),
+        )
 
 
 def soft_contacts_model(

--- a/src/jaxsim/physics/algos/terrain.py
+++ b/src/jaxsim/physics/algos/terrain.py
@@ -37,6 +37,12 @@ class FlatTerrain(Terrain):
 class PlaneTerrain(Terrain):
     plane_normal: jtp.Vector = jax_dataclasses.field(default=jnp.array([0, 0, 1.0]))
 
+    @staticmethod
+    def build(plane_normal: jtp.Vector) -> "PlaneTerrain":
+        """"""
+
+        return PlaneTerrain(plane_normal=jnp.array(plane_normal, dtype=float))
+
     def height(self, x: float, y: float) -> float:
         a, b, c = self.plane_normal
         return -(a * x + b * x) / c

--- a/src/jaxsim/physics/algos/utils.py
+++ b/src/jaxsim/physics/algos/utils.py
@@ -15,31 +15,42 @@ def process_inputs(
     tau: jtp.Vector = None,
     f_ext: jtp.Matrix = None,
 ) -> Tuple[jtp.Vector, jtp.Vector, jtp.Vector, jtp.Vector, jtp.Vector, jtp.Matrix]:
+    """
+    Adjust the inputs to the physics model.
+
+    Args:
+        physics_model: The physics model.
+        xfb: The variables of the base link.
+        q: The generalized coordinates.
+        qd: The generalized velocities.
+        qdd: The generalized accelerations.
+        tau: The generalized forces.
+        f_ext: The link external forces.
+
+    Returns:
+        The adjusted inputs.
+    """
+
     # Remove extra dimensions
-    q = q.squeeze() if q is not None else None
-    qd = qd.squeeze() if qd is not None else None
-    qdd = qdd.squeeze() if qdd is not None else None
-    tau = tau.squeeze() if tau is not None else None
-    xfb = xfb.squeeze() if xfb is not None else None
-    f_ext = f_ext.squeeze() if f_ext is not None else None
-
-    def fix_one_dof(vector: jtp.Vector) -> Optional[jtp.Vector]:
-        if vector is None:
-            return None
-
-        return jnp.array([vector]) if vector.shape == () else vector
+    q = q.squeeze() if q is not None else jnp.zeros(physics_model.dofs())
+    qd = qd.squeeze() if qd is not None else jnp.zeros(physics_model.dofs())
+    qdd = qdd.squeeze() if qdd is not None else jnp.zeros(physics_model.dofs())
+    tau = tau.squeeze() if tau is not None else jnp.zeros(physics_model.dofs())
+    xfb = xfb.squeeze() if xfb is not None else jnp.zeros(13).at[0].set(1)
+    f_ext = (
+        f_ext.squeeze()
+        if f_ext is not None
+        else jnp.zeros(shape=(physics_model.NB, 6)).squeeze()
+    )
 
     # Fix case with just 1 DoF
-    q = fix_one_dof(q)
-    qd = fix_one_dof(qd)
-    qdd = fix_one_dof(qdd)
-    tau = fix_one_dof(tau)
-
-    # Build matrix of external forces if not given
-    f_ext = f_ext if f_ext is not None else jnp.zeros(shape=(physics_model.NB, 6))
+    q = jnp.atleast_1d(q)
+    qd = jnp.atleast_1d(qd)
+    qdd = jnp.atleast_1d(qdd)
+    tau = jnp.atleast_1d(tau)
 
     # Fix case with just 1 body
-    f_ext = f_ext if physics_model.NB != 1 else f_ext.squeeze()[jnp.newaxis, ...]
+    f_ext = jnp.atleast_2d(f_ext)
 
     # Validate dimensions
     dofs = physics_model.dofs()


### PR DESCRIPTION
- For maintainability purpose, the algorithm has been rewritten to operate on an individual point, and then applied model-wise through `jax.vmap`
- The computation of the position and velocities of the collidable points now does not longer use removed `jax.experimental` resources

The theory of the contact model can be found in [diegoferigo/phd-thesis](https://github.com/diegoferigo/phd-thesis):
- Formulation in Section 7.3
- Algorithm in Section 8.1.8