### PR TITLE
Add static rendering in `MujocoVideoRecorder`

### DIFF
--- a/src/jaxsim/mujoco/visualizer.py
+++ b/src/jaxsim/mujoco/visualizer.py
@@ -52,13 +52,19 @@ class MujocoVideoRecorder:
         self.data = data if data is not None else self.data
         self.model = model if model is not None else self.model
 
-    def render_frame(self, camera_name: str | None = None) -> None:
+    def render_frame(self, camera_name: str | None = None) -> npt.NDArray:
         """"""
 
         mujoco.mj_forward(self.model, self.data)
         self.renderer.update_scene(data=self.data)  # TODO camera name
 
-        self.frames.append(self.renderer.render())
+        return self.renderer.render()
+
+    def record_frame(self, camera_name: str | None = None) -> None:
+        """"""
+
+        frame = self.render_frame(camera_name=camera_name)
+        self.frames.append(frame)
 
     def write_video(self, path: pathlib.Path, exist_ok: bool = False) -> None:
         """"""


### PR DESCRIPTION
This PR will add a method in the `MujocoVideoRecorder` class to return images to be rendered in Python Notebooks.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--85.org.readthedocs.build//85/

<!-- readthedocs-preview jaxsim end -->