### PR TITLE
Use structural pattern matching for `jcal`

### DIFF
--- a/src/jaxsim/math/joint.py
+++ b/src/jaxsim/math/joint.py
@@ -32,70 +32,71 @@ def jcalc(
     else:
         raise ValueError(jtyp)
 
-    if code is JointType.F:
-        raise ValueError("Fixed joints shouldn't be here")
+    match code:
+        case JointType.F:
+            raise ValueError("Fixed joints shouldn't be here")
 
-    if code is JointType.R:
-        jtyp: JointGenericAxis
+        case JointType.R:
+            jtyp: JointGenericAxis
 
-        Xj = Adjoint.from_rotation_and_translation(
-            rotation=Rotation.from_axis_angle(vector=q * jtyp.axis), inverse=True
-        )
+            Xj = Adjoint.from_rotation_and_translation(
+                rotation=Rotation.from_axis_angle(vector=q * jtyp.axis), inverse=True
+            )
 
-        S = jnp.vstack(jnp.hstack([jnp.zeros(3), jtyp.axis.squeeze()]))
+            S = jnp.vstack(jnp.hstack([jnp.zeros(3), jtyp.axis.squeeze()]))
 
-    elif code is JointType.P:
-        jtyp: JointGenericAxis
+        case JointType.P:
+            jtyp: JointGenericAxis
 
-        Xj = Adjoint.from_rotation_and_translation(
-            translation=jnp.array(q * jtyp.axis), inverse=True
-        )
+            Xj = Adjoint.from_rotation_and_translation(
+                translation=jnp.array(q * jtyp.axis), inverse=True
+            )
 
-        S = jnp.vstack(jnp.hstack([jtyp.axis.squeeze(), jnp.zeros(3)]))
+            S = jnp.vstack(jnp.hstack([jtyp.axis.squeeze(), jnp.zeros(3)]))
 
-    elif code is JointType.Rx:
-        Xj = Adjoint.from_rotation_and_translation(
-            rotation=Rotation.x(theta=q), inverse=True
-        )
+        case JointType.Rx:
+            Xj = Adjoint.from_rotation_and_translation(
+                rotation=Rotation.x(theta=q), inverse=True
+            )
 
-        S = jnp.vstack([0, 0, 0, 1.0, 0, 0])
+            S = jnp.vstack([0, 0, 0, 1.0, 0, 0])
 
-    elif code is JointType.Ry:
-        Xj = Adjoint.from_rotation_and_translation(
-            rotation=Rotation.y(theta=q), inverse=True
-        )
+        case JointType.Ry:
+            Xj = Adjoint.from_rotation_and_translation(
+                rotation=Rotation.y(theta=q), inverse=True
+            )
 
-        S = jnp.vstack([0, 0, 0, 0, 1.0, 0])
+            S = jnp.vstack([0, 0, 0, 0, 1.0, 0])
 
-    elif code is JointType.Rz:
-        Xj = Adjoint.from_rotation_and_translation(
-            rotation=Rotation.z(theta=q), inverse=True
-        )
+        case JointType.Rz:
+            Xj = Adjoint.from_rotation_and_translation(
+                rotation=Rotation.z(theta=q), inverse=True
+            )
 
-        S = jnp.vstack([0, 0, 0, 0, 0, 1.0])
+            S = jnp.vstack([0, 0, 0, 0, 0, 1.0])
 
-    elif code is JointType.Px:
-        Xj = Adjoint.from_rotation_and_translation(
-            translation=jnp.array([q, 0.0, 0.0]), inverse=True
-        )
+        case JointType.Px:
+            Xj = Adjoint.from_rotation_and_translation(
+                translation=jnp.array([q, 0.0, 0.0]), inverse=True
+            )
 
-        S = jnp.vstack([1.0, 0, 0, 0, 0, 0])
+            S = jnp.vstack([1.0, 0, 0, 0, 0, 0])
 
-    elif code is JointType.Py:
-        Xj = Adjoint.from_rotation_and_translation(
-            translation=jnp.array([0.0, q, 0.0]), inverse=True
-        )
+        case JointType.Py:
+            Xj = Adjoint.from_rotation_and_translation(
+                translation=jnp.array([0.0, q, 0.0]), inverse=True
+            )
 
-        S = jnp.vstack([0, 1.0, 0, 0, 0, 0])
+            S = jnp.vstack([0, 1.0, 0, 0, 0, 0])
 
-    elif code is JointType.Pz:
-        Xj = Adjoint.from_rotation_and_translation(
-            translation=jnp.array([0.0, 0.0, q]), inverse=True
-        )
+        case JointType.Pz:
+            Xj = Adjoint.from_rotation_and_translation(
+                translation=jnp.array([0.0, 0.0, q]), inverse=True
+            )
 
-        S = jnp.vstack([0, 0, 1.0, 0, 0, 0])
+            S = jnp.vstack([0, 0, 1.0, 0, 0, 0])
 
-    else:
-        raise ValueError(code)
+        case _:
+            raise ValueError(code)
 
     return Xj, S


### PR DESCRIPTION
This PR focuses on optimizing the computation speed of core algorithms modules that rely on `jcalc`, e.g. ABA, CRBA, RNEA and soft contacts. The implementation introduces [structural pattern matching](https://peps.python.org/pep-0622/), to replace extensive `if-else` statements. The anticipated outcome is an average speed improvement of about 80% in functions handling joint motion subspace or joint transformation.

`if-else` implementation:
```python
%timeit -n 5 _ = model.physics_model.joint_transforms(q)
>>> 884 ms ± 34.4 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)

%timeit -n 5 _ = model.physics_model.motion_subspaces(q)
>>> 879 ms ± 28.2 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
```

`structural pattern matching` implementation:
```python
%timeit -n 5 _ = model.physics_model.motion_subspaces(q)
>>> 173 ms ± 1.28 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)

%timeit -n 5 _ = model.physics_model.joint_transforms(q)
>>> 178 ms ± 6.12 ms per loop (mean ± std. dev. of 7 runs, 5 loops each)
```

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--77.org.readthedocs.build//77/

<!-- readthedocs-preview jaxsim end -->