### PR TITLE
Update `jaxsim.typing` module

### DIFF
--- a/src/jaxsim/typing.py
+++ b/src/jaxsim/typing.py
@@ -1,39 +1,37 @@
-from typing import Any, Dict, Hashable, List, NamedTuple, Tuple, Union
+from typing import Any, Hashable
 
-import jax.numpy as jnp
-import numpy.typing as npt
+import jax
 
+# =========
 # JAX types
-FloatJax = Union[jnp.float16, jnp.float32, jnp.float64]
-IntJax = Union[
-    jnp.int8,
-    jnp.int16,
-    jnp.int32,
-    jnp.int64,
-    jnp.uint8,
-    jnp.uint16,
-    jnp.uint32,
-    jnp.uint64,
-]
-ArrayJax = jnp.ndarray
-TensorJax = jnp.ndarray
+# =========
+
+ScalarJax = jax.Array
+IntJax = ScalarJax
+BoolJax = ScalarJax
+FloatJax = ScalarJax
+
+ArrayJax = jax.Array
 VectorJax = ArrayJax
 MatrixJax = ArrayJax
-PyTree = Union[
-    TensorJax,
-    Dict[Hashable, "PyTree"],
-    List["PyTree"],
-    NamedTuple,
-    Tuple["PyTree"],
-    None,
-    Any,
-]
 
+PyTree = dict[Hashable, "PyTree"] | list["PyTree"] | tuple["PyTree"] | None | Any
+
+# =======================
 # Mixed JAX / NumPy types
-Array = Union[npt.NDArray, ArrayJax]
-Tensor = Union[npt.NDArray, ArrayJax]
+# =======================
+
+Array = jax.typing.ArrayLike
 Vector = Array
 Matrix = Array
-Bool = Union[bool, ArrayJax]
-Int = Union[int, IntJax]
-Float = Union[float, FloatJax]
+
+Int = int | IntJax
+Bool = bool | ArrayJax
+Float = float | FloatJax
+
+ArrayLike = Array
+VectorLike = Vector
+MatrixLike = Matrix
+IntLike = Int
+BoolLike = Bool
+FloatLike = Float


### PR DESCRIPTION
The current `jaxsim.typing` module is rather old, it was developed when `jax.Array` and `jax.typing.ArrayLike` did not exist.

Now that we have them, we can transition towards something more readable. I propose the following target:

- Use `jaxsim.typing.*Like` for type hinting input arguments that might be python scalars, numpy arrays, or jax arrays (note that static arguments must be hashable and therefore cannot be arrays).
- Use `jaxsim.typing.*` (without `Like`) for type hinting output arguments, that are all jax numpy arrays.

We currently have `jaxsim.typing.*Jax` for jax-only types, that should be ported to their corresponding types without the `Jax` suffix.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--71.org.readthedocs.build/en/71/

<!-- readthedocs-preview jaxsim end -->