### PR TITLE
Update documentation on latest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ The JAXsim API documentation is available at [jaxsim.readthedocs.io](https://jax
 
 ## Installation
 
-You can install the project with [`pypa/pip`][pip], preferably in a [virtual environment][venv]:
+You can install the project using [`conda`][conda]:
+
+```bash
+conda install jaxsim -c conda-forge 
+```
+
+Or using [`pypa/pip`][pip], preferably in a [virtual environment][venv]::
 
 ```bash
 pip install jaxsim
@@ -44,8 +50,9 @@ pip install jaxsim
 Check [`setup.cfg`](setup.cfg) for the complete list of optional dependencies.
 Install all of them with `jaxsim[all]`.
 
-**Note:** For GPU support, follow the official [installation instruction][jax_gpu] of JAX.
+**Note:** For GPU support, follow the official [installation instructions][jax_gpu] of JAX.
 
+[conda]: https://anaconda.org/
 [pip]: https://github.com/pypa/pip/
 [venv]: https://docs.python.org/3/tutorial/venv.html
 [jax_gpu]: https://github.com/google/jax/#installation

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can install the project using [`conda`][conda]:
 conda install jaxsim -c conda-forge 
 ```
 
-Or using [`pypa/pip`][pip], preferably in a [virtual environment][venv]::
+Alternatively, you can use [`pypa/pip`][pip], preferably in a [virtual environment][venv]:
 
 ```bash
 pip install jaxsim

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The JAXsim API documentation is available at [jaxsim.readthedocs.io](https://jax
 You can install the project using [`conda`][conda]:
 
 ```bash
-conda install jaxsim -c conda-forge 
+conda install jaxsim -c conda-forge
 ```
 
 Alternatively, you can use [`pypa/pip`][pip], preferably in a [virtual environment][venv]:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_multiversion",
+    "enum_tools.autoenum",
 ]
 
 # -- Options for intersphinx extension

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,6 +5,26 @@ import sys
 
 from pkg_resources import get_distribution
 
+
+def _add_annotations_import(path):
+    with open(path, "r+") as f:
+        contents = f.read()
+        if not contents.startswith("from __future__ import annotations"):
+            f.seek(0, 0)
+            f.write("from __future__ import annotations  " + contents)
+
+
+def _recursive_add_annotations_import():
+    for path, _, files in os.walk("../jaxsim/"):
+        for file in [f for f in files if f.endswith(".py")]:
+            _add_annotations_import(os.path.join(path, file))
+
+
+if "READTHEDOCS" in os.environ:
+    _recursive_add_annotations_import()
+
+import jaxsim
+
 # -- Version information
 
 sys.path.insert(0, os.path.abspath("."))
@@ -46,18 +66,20 @@ extensions = [
 
 language = "en"
 
+html_theme = "sphinx_rtd_theme"
+
 templates_path = ["_templates"]
 
+html_title = f"JAXsim {version}"
+
 master_doc = "index"
+
+autodoc_typehints_format = "short"
 
 exclude_patterns = ["_build"]
 
 autodoc_typehints = "signature"
 
-# -- Options for HTML output
-
-html_theme = "sphinx_rtd_theme"
-
-# -- Options for EPUB output
+autosummary_generate = False
 
 epub_show_urls = "footnote"

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -6,12 +6,18 @@ Installation
 Prerequisites
 -------------
 
-JAXsim requires Python 3.10 or later. 
+JAXsim requires Python 3.11 or later. 
 
 Basic Installation
 ------------------
 
-You can install the project with `pypa/pip`, preferably in a `virtual environment`_:
+You can install the project with using `conda`_: 
+
+.. code-block:: bash
+
+   conda install jaxsim -c conda-forge
+
+Or using `pypa/pip`_, preferably in a `virtual environment`_:
 
 .. code-block:: bash
 
@@ -24,6 +30,7 @@ You can install all of them by specifying ``jaxsim[all]``.
 
     If you need GPU support, please follow the official `installation instruction`_ of JAX.
 
+.. _conda: https://anaconda.org/
 .. _pypa/pip: https://github.com/pypa/pip/
 .. _virtual environment: https://docs.python.org/3.8/tutorial/venv.html
 .. _installation instruction: https://github.com/google/jax/#installation

--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -17,7 +17,7 @@ You can install the project with using `conda`_:
 
    conda install jaxsim -c conda-forge
 
-Or using `pypa/pip`_, preferably in a `virtual environment`_:
+Alternatively, you can use `pypa/pip`_, preferably in a `virtual environment`_:
 
 .. code-block:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,12 +40,12 @@ Features
   :maxdepth: 2
   :caption: JAXsim API
 
-  modules/typing
   modules/high_level
   modules/math
-  modules/physics
   modules/parsers
+  modules/physics
   modules/simulation
+  modules/typing
   modules/utils
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,22 +29,24 @@ Features
 - Preliminary support for automatic differentiation of RBDAs.
 
 .. toctree::
-   :maxdepth: 2
-   :caption: User Guide
+  :hidden:
+  :maxdepth: 1
+  :caption: User Guide
 
-   guide/install
+  guide/install
 
 .. toctree::
-   :maxdepth: 2
-   :caption: JAXsim API
+  :hidden:
+  :maxdepth: 2
+  :caption: JAXsim API
 
-   modules/typing
-   modules/high_level
-   modules/math
-   modules/physics
-   modules/parsers
-   modules/simulation
-   modules/utils
+  modules/typing
+  modules/high_level
+  modules/math
+  modules/physics
+  modules/parsers
+  modules/simulation
+  modules/utils
 
 
 Examples

--- a/docs/jaxsim_conda_env.yml
+++ b/docs/jaxsim_conda_env.yml
@@ -17,5 +17,8 @@ dependencies:
   - sphinx_fontawesome
   - sphinx-multiversion
   - sphinx_rtd_theme
+  - sphinx-toolbox
   - pip
   - pptree
+  - pip:
+    - enum-tools[sphinx]

--- a/docs/modules/high_level.rst
+++ b/docs/modules/high_level.rst
@@ -1,4 +1,4 @@
-High Level 
+High Level
 ==========
 
 .. currentmodule:: jaxsim.high_level
@@ -24,5 +24,7 @@ Link
 Common
 ~~~~~~
 
-.. automodule:: jaxsim.high_level.common
+.. autoflag:: jaxsim.high_level.common.VelRepr
     :members:
+
+

--- a/docs/modules/high_level.rst
+++ b/docs/modules/high_level.rst
@@ -1,17 +1,28 @@
-.. _high_level:
-
-
 High Level 
 ==========
 
-.. autoclass:: jaxsim.high_level.model.Model
-    :members:
-    :inherited-members:
+.. currentmodule:: jaxsim.high_level
 
-.. autoclass:: jaxsim.high_level.joint.Joint
-    :members:
-    :inherited-members:
 
-.. autoclass:: jaxsim.high_level.link.Link
+Model
+~~~~~
+
+.. automodule:: jaxsim.high_level.model
     :members:
-    :inherited-members:
+
+Joint
+~~~~~
+
+.. automodule:: jaxsim.high_level.joint
+    :members:
+
+Link
+~~~~~
+.. automodule:: jaxsim.high_level.link
+    :members:
+
+Common
+~~~~~~
+
+.. automodule:: jaxsim.high_level.common
+    :members:

--- a/docs/modules/math.rst
+++ b/docs/modules/math.rst
@@ -1,41 +1,40 @@
-.. _math:
-
-
 Math 
 ====
 
+.. currentmodule:: jaxsim.math
+   
 .. automodule:: jaxsim.math.adjoint
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.conv
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.cross
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.inertia
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.joint
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.plucker
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.quaternion
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.rotation
     :members:
-    :inherited-members:
+    :undoc-members:
 
 .. automodule:: jaxsim.math.skew
     :members:
-    :inherited-members:
+    :undoc-members:

--- a/docs/modules/parsers.rst
+++ b/docs/modules/parsers.rst
@@ -1,6 +1,3 @@
-.. _parsers:
-
-
 Parsers 
 =======
 

--- a/docs/modules/physics.rst
+++ b/docs/modules/physics.rst
@@ -1,15 +1,8 @@
-.. _physics:
-
-
 Physics 
 =======
 
-.. _algos:
-
 Algos
 -----
-
-.. automodule:: jaxsim.physics.algos
 
 .. autofunction:: jaxsim.physics.algos.aba.aba
 
@@ -23,34 +16,25 @@ Algos
 
 .. automodule:: jaxsim.physics.algos.soft_contacts
     :members:
-    :inherited-members:
 
 .. automodule:: jaxsim.physics.algos.terrain
     :members:
-    :inherited-members:
     
 .. automodule:: jaxsim.physics.algos.utils
     :members:
-    :inherited-members:
-
-.. _model:
 
 Model
 -----
 
 .. automodule:: jaxsim.physics.model
     :members:
-    :inherited-members:
 
 .. automodule:: jaxsim.physics.model.ground_contact
     :members:
-    :inherited-members:
 
 .. automodule:: jaxsim.physics.model.physics_model_state
     :members:
-    :inherited-members:
 
 .. automodule:: jaxsim.physics.model.physics_model
     :members:
-    :inherited-members:
 

--- a/docs/modules/simulation.rst
+++ b/docs/modules/simulation.rst
@@ -1,4 +1,4 @@
-Simulation 
+Simulation
 ==========
 
 .. automodule:: jaxsim.simulation
@@ -8,7 +8,7 @@ Simulator
 
 .. autoclass:: jaxsim.simulation.simulator.SimulatorData
     :members:
-    
+
 .. autoclass:: jaxsim.simulation.simulator.JaxSim
     :members:
 
@@ -28,4 +28,7 @@ ODE
 ~~~
 
 .. automodule:: jaxsim.simulation.ode
+    :members:
+
+.. autoflag:: jaxsim.simulation.ode_integration.IntegratorType
     :members:

--- a/docs/modules/simulation.rst
+++ b/docs/modules/simulation.rst
@@ -1,15 +1,31 @@
-.. _simulation:
-
-
 Simulation 
 ==========
 
 .. automodule:: jaxsim.simulation
 
+Simulator
+~~~~~~~~~
+
 .. autoclass:: jaxsim.simulation.simulator.SimulatorData
     :members:
-    :inherited-members:
     
 .. autoclass:: jaxsim.simulation.simulator.JaxSim
     :members:
-    :inherited-members:
+
+Simulator Callbacks
+~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: jaxsim.simulation.simulator_callbacks
+
+.. autosummary::
+    CallbackHandler
+    ConfigureCallback
+    PostStepCallback
+    PreStepCallback
+    SimulatorCallback
+
+ODE
+~~~
+
+.. automodule:: jaxsim.simulation.ode
+    :members:

--- a/docs/modules/typing.rst
+++ b/docs/modules/typing.rst
@@ -1,34 +1,17 @@
-.. _typing:
-
-
 Typing 
 ======
 
-.. autoclass:: jaxsim.typing.PyTree
+.. currentmodule:: jaxsim.typing
 
-.. autoclass:: jaxsim.typing.Tensor
-    :undoc-members:
-
-.. autoclass:: jaxsim.typing.Matrix
-    :undoc-members:
-
-.. autoclass:: jaxsim.typing.Bool
-
-.. autoclass:: jaxsim.typing.Int
-
-.. autoclass:: jaxsim.typing.Float
-
-.. autoclass:: jaxsim.typing.Vector
-    :undoc-members:
-
-.. autoclass:: jaxsim.typing.FloatJax
-
-.. autoclass:: jaxsim.typing.IntJax
-
-.. autoclass:: jaxsim.typing.ArrayJax
-
-.. autoclass:: jaxsim.typing.TensorJax
-
-.. autoclass:: jaxsim.typing.VectorJax
-
-.. autoclass:: jaxsim.typing.MatrixJax
+.. autosummary::
+    PyTree
+    Matrix
+    Bool
+    Int
+    Float
+    Vector
+    FloatJax
+    IntJax
+    ArrayJax
+    VectorJax
+    MatrixJax

--- a/src/jaxsim/physics/algos/aba.py
+++ b/src/jaxsim/physics/algos/aba.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Tuple
 
 import jax

--- a/src/jaxsim/physics/model/physics_model.py
+++ b/src/jaxsim/physics/model/physics_model.py
@@ -45,14 +45,14 @@ class PhysicsModel(JaxsimDataclass):
     )
     is_floating_base: Static[bool] = dataclasses.field(default=False)
     gc: GroundContact = dataclasses.field(default_factory=lambda: GroundContact())
-    description: Static[jaxsim.parsers.descriptions.model.ModelDescription] = (
-        dataclasses.field(default=None)
-    )
+    description: Static[
+        jaxsim.parsers.descriptions.model.ModelDescription
+    ] = dataclasses.field(default=None)
 
     _parent_array_dict: Static[Dict[int, int]] = dataclasses.field(default_factory=dict)
-    _jtype_dict: Static[Dict[int, Union[JointType, JointDescriptor]]] = (
-        dataclasses.field(default_factory=dict)
-    )
+    _jtype_dict: Static[
+        Dict[int, Union[JointType, JointDescriptor]]
+    ] = dataclasses.field(default_factory=dict)
     _tree_transforms_dict: Dict[int, jtp.Matrix] = dataclasses.field(
         default_factory=dict
     )

--- a/src/jaxsim/physics/model/physics_model.py
+++ b/src/jaxsim/physics/model/physics_model.py
@@ -45,14 +45,14 @@ class PhysicsModel(JaxsimDataclass):
     )
     is_floating_base: Static[bool] = dataclasses.field(default=False)
     gc: GroundContact = dataclasses.field(default_factory=lambda: GroundContact())
-    description: Static[
-        jaxsim.parsers.descriptions.model.ModelDescription
-    ] = dataclasses.field(default=None)
+    description: Static[jaxsim.parsers.descriptions.model.ModelDescription] = (
+        dataclasses.field(default=None)
+    )
 
     _parent_array_dict: Static[Dict[int, int]] = dataclasses.field(default_factory=dict)
-    _jtype_dict: Static[
-        Dict[int, Union[JointType, JointDescriptor]]
-    ] = dataclasses.field(default_factory=dict)
+    _jtype_dict: Static[Dict[int, Union[JointType, JointDescriptor]]] = (
+        dataclasses.field(default_factory=dict)
+    )
     _tree_transforms_dict: Dict[int, jtp.Matrix] = dataclasses.field(
         default_factory=dict
     )

--- a/src/jaxsim/physics/model/physics_model_state.py
+++ b/src/jaxsim/physics/model/physics_model_state.py
@@ -135,8 +135,8 @@ class PhysicsModelInput(JaxsimDataclass):
     This class stores the joint torques and external forces acting on the bodies of a physics model.
 
     Attributes:
-        tau (jtp.Vector): An array representing the joint torques.
-        f_ext (jtp.Matrix): A matrix representing the external forces acting on the bodies of the physics model.
+        tau: An array representing the joint torques.
+        f_ext: A matrix representing the external forces acting on the bodies of the physics model.
     """
 
     tau: jtp.VectorJax

--- a/src/jaxsim/physics/model/physics_model_state.py
+++ b/src/jaxsim/physics/model/physics_model_state.py
@@ -129,6 +129,16 @@ class PhysicsModelState(JaxsimDataclass):
 
 @jax_dataclasses.pytree_dataclass
 class PhysicsModelInput(JaxsimDataclass):
+    """
+    A class representing the input to a physics model.
+
+    This class stores the joint torques and external forces acting on the bodies of a physics model.
+
+    Attributes:
+        tau (jtp.Vector): An array representing the joint torques.
+        f_ext (jtp.Matrix): A matrix representing the external forces acting on the bodies of the physics model.
+    """
+
     tau: jtp.VectorJax
     f_ext: jtp.MatrixJax
 

--- a/src/jaxsim/simulation/simulator_callbacks.py
+++ b/src/jaxsim/simulation/simulator_callbacks.py
@@ -68,12 +68,12 @@ class PostStepCallback(SimulatorCallback):
 class CallbackHandler(ConfigureCallback, PreStepCallback, PostStepCallback):
     """
     A class that handles callbacks for the simulator.
-    
+
     Note:
         The are different simulation stages with associated callbacks:
         - `configure`: runs before the first step is taken.
         - `pre_step`: runs at each step before integrating the dynamics and advancing the time.
-        - `post_step`: runs at each step after the integration of the dynamics. 
+        - `post_step`: runs at each step after the integration of the dynamics.
     """
 
     pass

--- a/src/jaxsim/simulation/simulator_callbacks.py
+++ b/src/jaxsim/simulation/simulator_callbacks.py
@@ -68,6 +68,12 @@ class PostStepCallback(SimulatorCallback):
 class CallbackHandler(ConfigureCallback, PreStepCallback, PostStepCallback):
     """
     A class that handles callbacks for the simulator.
+    
+    Note:
+        The are different simulation stages with associated callbacks:
+        - `configure`: runs before the first step is taken.
+        - `pre_step`: runs at each step before integrating the dynamics and advancing the time.
+        - `post_step`: runs at each step after the integration of the dynamics. 
     """
 
     pass

--- a/src/jaxsim/simulation/simulator_callbacks.py
+++ b/src/jaxsim/simulation/simulator_callbacks.py
@@ -14,10 +14,18 @@ PostStepCallbackSignature = Callable[
 
 
 class SimulatorCallback(abc.ABC):
+    """
+    A base class for simulator callbacks.
+    """
+
     pass
 
 
 class ConfigureCallback(SimulatorCallback):
+    """
+    A class for configuring a simulator callback.
+    """
+
     @property
     def configure_cb(self) -> ConfigureCallbackSignature:
         return lambda sim: self.configure(sim=sim)
@@ -28,6 +36,10 @@ class ConfigureCallback(SimulatorCallback):
 
 
 class PreStepCallback(SimulatorCallback):
+    """
+    A callback class for performing actions before each simulation step.
+    """
+
     @property
     def pre_step_cb(self) -> PreStepCallbackSignature:
         return lambda sim: self.pre_step(sim=sim)
@@ -38,6 +50,10 @@ class PreStepCallback(SimulatorCallback):
 
 
 class PostStepCallback(SimulatorCallback):
+    """
+    A callback class for performing actions after each simulation step.
+    """
+
     @property
     def post_step_cb(self) -> PostStepCallbackSignature:
         return lambda sim, step_data: self.post_step(sim=sim, step_data=step_data)
@@ -50,4 +66,8 @@ class PostStepCallback(SimulatorCallback):
 
 
 class CallbackHandler(ConfigureCallback, PreStepCallback, PostStepCallback):
+    """
+    A class that handles callbacks for the simulator.
+    """
+
     pass

--- a/src/jaxsim/simulation/simulator_callbacks.py
+++ b/src/jaxsim/simulation/simulator_callbacks.py
@@ -23,7 +23,7 @@ class SimulatorCallback(abc.ABC):
 
 class ConfigureCallback(SimulatorCallback):
     """
-    A class for configuring a simulator callback.
+    A callback class to define logic for configuring the simulator before taking the first step.
     """
 
     @property


### PR DESCRIPTION
This PR will add installation instructions using `conda` for `jaxsim` in README and in the documentation, which was updated according to the latest API.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--79.org.readthedocs.build//79/

<!-- readthedocs-preview jaxsim end -->