### PR TITLE
Make all fields of `simulator.JaxSim` static excluding `SimulatorData`

### DIFF
--- a/src/jaxsim/simulation/simulator.py
+++ b/src/jaxsim/simulation/simulator.py
@@ -63,7 +63,7 @@ class JaxSim(Vmappable):
     """The JaxSim simulator."""
 
     # Step size stored in ns in order to prevent floats approximation
-    step_size_ns: jtp.Int = dataclasses.field(
+    step_size_ns: Static[jtp.Int] = dataclasses.field(
         default_factory=lambda: jnp.array(1_000_000, dtype=jnp.uint64)
     )
 


### PR DESCRIPTION
With @flferretti, we noticed the occurrence of trace leaks in a jitted context of a parallel simulation on GPUs. It turns out that the leak was caused by the following line:

https://github.com/ami-iit/jaxsim/blob/6397508fbf2e84fb20a2fbbd24e1737cee72ecd2/src/jaxsim/simulation/simulator.py#L359

For some reason, jax detects a leak in this operation.

Converting `JaxSim.step_size_ns` to a static attribute was the most straightforward solution. The pay to price, this time, is losing the possibility to perform a parallel simulation whose models are integrated using different step sizes, that is regardless an edge case not so common. If needed, we can try to fix it in the future, what matters now is to simulate a large batch of models all together on hardware accelerators.

After this change, all attributes of `JaxSim` are marked as `Static`, with the exception of `JaxSim.data` that now contains the only mutable information — the real simulator state. It makes clear what can be changed during runtime —dynamically, w/o triggering recompilations— and what not.