### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    - id: check-ast
+    - id: check-merge-conflict
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.2.0
+    hooks:
+      - id: black
+        language_version: python3.11
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,7 @@ where = src
 style =
     black[jupyter]
     isort
+    pre-commit
 testing =
     idyntree
     pytest >= 6.0


### PR DESCRIPTION
This PR adds a pre-commit configuration file that includes hooks for checking AST, merge conflicts, YAML syntax, end-of-file, trailing whitespace, and code formatting using Black and isort.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--86.org.readthedocs.build//86/

<!-- readthedocs-preview jaxsim end -->