### PR TITLE
Run `pytest` in CI only in PRs that update either sources or tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}          
+          python-version: ${{ matrix.python }}
 
       - name: Download Python packages
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -67,6 +67,14 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src_and_tests:
+              - 'src/**'
+              - 'tests/**'              
+
       - name: Download Python packages
         uses: actions/download-artifact@v3
         with:
@@ -91,13 +99,17 @@ jobs:
           fetch-depth: 0
 
       - name: Install Gazebo Classic
-        if: contains(matrix.os, 'ubuntu')
+        if: |
+          contains(matrix.os, 'ubuntu') &&
+          steps.changes.outputs.src_and_tests == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install gazebo
 
       - name: Run the Python tests
-        if: contains(matrix.os, 'ubuntu')
+        if: |
+          contains(matrix.os, 'ubuntu') &&
+          steps.changes.outputs.src_and_tests == 'true'
         run: pytest
         env:
           JAX_PLATFORM_NAME: cpu

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -65,15 +65,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
-
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            src_and_tests:
-              - 'src/**'
-              - 'tests/**'              
+          python-version: ${{ matrix.python }}          
 
       - name: Download Python packages
         uses: actions/download-artifact@v3
@@ -94,10 +86,6 @@ jobs:
       - name: Import the package
         run: python -c "import jaxsim"
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
       - name: Install Gazebo Classic
         if: |
           contains(matrix.os, 'ubuntu') &&
@@ -106,10 +94,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install gazebo
 
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src: &src
+              - 'src/**'
+            tests: &tests
+              - 'tests/**'
+            src_and_tests:
+              - *src
+              - *tests
+
       - name: Run the Python tests
         if: |
           contains(matrix.os, 'ubuntu') &&
-          steps.changes.outputs.src_and_tests == 'true'
+          (github.event_name != 'pull_request' ||
+           steps.changes.outputs.src_and_tests == 'true')
         run: pytest
         env:
           JAX_PLATFORM_NAME: cpu

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -86,14 +86,6 @@ jobs:
       - name: Import the package
         run: python -c "import jaxsim"
 
-      - name: Install Gazebo Classic
-        if: |
-          contains(matrix.os, 'ubuntu') &&
-          steps.changes.outputs.src_and_tests == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install gazebo
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -108,6 +100,15 @@ jobs:
             src_and_tests:
               - *src
               - *tests
+
+      - name: Install Gazebo Classic
+        if: |
+          contains(matrix.os, 'ubuntu') &&
+          (github.event_name != 'pull_request' ||
+           steps.changes.outputs.src_and_tests == 'true')
+        run: |
+          sudo apt-get update
+          sudo apt-get install gazebo
 
       - name: Run the Python tests
         if: |


### PR DESCRIPTION
Since running `pytest` is pretty slow (~1h), let's mitigate our contribution on global warming by preventing to run the corresponding CI step when not needed.

I used https://github.com/dorny/paths-filter that seems quite popular.

Note that this change only targets PRs, not CI pipelines on branches. We just need green CI on PRs for merging.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--80.org.readthedocs.build//80/

<!-- readthedocs-preview jaxsim end -->