### PR TITLE
Allow to insert models from `rod` objects

### DIFF
--- a/src/jaxsim/high_level/model.py
+++ b/src/jaxsim/high_level/model.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import jax_dataclasses
 import numpy as np
+import rod
 from jax_dataclasses import Static
 
 import jaxsim.physics.algos.aba
@@ -125,7 +126,7 @@ class Model(JaxsimDataclass):
 
     @staticmethod
     def build_from_model_description(
-        model_description: Union[str, pathlib.Path],
+        model_description: Union[str, pathlib.Path, rod.Model],
         model_name: Optional[str] = None,
         vel_repr: VelRepr = VelRepr.Mixed,
         gravity: jtp.Array = jaxsim.physics.default_gravity(),
@@ -136,7 +137,8 @@ class Model(JaxsimDataclass):
         Build a Model object from a model description.
 
         Args:
-            model_description: Either a path to a file or a string containing the URDF/SDF description.
+            model_description: A path to an SDF/URDF file, a string containing its content,
+                or a pre-parsed/pre-built rod model.
             model_name: The optional name of the model that overrides the one in the description.
             vel_repr: The velocity representation to use.
             gravity: The 3D gravity vector.

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -32,7 +32,7 @@ class SDFData(NamedTuple):
 
 
 def extract_model_data(
-    model_description: Union[pathlib.Path, str],
+    model_description: Union[pathlib.Path, str, rod.Model],
     model_name: Optional[str] = None,
     is_urdf: Optional[bool] = None,
 ) -> SDFData:
@@ -40,7 +40,8 @@ def extract_model_data(
     Extract data from an SDF/URDF resource useful to build a JaxSim model.
 
     Args:
-        model_description: Either a path to an SDF/URDF file or a string containing its content.
+        model_description: A path to an SDF/URDF file, a string containing its content,
+          or a pre-parsed/pre-built rod model.
         model_name: The name of the model to extract from the SDF resource.
         is_urdf: Whether the SDF resource is a URDF file. Needed only if model_description
             is a URDF string.
@@ -49,17 +50,20 @@ def extract_model_data(
         The extracted model data.
     """
 
-    # Parse the SDF resource
-    sdf_element = rod.Sdf.load(sdf=model_description, is_urdf=is_urdf)
+    if isinstance(model_description, rod.Model):
+        sdf_model = model_description
+    else:
+        # Parse the SDF resource
+        sdf_element = rod.Sdf.load(sdf=model_description, is_urdf=is_urdf)
 
-    if len(sdf_element.models()) == 0:
-        raise RuntimeError("Failed to find any model in SDF resource")
+        if len(sdf_element.models()) == 0:
+            raise RuntimeError("Failed to find any model in SDF resource")
 
-    # Assume the SDF resource has only one model, or the desired model name is given
-    sdf_models = {m.name: m for m in sdf_element.models()}
-    sdf_model = (
-        sdf_element.models()[0] if len(sdf_models) == 1 else sdf_models[model_name]
-    )
+        # Assume the SDF resource has only one model, or the desired model name is given
+        sdf_models = {m.name: m for m in sdf_element.models()}
+        sdf_model = (
+            sdf_element.models()[0] if len(sdf_models) == 1 else sdf_models[model_name]
+        )
 
     # Log model name
     logging.debug(msg=f"Found model '{sdf_model.name}' in SDF resource")
@@ -298,13 +302,15 @@ def extract_model_data(
 
 
 def build_model_description(
-    model_description: Union[pathlib.Path, str], is_urdf: Optional[bool] = False
+    model_description: Union[pathlib.Path, str, rod.Model],
+    is_urdf: Optional[bool] = False,
 ) -> descriptions.ModelDescription:
     """
     Builds a model description from an SDF/URDF resource.
 
     Args:
-        model_description: Either a path to an SDF/URDF file or a string containing its content.
+        model_description: A path to an SDF/URDF file, a string containing its content,
+          or a pre-parsed/pre-built rod model.
         is_urdf: Whether the SDF resource is a URDF file. Needed only if model_description
             is a URDF string.
     Returns:

--- a/src/jaxsim/simulation/simulator.py
+++ b/src/jaxsim/simulation/simulator.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
+import rod
 from jax_dataclasses import Static
 
 import jaxsim.high_level
@@ -226,7 +227,7 @@ class JaxSim(JaxsimDataclass):
 
     def insert_model_from_description(
         self,
-        model_description: Union[pathlib.Path, str],
+        model_description: Union[pathlib.Path, str, rod.Model],
         model_name: Optional[str] = None,
         considered_joints: Optional[List[str]] = None,
     ) -> Model:
@@ -234,7 +235,8 @@ class JaxSim(JaxsimDataclass):
         Insert a model from a model description.
 
         Args:
-            model_description: Either a path to a file or a string containing the URDF/SDF description.
+            model_description: A path to an SDF/URDF file, a string containing its content,
+                or a pre-parsed/pre-built rod model.
             model_name: The optional name of the model that overrides the one in the description.
             considered_joints: Optional list of joints to consider.
                                It is also useful to specify the joint serialization.


### PR DESCRIPTION
This change enables to bypass entirely URDF / SDF descriptions (both files and strings). 

It can be extremely useful in robot learning applications where the model has to be changed programmatically. Right now, even if the application has an in-memory rod model (that is easy to modify), it has to either serialize to string or write to file before passing it to jaxsim. Now, paying the price of extra time necessary for the parsing, the rod object can be edited in-memory and passed directly to jaxsim.

This is also useful, for example, to perform domain randomization in a highly parallel simulation.