### PR TITLE
Implement ABA with `jax.lax.scan`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,10 +57,10 @@ install_requires =
     coloredlogs
     distrax
     flax
-    jax >=0.3.14, <0.3.16
-    jaxlib == 0.3.15
+    jax 
+    jaxlib 
     jaxlie
-    jax_dataclasses >= 1.2.2, < 1.4.0
+    jax_dataclasses < 1.4.0
     pptree
     rod
     scipy

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -2,7 +2,7 @@ import dataclasses
 import pathlib
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import jax.experimental.ode
+import jax
 import jax.numpy as jnp
 import jax_dataclasses
 import numpy as np
@@ -721,7 +721,7 @@ class Model(JaxsimDataclass):
         return f_B, tau
 
     def forward_dynamics(
-        self, tau: jtp.Vector = None, prefer_aba: float = True
+        self, tau: jtp.Vector = None, prefer_aba: bool = True
     ) -> Tuple[jtp.Vector, jtp.Vector]:
         return (
             self.forward_dynamics_aba(tau=tau)

--- a/src/jaxsim/physics/algos/soft_contacts.py
+++ b/src/jaxsim/physics/algos/soft_contacts.py
@@ -3,7 +3,6 @@ import dataclasses
 from typing import Tuple
 
 import jax
-import jax.experimental.loops
 import jax.flatten_util
 import jax.numpy as jnp
 import jax_dataclasses


### PR DESCRIPTION
* Remove `jax<0.3.16` pin

* Remove `jax.experimental.loops`

I wasn't able to remove the dependency on  `jax_dataclasses < 1.4.0` as it resulted in a circular import in the [`high_level`](https://github.com/ami-iit/jaxsim/tree/main/src/jaxsim/high_level) module.

C.C. @traversaro @CarlottaSartore 