### PR TITLE
ABA and RNEA with `jax.lax.scan`, Python 3.11, fixed bugs in other representations

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -61,7 +61,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          # - "3.11"
+          - "3.11"
 
     steps:
 
@@ -76,12 +76,34 @@ jobs:
           path: dist
           name: dist
 
-      - name: Install wheel
+      - name: Install wheel (ubuntu)
+        if: contains(matrix.os, 'ubuntu')
         shell: bash
-        run: pip install dist/*.whl
+        run: pip install "$(find dist/ -type f -name '*.whl')[all]"
+
+      - name: Install wheel (macos)
+        if: contains(matrix.os, 'macos')
+        shell: bash
+        run: pip install "$(find dist/ -type f -name '*.whl')"
 
       - name: Import the package
         run: python -c "import jaxsim"
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Gazebo Classic
+        if: contains(matrix.os, 'ubuntu') && (matrix.python == '3.10' || matrix.python == '3.11')
+        run: |
+          sudo apt-get update
+          sudo apt-get install gazebo
+
+      - name: Run the Python tests
+        if: contains(matrix.os, 'ubuntu') && (matrix.python == '3.10' || matrix.python == '3.11')
+        run: pytest
+        env:
+          JAX_PLATFORM_NAME: cpu
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -76,6 +76,12 @@ jobs:
           path: dist
           name: dist
 
+      # Workaround: install iDynTree for Python 3.11
+      - name: iDynTree on Python 3.11
+        if: contains(matrix.os, 'ubuntu') && matrix.python == '3.11'
+        shell: bash
+        run: pip install --pre idyntree
+
       - name: Install wheel (ubuntu)
         if: contains(matrix.os, 'ubuntu')
         shell: bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description_content_type = text/markdown
 author = Diego Ferigo
 author_email = diego.ferigo@iit.it
 license = BSD
-license_file = LICENSE
+license_files = LICENSE
 platforms = any
 url = https://github.com/ami-iit/jaxsim
 
@@ -71,8 +71,10 @@ style =
     black
     isort
 testing =
+    idyntree
     pytest
     pytest-icdiff
+    robot-descriptions
 all =
     %(style)s
     %(testing)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,12 +55,10 @@ package_dir =
 python_requires = >=3.8
 install_requires =
     coloredlogs
-    distrax
-    flax
-    jax >=0.3.14, <0.3.16
-    jaxlib == 0.3.15
+    jax >= 0.4.1
+    jaxlib
     jaxlie
-    jax_dataclasses >= 1.2.2, < 1.4.0
+    jax_dataclasses >= 1.4.0
     pptree
     rod
     scipy

--- a/src/jaxsim/high_level/joint.py
+++ b/src/jaxsim/high_level/joint.py
@@ -1,9 +1,10 @@
-from typing import Tuple
+import dataclasses
+from typing import Any, Tuple
 
 import jax_dataclasses
+from jax_dataclasses import Static
 
-import jaxsim.high_level
-import jaxsim.parsers.descriptions as descriptions
+import jaxsim.parsers
 import jaxsim.typing as jtp
 from jaxsim.utils import JaxsimDataclass
 
@@ -14,10 +15,13 @@ class Joint(JaxsimDataclass):
     High-level class to operate on a single joint of a simulated model.
     """
 
-    joint_description: descriptions.JointDescription = jax_dataclasses.static_field()
-    parent_model: "jaxsim.high_level.model.Model" = jax_dataclasses.field(
-        default=None, repr=False, compare=False
-    )
+    joint_description: Static[jaxsim.parsers.descriptions.JointDescription]
+
+    _parent_model: Any = dataclasses.field(default=None, repr=False, compare=False)
+
+    @property
+    def parent_model(self) -> "jaxsim.high_level.model.Model":
+        return self._parent_model
 
     def valid(self) -> bool:
         return self.parent_model is not None

--- a/src/jaxsim/high_level/link.py
+++ b/src/jaxsim/high_level/link.py
@@ -149,22 +149,22 @@ class Link(JaxsimDataclass):
             raise ValueError(output_vel_repr)
 
     def external_force(self) -> jtp.Vector:
+        """
+        Return the active external force acting on the link.
+
+        This external force is a user input and is not computed by the physics engine.
+        During the simulation, this external force is summed to other terms like those
+        related to enforce contact constraints.
+
+        Returns:
+            The active external 6D force acting on the link in the active representation.
+        """
+
         W_f_ext = self.parent_model.data.model_input.f_ext[self.index()]
 
-        if self.parent_model.velocity_representation is VelRepr.Inertial:
-            return W_f_ext
-
-        elif self.parent_model.velocity_representation is VelRepr.Body:
-            W_H_B = self.parent_model.base_transform()
-            W_X_B = sixd.se3.SE3.from_matrix(W_H_B).adjoint()
-
-            return W_X_B.transpose() @ W_f_ext
-
-        elif self.parent_model.velocity_representation is VelRepr.Mixed:
-            raise NotImplementedError
-
-        else:
-            raise ValueError(self.parent_model.velocity_representation)
+        return self.parent_model.inertial_to_active_representation(
+            array=W_f_ext, is_force=True
+        )
 
     def add_external_force(
         self, force: jtp.Array = None, torque: jtp.Array = None

--- a/src/jaxsim/high_level/link.py
+++ b/src/jaxsim/high_level/link.py
@@ -1,9 +1,12 @@
+import dataclasses
+from typing import Any
+
 import jax.numpy as jnp
 import jax_dataclasses
 import numpy as np
+from jax_dataclasses import Static
 
-import jaxsim.high_level
-import jaxsim.parsers.descriptions as descriptions
+import jaxsim.parsers
 import jaxsim.sixd as sixd
 import jaxsim.typing as jtp
 from jaxsim.physics.algos.jacobian import jacobian
@@ -18,10 +21,13 @@ class Link(JaxsimDataclass):
     High-level class to operate on a single link of a simulated model.
     """
 
-    link_description: descriptions.LinkDescription = jax_dataclasses.static_field()
-    parent_model: "jaxsim.high_level.model.Model" = jax_dataclasses.field(
-        default=None, repr=False, compare=False
-    )
+    link_description: Static[jaxsim.parsers.descriptions.LinkDescription]
+
+    _parent_model: Any = dataclasses.field(default=None, repr=False, compare=False)
+
+    @property
+    def parent_model(self) -> "jaxsim.high_level.model.Model":
+        return self._parent_model
 
     def valid(self) -> bool:
         return self.parent_model is not None

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -693,14 +693,6 @@ class Model(JaxsimDataclass):
         joint_accelerations: jtp.Vector = None,
         base_acceleration: jtp.Vector = jnp.zeros(6),
     ) -> Tuple[jtp.Vector, jtp.Vector]:
-        if (
-            self.velocity_representation is VelRepr.Mixed
-            and self.floating_base()
-            and not jnp.allclose(self.data.model_state.base_angular_velocity, 0)
-        ):
-            msg = "This method has to be fixed in Mixed representation"
-            raise ValueError(msg)
-
         # Build joint accelerations if not provided
         joint_accelerations = (
             joint_accelerations
@@ -748,14 +740,6 @@ class Model(JaxsimDataclass):
     def forward_dynamics_aba(
         self, tau: jtp.Vector = None
     ) -> Tuple[jtp.Vector, jtp.Vector]:
-        if (
-            self.velocity_representation is not VelRepr.Inertial
-            and (self.data.model_input.f_ext != 0).any()
-        ):
-            msg1 = "This method has to be fixed for Body and Mixed representation, "
-            msg2 = "use forward_dynamics_crb instead."
-            raise ValueError(msg1 + msg2)
-
         # Build joint torques if not provided
         tau = tau if tau is not None else jnp.zeros_like(self.joint_positions())
 

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -2,7 +2,6 @@ import dataclasses
 import pathlib
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import jax.experimental.ode
 import jax.numpy as jnp
 import jax_dataclasses
 import numpy as np

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -757,7 +757,10 @@ class Model(JaxsimDataclass):
         sdd = jnp.atleast_1d(sdd.squeeze())
 
         # Express W_a_WB in the active representation
-        a_WB = self.inertial_to_active_representation(array=W_a_WB)
+        if self.floating_base():
+            a_WB = self.inertial_to_active_representation(array=W_a_WB)
+        else:
+            a_WB = jnp.zeros_like(W_a_WB).squeeze()
 
         return a_WB, sdd
 

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -544,6 +544,20 @@ class Model(JaxsimDataclass):
         return self.inertial_to_active_representation(array=W_v_WB)
 
     def external_forces(self) -> jtp.Matrix:
+        """
+        Return the active external forces acting on the robot.
+
+        The external forces are a user input and are not computed by the physics engine.
+        During the simulation, these external forces are summed to other terms like
+        the external forces due to the contact with the environment.
+
+        Returns:
+            A matrix of shape (n_links, 6) containing the external forces acting on the
+            robot links. The forces are expressed in the active representation.
+        """
+
+        # Get the active external forces that are always stored internally
+        # in Inertial representation
         W_f_ext = self.data.model_input.f_ext
 
         inertial_to_active = lambda f: self.inertial_to_active_representation(

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -653,7 +653,7 @@ class Model(JaxsimDataclass):
         else:
             raise ValueError(self.velocity_representation)
 
-    def free_floating_generalized_forces(self) -> jtp.Vector:
+    def free_floating_bias_forces(self) -> jtp.Vector:
         model_state = self.data.model_state
         model = self.copy().mutable(validate=True)
 

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -1072,12 +1072,12 @@ class Model(JaxsimDataclass):
             W_H_B = self.base_transform()
 
             if not is_force:
-                B_X_W: jtp.Array = sixd.se3.SE3.from_matrix(W_H_B).inverse().adjoint()
-                B_array = B_X_W @ W_array
+                B_Xv_W = sixd.se3.SE3.from_matrix(W_H_B).inverse().adjoint()
+                B_array = B_Xv_W @ W_array
 
             else:
-                W_X_B: jtp.Array = sixd.se3.SE3.from_matrix(W_H_B).adjoint()
-                B_array = W_X_B.T @ W_array
+                B_Xf_W = sixd.se3.SE3.from_matrix(W_H_B).adjoint().T
+                B_array = B_Xf_W @ W_array
 
             return B_array
 
@@ -1085,12 +1085,12 @@ class Model(JaxsimDataclass):
             W_H_BW = jnp.eye(4).at[0:3, 3].set(self.base_position())
 
             if not is_force:
-                BW_X_W = sixd.se3.SE3.from_matrix(W_H_BW).inverse().adjoint()
-                BW_array = BW_X_W @ W_array
+                BW_Xv_W = sixd.se3.SE3.from_matrix(W_H_BW).inverse().adjoint()
+                BW_array = BW_Xv_W @ W_array
 
             else:
-                W_X_BW = sixd.se3.SE3.from_matrix(W_H_BW).adjoint()
-                BW_array = W_X_BW.transpose() @ W_array
+                BW_Xf_W = sixd.se3.SE3.from_matrix(W_H_BW).adjoint().T
+                BW_array = BW_Xf_W @ W_array
 
             return BW_array
 
@@ -1114,12 +1114,12 @@ class Model(JaxsimDataclass):
             W_H_B = self.base_transform()
 
             if not is_force:
-                W_X_B: jtp.Array = sixd.se3.SE3.from_matrix(W_H_B).adjoint()
-                W_array = W_X_B @ B_array
+                W_Xv_B: jtp.Array = sixd.se3.SE3.from_matrix(W_H_B).adjoint()
+                W_array = W_Xv_B @ B_array
 
             else:
-                B_X_W: jtp.Array = sixd.se3.SE3.from_matrix(W_H_B).inverse().adjoint()
-                W_array = B_X_W.T @ B_array
+                W_Xf_B = sixd.se3.SE3.from_matrix(W_H_B).inverse().adjoint().T
+                W_array = W_Xf_B @ B_array
 
             return W_array
 
@@ -1128,12 +1128,12 @@ class Model(JaxsimDataclass):
             W_H_BW = jnp.eye(4).at[0:3, 3].set(self.base_position())
 
             if not is_force:
-                W_X_BW: jtp.Array = sixd.se3.SE3.from_matrix(W_H_BW).adjoint()
-                W_array = W_X_BW @ BW_array
+                W_Xv_BW: jtp.Array = sixd.se3.SE3.from_matrix(W_H_BW).adjoint()
+                W_array = W_Xv_BW @ BW_array
 
             else:
-                BW_X_W: jtp.Array = sixd.se3.SE3.from_matrix(W_H_BW).inverse().adjoint()
-                W_array = BW_X_W.T @ BW_array
+                W_Xf_BW = sixd.se3.SE3.from_matrix(W_H_BW).inverse().adjoint().T
+                W_array = W_Xf_BW @ BW_array
 
             return W_array
 

--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -576,15 +576,53 @@ class Model(JaxsimDataclass):
     def generalized_velocity(self) -> jtp.Vector:
         return jnp.hstack([self.base_velocity(), self.joint_velocities()])
 
-    def generalized_jacobian(self, output_vel_repr: VelRepr = None) -> jtp.Matrix:
-        return jnp.vstack(
+    def generalized_free_floating_jacobian(
+        self, output_vel_repr: VelRepr = None
+    ) -> jtp.Matrix:
+        """"""
+
+        if output_vel_repr is None:
+            output_vel_repr = self.velocity_representation
+
+        # The body frame of the Link.jacobian method is the link frame L.
+        # In this method, we want instead to use the base link B as body frame.
+        # Therefore, we always get the link jacobian having Inertial as output
+        # representation, and then we convert it to the desired output representation.
+        if output_vel_repr is VelRepr.Inertial:
+            to_output = lambda J: J
+
+        elif output_vel_repr is VelRepr.Body:
+
+            def to_output(W_J_Wi):
+                W_H_B = self.base_transform()
+                B_X_W = sixd.se3.SE3.from_matrix(W_H_B).inverse().adjoint()
+                return B_X_W @ W_J_Wi
+
+        elif output_vel_repr is VelRepr.Mixed:
+
+            def to_output(W_J_Wi):
+                W_H_B = self.base_transform()
+                W_H_BW = jnp.array(W_H_B).at[0:3, 0:3].set(jnp.eye(3))
+                BW_X_W = sixd.se3.SE3.from_matrix(W_H_BW).inverse().adjoint()
+                return BW_X_W @ W_J_Wi
+
+        else:
+            raise ValueError(output_vel_repr)
+
+        # Get the link jacobians in Inertial representation and convert them to the
+        # target output representation in which the body frame is the base link B
+        J_free_floating = jnp.vstack(
             [
-                self.get_link(link_name=link_name).jacobian(
-                    output_vel_repr=output_vel_repr
+                to_output(
+                    self.get_link(link_name=link_name).jacobian(
+                        output_vel_repr=VelRepr.Inertial
+                    )
                 )
                 for link_name in self.link_names()
             ]
         )
+
+        return J_free_floating
 
     def free_floating_mass_matrix(self) -> jtp.Matrix:
         M_body = jaxsim.physics.algos.crba.crba(

--- a/src/jaxsim/parsers/descriptions/link.py
+++ b/src/jaxsim/parsers/descriptions/link.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 import jax.numpy as jnp
 import jax_dataclasses
+from jax_dataclasses import Static
 
 import jaxsim.typing as jtp
 from jaxsim.sixd import se3
@@ -12,13 +13,17 @@ from jaxsim.utils import JaxsimDataclass
 
 @jax_dataclasses.pytree_dataclass
 class LinkDescription(JaxsimDataclass):
-    name: str = jax_dataclasses.static_field()
+    """
+    In-memory description of a robot link.
+    """
+
+    name: Static[str]
     mass: float
     inertia: jtp.Matrix
     index: Optional[int] = None
-    parent: "LinkDescription" = jax_dataclasses.static_field(default=None, repr=False)
+    parent: Static["LinkDescription"] = dataclasses.field(default=None, repr=False)
     pose: jtp.Matrix = dataclasses.field(default_factory=lambda: jnp.eye(4), repr=False)
-    children: List["LinkDescription"] = jax_dataclasses.static_field(
+    children: Static[List["LinkDescription"]] = dataclasses.field(
         default_factory=list, repr=False
     )
 

--- a/src/jaxsim/physics/algos/rnea.py
+++ b/src/jaxsim/physics/algos/rnea.py
@@ -1,5 +1,6 @@
-from typing import Dict, Tuple
+from typing import Tuple
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -20,6 +21,10 @@ def rnea(
     a0fb: jtp.Vector = jnp.zeros(6),
     f_ext: jtp.Matrix = None,
 ) -> Tuple[jtp.Vector, jtp.Vector]:
+    """
+    Recursive Newton-Euler Algorithm (RNEA) algorithm for inverse dynamics.
+    """
+
     xfb, q, qd, qdd, _, f_ext = utils.process_inputs(
         physics_model=model, xfb=xfb, q=q, qd=qd, qdd=qdd, f_ext=f_ext
     )
@@ -30,81 +35,130 @@ def rnea(
     if a0fb.shape[0] != 6:
         raise ValueError(a0fb.shape)
 
-    I = model.spatial_inertias
-    Xtree = model.tree_transforms
-    Xj = model.joint_transforms(q=q)
+    M = model.spatial_inertias
+    pre_X_λi = model.tree_transforms
+    i_X_pre = model.joint_transforms(q=q)
     S = model.motion_subspaces(q=q)
-    Xup = jnp.zeros_like(Xtree)
+    i_X_λi = jnp.zeros_like(pre_X_λi)
 
-    i_X_0 = jnp.zeros_like(Xtree)
+    i_X_0 = jnp.zeros_like(pre_X_λi)
     i_X_0 = i_X_0.at[0].set(jnp.eye(6))
 
-    v: Dict[int, jtp.VectorJax] = dict()
-    a: Dict[int, jtp.VectorJax] = dict()
-    f: Dict[int, jtp.VectorJax] = dict()
+    # Parent array mapping: i -> λ(i).
+    # Exception: λ(0) must not be used, it's initialized to -1.
+    λ = model.parent_array()
+
+    v = jnp.array([jnp.zeros([6, 1])] * model.NB)
+    a = jnp.array([jnp.zeros([6, 1])] * model.NB)
+    f = jnp.array([jnp.zeros([6, 1])] * model.NB)
 
     # 6D transform of base velocity
-    Xup_0 = B_X_W = Adjoint.from_quaternion_and_translation(
+    B_X_W = Adjoint.from_quaternion_and_translation(
         quaternion=xfb[0:4],
         translation=xfb[4:7],
         inverse=True,
         normalize_quaternion=True,
     )
-    Xup = Xup.at[0].set(Xup_0)
+    i_X_λi = i_X_λi.at[0].set(B_X_W)
 
-    v[0] = jnp.zeros(shape=(6, 1))
-    f[0] = jnp.zeros(shape=(6, 1))
-    a[0] = -B_X_W @ jnp.vstack(gravity)
+    a_0 = -B_X_W @ jnp.vstack(gravity)
+    a = a.at[0].set(a_0)
 
     if model.is_floating_base:
         W_v_WB = jnp.vstack(jnp.hstack([xfb[10:13], xfb[7:10]]))
-        v[0] = B_X_W @ W_v_WB
 
-        a[0] = B_X_W @ (jnp.vstack(a0fb) - jnp.vstack(gravity))
-        f[0] = (
-            I[0] @ a[0]
-            + Cross.vx_star(v[0]) @ I[0] @ v[0]
-            - jnp.linalg.inv(B_X_W).T @ jnp.vstack(f_ext[0])
+        v_0 = B_X_W @ W_v_WB
+        v = v.at[0].set(v_0)
+
+        a_0 = B_X_W @ (jnp.vstack(a0fb) - jnp.vstack(gravity))
+        a = a.at[0].set(a_0)
+
+        f_0 = (
+            M[0] @ a[0]
+            + Cross.vx_star(v[0]) @ M[0] @ v[0]
+            - Adjoint.inverse(B_X_W).T @ jnp.vstack(f_ext[0])
         )
+        f = f.at[0].set(f_0)
 
-    for i in np.arange(start=1, stop=model.NB):
+    ForwardPassCarry = Tuple[
+        jtp.MatrixJax, jtp.MatrixJax, jtp.MatrixJax, jtp.MatrixJax, jtp.MatrixJax
+    ]
+    forward_pass_carry = (i_X_λi, v, a, i_X_0, f)
+
+    def forward_pass(
+        carry: ForwardPassCarry, i: jtp.Int
+    ) -> Tuple[ForwardPassCarry, None]:
         ii = i - 1
+        i_X_λi, v, a, i_X_0, f = carry
 
         vJ = S[i] * qd[ii]
-        Xup_i = Xj[i] @ Xtree[i]
-        Xup = Xup.at[i].set(Xup_i)
+        i_X_λi_i = i_X_pre[i] @ pre_X_λi[i]
+        i_X_λi = i_X_λi.at[i].set(i_X_λi_i)
 
-        λi = model._parent_array_dict[i]
-        v[i] = Xup[i] @ v[λi] + vJ
-        a[i] = Xup[i] @ a[λi] + S[i] * qdd[ii] + Cross.vx(v[i]) @ vJ
+        v_i = i_X_λi[i] @ v[λ[i]] + vJ
+        v = v.at[i].set(v_i)
 
-        i_X_0_i = Xup[i] @ i_X_0[λi]
+        a_i = i_X_λi[i] @ a[λ[i]] + S[i] * qdd[ii] + Cross.vx(v[i]) @ vJ
+        a = a.at[i].set(a_i)
+
+        i_X_0_i = i_X_λi[i] @ i_X_0[λ[i]]
         i_X_0 = i_X_0.at[i].set(i_X_0_i)
-        i_X_W = jnp.linalg.inv(i_X_0[i] @ B_X_W).T
+        i_Xf_W = Adjoint.inverse(i_X_0[i] @ B_X_W).T
 
-        f[i] = (
-            I[i] @ a[i]
-            + Cross.vx_star(v[i]) @ I[i] @ v[i]
-            - i_X_W @ jnp.vstack(f_ext[i])
+        f_i = (
+            M[i] @ a[i]
+            + Cross.vx_star(v[i]) @ M[i] @ v[i]
+            - i_Xf_W @ jnp.vstack(f_ext[i])
         )
+        f = f.at[i].set(f_i)
+
+        return (i_X_λi, v, a, i_X_0, f), None
+
+    (i_X_λi, v, a, i_X_0, f), _ = jax.lax.scan(
+        f=forward_pass,
+        init=forward_pass_carry,
+        xs=np.arange(start=1, stop=model.NB),
+    )
 
     tau = jnp.zeros_like(q)
 
-    for i in reversed(np.arange(start=1, stop=model.NB)):
+    BackwardPassCarry = Tuple[jtp.MatrixJax, jtp.MatrixJax]
+    backward_pass_carry = (tau, f)
+
+    def backward_pass(
+        carry: BackwardPassCarry, i: jtp.Int
+    ) -> Tuple[BackwardPassCarry, None]:
         ii = i - 1
+        tau, f = carry
 
         value = S[i].T @ f[i]
         tau = tau.at[ii].set(value.squeeze())
 
-        λi = model._parent_array_dict[i]
+        def update_f(f: jtp.MatrixJax) -> jtp.MatrixJax:
+            f_λi = f[λ[i]] + i_X_λi[i].T @ f[i]
+            f = f.at[λ[i]].set(f_λi)
+            return f
 
-        if λi != 0 or model.is_floating_base:
-            f[λi] = f[λi] + Xup[i].T @ f[i]
+        f = jax.lax.cond(
+            pred=jnp.array([λ[i] != 0, model.is_floating_base]).any(),
+            true_fun=update_f,
+            false_fun=lambda f: f,
+            operand=f,
+        )
+
+        return (tau, f), None
+
+    (tau, f), _ = jax.lax.scan(
+        f=backward_pass,
+        init=backward_pass_carry,
+        xs=np.flip(np.arange(start=1, stop=model.NB)),
+    )
 
     # Handle 1 DoF models
     tau = jnp.atleast_1d(tau.squeeze())
     tau = jnp.vstack(tau) if tau.size > 0 else jnp.empty(shape=(0, 1))
 
+    # Express the base 6D force in the world frame
     W_f0 = B_X_W.T @ jnp.vstack(f[0])
 
     return W_f0, tau

--- a/src/jaxsim/physics/algos/soft_contacts.py
+++ b/src/jaxsim/physics/algos/soft_contacts.py
@@ -3,7 +3,6 @@ import dataclasses
 from typing import Tuple
 
 import jax
-import jax.experimental.loops
 import jax.flatten_util
 import jax.numpy as jnp
 import jax_dataclasses

--- a/src/jaxsim/physics/algos/soft_contacts.py
+++ b/src/jaxsim/physics/algos/soft_contacts.py
@@ -55,6 +55,10 @@ def collidable_points_pos_vel(
     qd: jtp.Vector,
     xfb: jtp.Vector = None,
 ) -> Tuple[jtp.Matrix, jtp.Matrix]:
+    """
+    Compute the position and linear velocity of collidable points in the world frame.
+    """
+
     # Make sure that shape and size are correct
     xfb, q, qd, _, _, _ = utils.process_inputs(physics_model=model, xfb=xfb, q=q, qd=qd)
 
@@ -181,11 +185,11 @@ def collidable_points_pos_vel(
 
 @jax_dataclasses.pytree_dataclass
 class SoftContactsParams:
-    """"""
+    """Parameters of the soft contacts model."""
 
-    K: float = dataclasses.field(default=jnp.array(1e6, dtype=float))
-    D: float = dataclasses.field(default=jnp.array(2000, dtype=float))
-    mu: float = dataclasses.field(default=jnp.array(0.5, dtype=float))
+    K: float = dataclasses.field(default_factory=lambda: jnp.array(1e6, dtype=float))
+    D: float = dataclasses.field(default_factory=lambda: jnp.array(2000, dtype=float))
+    mu: float = dataclasses.field(default_factory=lambda: jnp.array(0.5, dtype=float))
 
     @staticmethod
     def build(
@@ -202,6 +206,8 @@ class SoftContactsParams:
 
 @jax_dataclasses.pytree_dataclass
 class SoftContacts:
+    """Soft contacts model."""
+
     parameters: SoftContactsParams = dataclasses.field(
         default_factory=SoftContactsParams
     )

--- a/src/jaxsim/physics/algos/terrain.py
+++ b/src/jaxsim/physics/algos/terrain.py
@@ -35,7 +35,9 @@ class FlatTerrain(Terrain):
 
 @jax_dataclasses.pytree_dataclass
 class PlaneTerrain(Terrain):
-    plane_normal: jtp.Vector = jax_dataclasses.field(default=jnp.array([0, 0, 1.0]))
+    plane_normal: jtp.Vector = jax_dataclasses.field(
+        default_factory=lambda: jnp.array([0, 0, 1.0])
+    )
 
     @staticmethod
     def build(plane_normal: jtp.Vector) -> "PlaneTerrain":

--- a/src/jaxsim/physics/model/ground_contact.py
+++ b/src/jaxsim/physics/model/ground_contact.py
@@ -1,15 +1,22 @@
+import dataclasses
+
 import jax.numpy as jnp
 import jax_dataclasses
 import numpy as np
 import numpy.typing as npt
+from jax_dataclasses import Static
 
 from jaxsim.parsers.descriptions import ModelDescription
 
 
 @jax_dataclasses.pytree_dataclass
 class GroundContact:
-    point: npt.NDArray = jax_dataclasses.field(default_factory=lambda: jnp.array([]))
-    body: npt.NDArray = jax_dataclasses.static_field(
+    """
+    Class to store the collidable points of a robot model.
+    """
+
+    point: npt.NDArray = dataclasses.field(default_factory=lambda: jnp.array([]))
+    body: Static[npt.NDArray] = dataclasses.field(
         default_factory=lambda: np.array([], dtype=int)
     )
 

--- a/src/jaxsim/physics/model/physics_model.py
+++ b/src/jaxsim/physics/model/physics_model.py
@@ -5,7 +5,7 @@ import jax.lax
 import jax.numpy as jnp
 import jax_dataclasses
 import numpy as np
-from jax_dataclasses import pytree_dataclass, static_field
+from jax_dataclasses import Static
 
 import jaxsim.parsers
 import jaxsim.physics
@@ -19,25 +19,29 @@ from .ground_contact import GroundContact
 from .physics_model_state import PhysicsModelState
 
 
-@pytree_dataclass
+@jax_dataclasses.pytree_dataclass
 class PhysicsModel(JaxsimDataclass):
-    NB: int = static_field()
-    initial_state: PhysicsModelState = jax_dataclasses.field(default=None)
+    """
+    A read-only class to store all the information necessary to run RBDAs on a model.
+    """
+
+    NB: Static[int]
+    initial_state: PhysicsModelState = dataclasses.field(default=None)
     gravity: jtp.Vector = dataclasses.field(
         default_factory=lambda: jnp.hstack(
             [np.zeros(3), jaxsim.physics.default_gravity()]
         )
     )
-    is_floating_base: bool = static_field(default_factory=lambda: False)
+    is_floating_base: Static[bool] = dataclasses.field(default=False)
     gc: GroundContact = dataclasses.field(default_factory=lambda: GroundContact())
-    description: jaxsim.parsers.descriptions.model.ModelDescription = static_field(
-        default=None
-    )
+    description: Static[
+        jaxsim.parsers.descriptions.model.ModelDescription
+    ] = dataclasses.field(default=None)
 
-    _parent_array_dict: Dict[int, int] = static_field(default_factory=dict)
-    _jtype_dict: Dict[int, Union[JointType, JointDescriptor]] = static_field(
-        default_factory=dict
-    )
+    _parent_array_dict: Static[Dict[int, int]] = dataclasses.field(default_factory=dict)
+    _jtype_dict: Static[
+        Dict[int, Union[JointType, JointDescriptor]]
+    ] = dataclasses.field(default_factory=dict)
     _tree_transforms_dict: Dict[int, jtp.Matrix] = dataclasses.field(
         default_factory=dict
     )

--- a/src/jaxsim/physics/model/physics_model_state.py
+++ b/src/jaxsim/physics/model/physics_model_state.py
@@ -113,7 +113,7 @@ class PhysicsModelState(JaxsimDataclass):
 
 
 @jax_dataclasses.pytree_dataclass
-class PhysicsModelInput:
+class PhysicsModelInput(JaxsimDataclass):
     tau: jtp.VectorJax
     f_ext: jtp.MatrixJax
 

--- a/src/jaxsim/simulation/simulator.py
+++ b/src/jaxsim/simulation/simulator.py
@@ -32,7 +32,9 @@ class SimulatorData(JaxsimDataclass):
     """
 
     # Simulation time stored in ns in order to prevent floats approximation
-    time_ns: jtp.Int = jnp.array(0, dtype=jnp.uint64)
+    time_ns: jtp.Int = dataclasses.field(
+        default_factory=lambda: jnp.array(0, dtype=jnp.uint64)
+    )
 
     # Terrain and contact parameters
     terrain: Terrain = dataclasses.field(default_factory=lambda: FlatTerrain())

--- a/src/jaxsim/simulation/simulator.py
+++ b/src/jaxsim/simulation/simulator.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
+from jax_dataclasses import Static
 
 import jaxsim.high_level
 import jaxsim.parsers.descriptions as descriptions
@@ -34,16 +35,16 @@ class SimulatorData(JaxsimDataclass):
     time_ns: jtp.Int = jnp.array(0, dtype=jnp.uint64)
 
     # Terrain and contact parameters
-    terrain: Terrain = jax_dataclasses.field(default_factory=lambda: FlatTerrain())
-    contact_parameters: SoftContactsParams = jax_dataclasses.field(
+    terrain: Terrain = dataclasses.field(default_factory=lambda: FlatTerrain())
+    contact_parameters: SoftContactsParams = dataclasses.field(
         default_factory=lambda: SoftContactsParams()
     )
 
     # Dictionary containing all handled models
-    models: Dict[str, Model] = jax_dataclasses.field(default_factory=dict)
+    models: Dict[str, Model] = dataclasses.field(default_factory=dict)
 
     # Default gravity vector (could be overridden for individual models)
-    gravity: jtp.Vector = jax_dataclasses.field(
+    gravity: jtp.Vector = dataclasses.field(
         default_factory=lambda: jaxsim.physics.default_gravity()
     )
 
@@ -53,19 +54,19 @@ class JaxSim(JaxsimDataclass):
     """The JaxSim simulator."""
 
     # Step size stored in ns in order to prevent floats approximation
-    step_size_ns: jtp.Int = jax_dataclasses.field(
+    step_size_ns: jtp.Int = dataclasses.field(
         default_factory=lambda: jnp.array(1_000_000, dtype=jnp.uint64)
     )
 
     # Number of sub-steps performed at each integration step.
     # Note: there is no collision detection performed in sub-steps.
-    steps_per_run: jtp.Int = jax_dataclasses.static_field(default=1)
+    steps_per_run: Static[jtp.Int] = dataclasses.field(default=1)
 
     # Default velocity representation (could be overridden for individual models)
-    velocity_representation: VelRepr = jax_dataclasses.field(default=VelRepr.Inertial)
+    velocity_representation: VelRepr = dataclasses.field(default=VelRepr.Inertial)
 
     # Integrator type
-    integrator_type: ode_integration.IntegratorType = jax_dataclasses.static_field(
+    integrator_type: Static[ode_integration.IntegratorType] = dataclasses.field(
         default=ode_integration.IntegratorType.EulerForward
     )
 

--- a/src/jaxsim/utils.py
+++ b/src/jaxsim/utils.py
@@ -96,7 +96,7 @@ class JaxsimDataclass(abc.ABC):
         return self
 
     def copy(self: T) -> T:
-        obj = jax.tree_util.tree_map(lambda leaf: leaf, self)
+        obj = copy.deepcopy(self)
         obj._set_mutability(mutability=self._mutability())
         return obj
 

--- a/tests/test_eom.py
+++ b/tests/test_eom.py
@@ -1,0 +1,132 @@
+import pathlib
+
+import jax
+import numpy as np
+import pytest
+
+from jaxsim.high_level.common import VelRepr
+from jaxsim.high_level.model import Model
+
+from . import utils_idyntree, utils_models, utils_rng
+
+
+@pytest.mark.parametrize(
+    "robot, vel_repr",
+    [
+        (utils_models.Robot.DoublePendulum, VelRepr.Inertial),
+        (utils_models.Robot.DoublePendulum, VelRepr.Body),
+        (utils_models.Robot.DoublePendulum, VelRepr.Mixed),
+        (utils_models.Robot.Ur10, VelRepr.Inertial),
+        (utils_models.Robot.Ur10, VelRepr.Body),
+        (utils_models.Robot.Ur10, VelRepr.Mixed),
+        (utils_models.Robot.AnymalC, VelRepr.Inertial),
+        (utils_models.Robot.AnymalC, VelRepr.Body),
+        (utils_models.Robot.AnymalC, VelRepr.Mixed),
+        (utils_models.Robot.Cassie, VelRepr.Inertial),
+        (utils_models.Robot.Cassie, VelRepr.Body),
+        (utils_models.Robot.Cassie, VelRepr.Mixed),
+        # (utils_models.Robot.iCub, VelRepr.Inertial),
+        # (utils_models.Robot.iCub, VelRepr.Body),
+        # (utils_models.Robot.iCub, VelRepr.Mixed),
+    ],
+)
+def test_eom(robot: utils_models.Robot, vel_repr: VelRepr) -> None:
+    """Unit test of all the terms of the floating-base Equations of Motion."""
+
+    # Initialize the gravity
+    gravity = np.array([0, 0, -10.0])
+
+    # Get the URDF of the robot
+    urdf_file_path = utils_models.ModelFactory.get_model_description(robot=robot)
+
+    # Build the high-level model
+    model_jaxsim = Model.build_from_model_description(
+        model_description=urdf_file_path,
+        vel_repr=vel_repr,
+        gravity=gravity,
+        is_urdf=True,
+    ).mutable(mutable=True, validate=True)
+
+    # Initialize the model with a random state
+    model_jaxsim.data.model_state = utils_rng.random_physics_model_state(
+        physics_model=model_jaxsim.physics_model
+    )
+
+    # Initialize the model with a random input
+    model_jaxsim.data.model_input = utils_rng.random_physics_model_input(
+        physics_model=model_jaxsim.physics_model
+    )
+
+    # Get the joint torques
+    tau = model_jaxsim.joint_generalized_forces_targets()
+
+    # ==========================
+    # Ground truth with iDynTree
+    # ==========================
+
+    kin_dyn = utils_idyntree.KinDynComputations.build(
+        urdf=pathlib.Path(urdf_file_path),
+        considered_joints=model_jaxsim.joint_names(),
+        vel_repr=vel_repr,
+        gravity=gravity,
+    )
+
+    kin_dyn.set_robot_state(
+        joint_positions=np.array(model_jaxsim.joint_positions()),
+        joint_velocities=np.array(model_jaxsim.joint_velocities()),
+        base_transform=np.array(model_jaxsim.base_transform()),
+        base_velocity=np.array(model_jaxsim.base_velocity()),
+    )
+
+    assert kin_dyn.joint_names() == model_jaxsim.joint_names()
+    assert kin_dyn.gravity == pytest.approx(model_jaxsim.physics_model.gravity[0:3])
+    assert kin_dyn.joint_positions() == pytest.approx(model_jaxsim.joint_positions())
+    assert kin_dyn.joint_velocities() == pytest.approx(model_jaxsim.joint_velocities())
+    assert kin_dyn.base_velocity() == pytest.approx(model_jaxsim.base_velocity())
+    assert kin_dyn.frame_transform(model_jaxsim.base_frame()) == pytest.approx(
+        model_jaxsim.base_transform()
+    )
+
+    M_idt = kin_dyn.mass_matrix()
+    h_idt = kin_dyn.bias_forces()
+    g_idt = kin_dyn.gravity_forces()
+
+    J_idt = np.vstack(
+        [
+            kin_dyn.jacobian_frame(frame_name=link_name)
+            for link_name in model_jaxsim.link_names()
+        ]
+    )
+
+    # ================================
+    # Test individual terms of the EoM
+    # ================================
+
+    jit_enabled = True
+    fn = jax.jit if jit_enabled else lambda x: x
+
+    M_jaxsim = fn(model_jaxsim.free_floating_mass_matrix)()
+    g_jaxsim = fn(model_jaxsim.free_floating_gravity_forces)()
+    h_jaxsim = fn(model_jaxsim.free_floating_bias_forces)()
+    J_jaxsim = np.vstack([link.jacobian() for link in model_jaxsim.links()])
+
+    sl = np.s_[0:] if model_jaxsim.floating_base() else np.s_[6:]
+    assert M_jaxsim[sl, sl] == pytest.approx(M_idt[sl, sl], abs=1e-3)
+    assert g_jaxsim[sl] == pytest.approx(g_idt[sl], abs=1e-3)
+    assert h_jaxsim[sl] == pytest.approx(h_idt[sl], abs=1e-3)
+    assert J_jaxsim == pytest.approx(J_idt, abs=1e-3)
+
+    # ===========================================
+    # Test the forward dynamics computed with CRB
+    # ===========================================
+
+    J_ff = fn(model_jaxsim.generalized_free_floating_jacobian)()
+    f_ext = fn(model_jaxsim.external_forces)().flatten()
+    nud = np.hstack(fn(model_jaxsim.forward_dynamics_crb)(tau=tau))
+    S = np.block(
+        [np.zeros(shape=(model_jaxsim.dofs(), 6)), np.eye(model_jaxsim.dofs())]
+    ).T
+
+    assert h_jaxsim[sl] == pytest.approx(
+        (S @ tau + J_ff.T @ f_ext - M_jaxsim @ nud)[sl], abs=1e-3
+    )

--- a/tests/test_forward_dynamics.py
+++ b/tests/test_forward_dynamics.py
@@ -1,0 +1,75 @@
+import jax
+import numpy as np
+import pytest
+
+from jaxsim.high_level.common import VelRepr
+from jaxsim.high_level.model import Model
+
+from . import utils_models, utils_rng
+
+
+@pytest.mark.parametrize(
+    "robot, vel_repr",
+    [
+        (utils_models.Robot.DoublePendulum, VelRepr.Inertial),
+        (utils_models.Robot.DoublePendulum, VelRepr.Body),
+        (utils_models.Robot.DoublePendulum, VelRepr.Mixed),
+        (utils_models.Robot.Ur10, VelRepr.Inertial),
+        (utils_models.Robot.Ur10, VelRepr.Body),
+        (utils_models.Robot.Ur10, VelRepr.Mixed),
+        (utils_models.Robot.AnymalC, VelRepr.Inertial),
+        (utils_models.Robot.AnymalC, VelRepr.Body),
+        (utils_models.Robot.AnymalC, VelRepr.Mixed),
+        (utils_models.Robot.Cassie, VelRepr.Inertial),
+        (utils_models.Robot.Cassie, VelRepr.Body),
+        (utils_models.Robot.Cassie, VelRepr.Mixed),
+        # (utils_models.Robot.iCub, VelRepr.Inertial),
+        # (utils_models.Robot.iCub, VelRepr.Body),
+        # (utils_models.Robot.iCub, VelRepr.Mixed),
+    ],
+)
+def test_aba(robot: utils_models.Robot, vel_repr: VelRepr) -> None:
+    """
+    Unit test of the ABA algorithm against forward dynamics computed from the EoM.
+    """
+
+    # Initialize the gravity
+    gravity = np.array([0, 0, -10.0])
+
+    # Get the URDF of the robot
+    urdf_file_path = utils_models.ModelFactory.get_model_description(robot=robot)
+
+    # Build the high-level model
+    model = Model.build_from_model_description(
+        model_description=urdf_file_path,
+        vel_repr=vel_repr,
+        gravity=gravity,
+        is_urdf=True,
+    ).mutable(mutable=True, validate=True)
+
+    # Initialize the model with a random state
+    model.data.model_state = utils_rng.random_physics_model_state(
+        physics_model=model.physics_model
+    )
+
+    # Initialize the model with a random input
+    model.data.model_input = utils_rng.random_physics_model_input(
+        physics_model=model.physics_model
+    )
+
+    # Get the joint torques
+    tau = model.joint_generalized_forces_targets()
+
+    # Compute model acceleration with ABA
+    jit_enabled = True
+    fn = jax.jit if jit_enabled else lambda x: x
+    a_WB_aba, sdd_aba = fn(model.forward_dynamics_aba)(tau=tau)
+
+    # ==============================================
+    # Compute forward dynamics with dedicated method
+    # ==============================================
+
+    a_WB, sdd = model.forward_dynamics_crb(tau=tau)
+
+    assert sdd.squeeze() == pytest.approx(sdd_aba.squeeze(), abs=0.5)
+    assert a_WB.squeeze() == pytest.approx(a_WB_aba.squeeze(), abs=0.2)

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -1,0 +1,236 @@
+import dataclasses
+import pathlib
+from typing import List, Optional, Union
+
+import idyntree.bindings as idt
+import numpy as np
+import numpy.typing as npt
+
+from jaxsim.high_level.common import VelRepr
+
+
+@dataclasses.dataclass
+class KinDynComputations:
+    """High-level wrapper of the iDynTree KinDynComputations class."""
+
+    vel_repr: VelRepr
+    gravity: npt.NDArray
+    kin_dyn: idt.KinDynComputations
+
+    @staticmethod
+    def build(
+        urdf: Union[pathlib.Path, str],
+        considered_joints: List[str] = None,
+        vel_repr: VelRepr = VelRepr.Inertial,
+        gravity: npt.NDArray = dataclasses.field(
+            default_factory=lambda: np.array([0, 0, -10.0])
+        ),
+    ) -> "KinDynComputations":
+        """"""
+
+        # Read the URDF description
+        urdf_string = urdf.read_text() if isinstance(urdf, pathlib.Path) else urdf
+
+        # Create the model loader
+        mdl_loader = idt.ModelLoader()
+
+        # Load the URDF description
+        if not (
+            mdl_loader.loadModelFromString(urdf_string)
+            if considered_joints is None
+            else mdl_loader.loadReducedModelFromString(urdf_string, considered_joints)
+        ):
+            raise RuntimeError(f"Failed to load URDF description")
+
+        # Create KinDynComputations and insert the model
+        kindyn = idt.KinDynComputations()
+
+        if not kindyn.loadRobotModel(mdl_loader.model()):
+            raise RuntimeError("Failed to load model")
+
+        vel_repr_to_idyntree = {
+            VelRepr.Inertial: idt.INERTIAL_FIXED_REPRESENTATION,
+            VelRepr.Body: idt.BODY_FIXED_REPRESENTATION,
+            VelRepr.Mixed: idt.MIXED_REPRESENTATION,
+        }
+
+        # Configure the frame representation
+        if not kindyn.setFrameVelocityRepresentation(vel_repr_to_idyntree[vel_repr]):
+            raise RuntimeError("Failed to set the frame representation")
+
+        return KinDynComputations(
+            kin_dyn=kindyn,
+            vel_repr=vel_repr,
+            gravity=np.array(gravity).squeeze(),
+        )
+
+    def set_robot_state(
+        self,
+        joint_positions: Optional[npt.NDArray] = None,
+        joint_velocities: Optional[npt.NDArray] = None,
+        base_transform: npt.NDArray = np.eye(4),
+        base_velocity: npt.NDArray = np.zeros(6),
+        world_gravity: Optional[npt.NDArray] = None,
+    ) -> None:
+        joint_positions = (
+            joint_positions if joint_positions is not None else np.zeros(self.dofs())
+        )
+
+        joint_velocities = (
+            joint_velocities if joint_velocities is not None else np.zeros(self.dofs())
+        )
+
+        gravity = world_gravity if world_gravity is not None else self.gravity
+
+        if joint_positions.size != self.dofs():
+            raise ValueError(joint_positions.size, self.dofs())
+
+        if joint_velocities.size != self.dofs():
+            raise ValueError(joint_velocities.size, self.dofs())
+
+        if gravity.size != 3:
+            raise ValueError(gravity.size, 3)
+
+        if base_transform.shape != (4, 4):
+            raise ValueError(base_transform.shape, (4, 4))
+
+        if base_velocity.size != 6:
+            raise ValueError(base_velocity.size)
+
+        g = idt.Vector3().FromPython(np.array(gravity))
+        s = idt.VectorDynSize().FromPython(np.array(joint_positions))
+        s_dot = idt.VectorDynSize().FromPython(np.array(joint_velocities))
+
+        p = idt.Position(*[float(i) for i in np.array(base_transform[0:3, 3])])
+        R = idt.Rotation()
+        R = R.FromPython(np.array(base_transform[0:3, 0:3]))
+        world_H_base = idt.Transform()
+        world_H_base.setPosition(p)
+        world_H_base.setRotation(R)
+
+        v_WB = idt.Twist().FromPython(base_velocity)
+
+        if not self.kin_dyn.setRobotState(world_H_base, s, v_WB, s_dot, g):
+            raise RuntimeError("Failed to set the robot state")
+
+        # Update stored gravity
+        self.world_gravity = gravity
+
+    def dofs(self) -> int:
+        return self.kin_dyn.getNrOfDegreesOfFreedom()
+
+    def joint_names(self) -> List[str]:
+        model: idt.Model = self.kin_dyn.model()
+        return [model.getJointName(i) for i in range(model.getNrOfJoints())]
+
+    def link_names(self) -> List[str]:
+        return [
+            self.kin_dyn.getFrameName(i) for i in range(self.kin_dyn.getNrOfLinks())
+        ]
+
+    def joint_positions(self) -> npt.NDArray:
+        vector = idt.VectorDynSize()
+
+        if not self.kin_dyn.getJointPos(vector):
+            raise RuntimeError("Failed to extract joint positions")
+
+        return vector.toNumPy()
+
+    def joint_velocities(self) -> npt.NDArray:
+        vector = idt.VectorDynSize()
+
+        if not self.kin_dyn.getJointVel(vector):
+            raise RuntimeError("Failed to extract joint velocities")
+
+        return vector.toNumPy()
+
+    def jacobian_frame(self, frame_name: str) -> npt.NDArray:
+        if self.kin_dyn.getFrameIndex(frame_name) < 0:
+            raise ValueError(f"Frame '{frame_name}' does not exist")
+
+        J = idt.MatrixDynSize(6, 6 + self.dofs())
+
+        if not self.kin_dyn.getFrameFreeFloatingJacobian(frame_name, J):
+            raise RuntimeError("Failed to get the frame free-floating jacobian")
+
+        return J.toNumPy()
+
+    def total_mass(self) -> float:
+        model: idt.Model = self.kin_dyn.model()
+        return model.getTotalMass()
+
+    def spatial_inertia(self, link_name: str) -> npt.NDArray:
+        if link_name not in self.link_names():
+            raise ValueError(link_name)
+
+        model = self.kin_dyn.model()
+
+        return (
+            model.getLink(model.getLinkIndex(link_name)).inertia().asMatrix().toNumPy()
+        )
+
+    def floating_base_frame(self) -> str:
+        return self.kin_dyn.getFloatingBase()
+
+    def frame_transform(self, frame_name: str) -> npt.NDArray:
+        if self.kin_dyn.getFrameIndex(frame_name) < 0:
+            raise ValueError(f"Frame '{frame_name}' does not exist")
+
+        if frame_name == self.floating_base_frame():
+            H_idt = self.kin_dyn.getWorldBaseTransform()
+        else:
+            H_idt = self.kin_dyn.getWorldTransform(frame_name)
+
+        # return H_idt.asHomogeneousTransform().toNumPy()
+
+        H = np.eye(4)
+        H[0:3, 3] = H_idt.getPosition().toNumPy()
+        H[0:3, 0:3] = H_idt.getRotation().toNumPy()
+
+        return H
+
+    def base_velocity(self) -> npt.NDArray:
+        nu = idt.VectorDynSize()
+
+        if not self.kin_dyn.getModelVel(nu):
+            raise RuntimeError("Failed to get the model velocity")
+
+        return nu.toNumPy()[0:6]
+
+    def com_position(self) -> npt.NDArray:
+        W_p_G = self.kin_dyn.getCenterOfMassPosition()
+        return W_p_G.toNumPy()
+
+    def mass_matrix(self) -> npt.NDArray:
+        M = idt.MatrixDynSize()
+
+        if not self.kin_dyn.getFreeFloatingMassMatrix(M):
+            raise RuntimeError("Failed to get the free floating mass matrix")
+
+        return M.toNumPy()
+
+    def bias_forces(self) -> npt.NDArray:
+        h = idt.FreeFloatingGeneralizedTorques(self.kin_dyn.model())
+
+        if not self.kin_dyn.generalizedBiasForces(h):
+            raise RuntimeError("Failed to get the generalized bias forces")
+
+        base_wrench: idt.Wrench = h.baseWrench()
+        joint_torques: idt.JointDOFsDoubleArray = h.jointTorques()
+
+        return np.hstack(
+            [base_wrench.toNumPy().flatten(), joint_torques.toNumPy().flatten()]
+        )
+
+    def gravity_forces(self) -> npt.NDArray:
+        g = idt.FreeFloatingGeneralizedTorques(self.kin_dyn.model())
+
+        if not self.kin_dyn.generalizedGravityForces(g):
+            raise RuntimeError("Failed to get the generalized gravity forces")
+
+        base_wrench: idt.Wrench = g.baseWrench()
+        joint_torques: idt.JointDOFsDoubleArray = g.jointTorques()
+
+        return np.hstack(
+            [base_wrench.toNumPy().flatten(), joint_torques.toNumPy().flatten()]
+        )

--- a/tests/utils_models.py
+++ b/tests/utils_models.py
@@ -1,0 +1,56 @@
+import enum
+import pathlib
+
+import robot_descriptions.anymal_c_description
+import robot_descriptions.cassie_description
+import robot_descriptions.double_pendulum_description
+import robot_descriptions.icub_description
+import robot_descriptions.laikago_description
+import robot_descriptions.panda_description
+import robot_descriptions.ur10_description
+
+
+class Robot(enum.IntEnum):
+    iCub = enum.auto()
+    Ur10 = enum.auto()
+    Panda = enum.auto()
+    Cassie = enum.auto()
+    AnymalC = enum.auto()
+    Laikago = enum.auto()
+    DoublePendulum = enum.auto()
+
+
+class ModelFactory:
+    """Factory class providing URDF files used by the tests."""
+
+    @staticmethod
+    def get_model_description(robot: Robot) -> pathlib.Path:
+        """
+        Get the URDF file of different robots.
+
+        Args:
+            robot: Robot name of the desired URDF file.
+
+        Returns:
+            Path to the URDF file of the robot.
+        """
+
+        match robot:
+            case Robot.iCub:
+                return pathlib.Path(robot_descriptions.icub_description.URDF_PATH)
+            case Robot.Ur10:
+                return pathlib.Path(robot_descriptions.ur10_description.URDF_PATH)
+            case Robot.Panda:
+                return pathlib.Path(robot_descriptions.panda_description.URDF_PATH)
+            case Robot.Cassie:
+                return pathlib.Path(robot_descriptions.cassie_description.URDF_PATH)
+            case Robot.AnymalC:
+                return pathlib.Path(robot_descriptions.anymal_c_description.URDF_PATH)
+            case Robot.Laikago:
+                return pathlib.Path(robot_descriptions.laikago_description.URDF_PATH)
+            case Robot.DoublePendulum:
+                return pathlib.Path(
+                    robot_descriptions.double_pendulum_description.URDF_PATH
+                )
+            case _:
+                raise ValueError(f"Unknown robot '{robot}'")

--- a/tests/utils_rng.py
+++ b/tests/utils_rng.py
@@ -1,0 +1,96 @@
+import numpy as np
+
+from jaxsim import logging, sixd
+from jaxsim.physics.model.physics_model import PhysicsModel
+from jaxsim.physics.model.physics_model_state import (
+    PhysicsModelInput,
+    PhysicsModelState,
+)
+from jaxsim.utils import Mutability
+
+# Initialize a global RNG used by all tests
+test_rng = None
+
+
+def get_rng(seed: int = None) -> np.random.Generator:
+    """
+    Get a random number generator that can be used to produce reproducibile sequences.
+
+    Args:
+        seed: The optional seed of the RNG (ignored if the RNG
+
+    Returns:
+        A random number generator.
+    """
+
+    global test_rng
+
+    if test_rng is not None and seed is not None:
+        msg = "Seed was already configured globally, ignoring the new one"
+        logging.warning(msg=msg)
+
+    seed = seed if seed is not None else 42
+    test_rng = test_rng if test_rng is not None else np.random.default_rng(seed=seed)
+
+    return test_rng
+
+
+def random_physics_model_state(physics_model: PhysicsModel) -> PhysicsModelState:
+    """
+    Generate a random `PhysicsModelState` object.
+
+    Args:
+        physics_model: the physics model to which the random state refers to.
+
+    Returns:
+        The random `PhysicsModelState` object.
+    """
+
+    rng = get_rng()
+
+    with PhysicsModelState.zero(physics_model=physics_model).mutable_context(
+        mutability=Mutability.MUTABLE
+    ) as state:
+        # Generate random joint quantities
+        state.joint_positions = rng.uniform(size=physics_model.dofs(), low=-1)
+        state.joint_velocities = rng.uniform(size=physics_model.dofs(), low=-1)
+
+        # Generate random base quantities
+        state.base_position = rng.uniform(size=3, low=-1)
+        state.base_quaternion = sixd.so3.SO3.from_rpy_radians(
+            *rng.uniform(low=0, high=2 * np.pi, size=3)
+        ).as_quaternion_xyzw()[np.array([3, 0, 1, 2])]
+
+        # If floating-base, generate random base velocities
+        if physics_model.is_floating_base:
+            state.base_linear_velocity = rng.uniform(size=3, low=-1)
+            state.base_angular_velocity = rng.uniform(size=3, low=-1)
+
+    return state
+
+
+def random_physics_model_input(physics_model: PhysicsModel) -> PhysicsModelInput:
+    """
+    Generate a random `PhysicsModelInput` object.
+
+    Args:
+        physics_model: the physics model to which the random state refers to.
+
+    Returns:
+        The random `PhysicsModelInput` object.
+    """
+
+    rng = get_rng()
+
+    with PhysicsModelInput.zero(physics_model=physics_model).mutable_context(
+        mutability=Mutability.MUTABLE
+    ) as model_input:
+        # Generate random joint torques and external forces
+        model_input.tau = 10 * rng.uniform(size=physics_model.dofs(), low=-1)
+        model_input.f_ext = 10 * rng.uniform(size=[physics_model.NB, 6], low=-1)
+
+        # Zero the base force if the robot is fixed base
+        if not physics_model.is_floating_base and physics_model.NB > 0:
+            model_input.f_ext[0] = np.zeros(6)
+
+    return model_input


### PR DESCRIPTION
This is a quite big PR that I couldn't split easily in small ones. New features:

- Implemented ABA with `jax.lax.scan`, therefore removing the deprecated experimental loops (thanks @fl-ferr for #35, this PR inherits your changes) (fixing #13).
- Implement RNEA wih `jax.lax.scan` instead of plain for loops (fixing #12).
- Without the experimental loops, we can now use recent `jax` versions (fixing #27).
- Updated the dataclasses to recent `jax_dataclasses` breaking changes (fixing #36).
- Add initial unit test against iDynTree for some of the the RBDA (CRBA, RNEA, ABA).
- Fixed all errors in the computation of ABA and RNEA in some representation (fixing #13).
- Update project to run on Python 3.11 (mainly due to [this breaking change](https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses)).