### PR TITLE
Fix CI/CD

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     jaxlib < 0.4.11
     jaxlie
     jax_dataclasses >= 1.4.0
+    ml-dtypes < 0.3.0
     pptree
     rod
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ python_requires = >=3.10
 install_requires =
     coloredlogs
     jax >= 0.4.1, <0.4.11
-    jaxlib
+    jaxlib < 0.4.11
     jaxlie
     jax_dataclasses >= 1.4.0
     pptree

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ package_dir =
 python_requires = >=3.10
 install_requires =
     coloredlogs
-    jax >= 0.4.1
+    jax >= 0.4.1, <0.4.11
     jaxlib
     jaxlie
     jax_dataclasses >= 1.4.0


### PR DESCRIPTION
The pins are only necessary in the current version of `main`. The upcoming [`new_api`](https://github.com/ami-iit/jaxsim/tree/new_api) branch should already be compatible with the latest jax versions.