### PR TITLE
Fix arguments order in `ode.dx_dt`

### DIFF
--- a/src/jaxsim/simulation/ode.py
+++ b/src/jaxsim/simulation/ode.py
@@ -74,9 +74,9 @@ def compute_contact_forces(
 
 def dx_dt(
     x: ode_data.ODEState,
+    t: jtp.Float | None,
     physics_model: PhysicsModel,
     soft_contacts_params: SoftContactsParams = SoftContactsParams(),
-    t: jtp.Float | None = None,
     ode_input: ode_data.ODEInput | None = None,
     terrain: Terrain = FlatTerrain(),
 ) -> Tuple[ode_data.ODEState, Dict[str, Any]]:


### PR DESCRIPTION
This PR fixes an issue caused by #64, for which the disposition of the variable `t` was changed. As a consequence, when `dx_dt` is called inside the closures of `ode_integration` the argument `physics_model` was interpreted as `t`. 