### PR TITLE
Fix ReadTheDocs preview url in PRs

### DIFF
--- a/.github/workflows/read_the_docs.yml
+++ b/.github/workflows/read_the_docs.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "jaxsim"
+          project-language: ""


### PR DESCRIPTION
Solves preview url problem described in https://github.com/ami-iit/jaxsim/pull/73#issuecomment-1921594068.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--74.org.readthedocs.build/en/74/

<!-- readthedocs-preview jaxsim end -->