### PR TITLE
Introduce new functional APIs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - jax-dataclasses >= 1.4.0
   - pptree
   - rod
+  - typing_extensions # python<3.12
   # Optional dependencies from setup.cfg
   # [style]
   - black

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ install_requires =
     jax_dataclasses >= 1.4.0
     pptree
     rod
+    typing_extensions ; python_version < '3.12'
 
 [options.packages.find]
 where = src

--- a/src/jaxsim/api/__init__.py
+++ b/src/jaxsim/api/__init__.py
@@ -1,0 +1,1 @@
+from . import contact, data, joint, link, model

--- a/src/jaxsim/api/__init__.py
+++ b/src/jaxsim/api/__init__.py
@@ -1,1 +1,1 @@
-from . import contact, data, joint, link, model
+from . import contact, data, joint, link, model, ode

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -1,0 +1,74 @@
+import jax
+
+import jaxsim.typing as jtp
+
+from . import data as Data
+from . import model as Model
+
+
+@jax.jit
+def collidable_point_kinematics(
+    model: Model.JaxSimModel, data: Data.JaxSimModelData
+) -> tuple[jtp.Matrix, jtp.Matrix]:
+    """
+    Compute the position and 3D velocity of the collidable points in the world frame.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The position and velocity of the collidable points in the world frame.
+
+    Note:
+        The collidable point velocity is the plain coordinate derivative of the position.
+        If we attach a frame C = (p_C, [C]) to the collidable point, it corresponds to
+        the linear component of the mixed 6D frame velocity.
+    """
+
+    from jaxsim.physics.algos.soft_contacts import collidable_points_pos_vel
+
+    W_p_Ci, W_ṗ_Ci = collidable_points_pos_vel(
+        model=model.physics_model,
+        q=data.state.physics_model.joint_positions,
+        qd=data.state.physics_model.joint_velocities,
+        xfb=data.state.physics_model.xfb(),
+    )
+
+    return W_p_Ci.T, W_ṗ_Ci.T
+
+
+@jax.jit
+def collidable_point_positions(
+    model: Model.JaxSimModel, data: Data.JaxSimModelData
+) -> jtp.Matrix:
+    """
+    Compute the position of the collidable points in the world frame.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The position of the collidable points in the world frame.
+    """
+
+    return collidable_point_kinematics(model=model, data=data)[0]
+
+
+@jax.jit
+def collidable_point_velocities(
+    model: Model.JaxSimModel, data: Data.JaxSimModelData
+) -> jtp.Matrix:
+    """
+    Compute the 3D velocity of the collidable points in the world frame.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The 3D velocity of the collidable points.
+    """
+
+    return collidable_point_kinematics(model=model, data=data)[1]

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -172,8 +172,8 @@ def estimate_good_soft_contacts_parameters(
         if model.physics_model.is_floating_base:
             W_pz_C = collidable_point_positions(model=model, data=zero_data)[:, -1]
             return 2 * (W_p_CoM[2] - W_pz_C.min())
-        else:
-            return 2 * W_p_CoM
+
+        return 2 * W_p_CoM
 
     max_δ = (
         max_penetration

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -1,4 +1,7 @@
+import functools
+
 import jax
+import jax.numpy as jnp
 
 import jaxsim.typing as jtp
 
@@ -72,3 +75,54 @@ def collidable_point_velocities(
     """
 
     return collidable_point_kinematics(model=model, data=data)[1]
+
+
+@functools.partial(jax.jit, static_argnames=["link_names"])
+def in_contact(
+    model: Model.JaxSimModel,
+    data: Data.JaxSimModelData,
+    *,
+    link_names: tuple[str, ...] | None = None,
+) -> jtp.Vector:
+    """
+    Return whether the links are in contact with the terrain.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        link_names:
+            The names of the links to consider. If None, all links are considered.
+
+    Returns:
+        A boolean vector indicating whether the links are in contact with the terrain.
+    """
+
+    link_names = link_names if link_names is not None else model.link_names()
+
+    if set(link_names) - set(model.link_names()) != set():
+        raise ValueError("One or more link names are not part of the model")
+
+    from jaxsim.physics.algos.soft_contacts import collidable_points_pos_vel
+
+    W_p_Ci, _ = collidable_points_pos_vel(
+        model=model.physics_model,
+        q=data.state.physics_model.joint_positions,
+        qd=data.state.physics_model.joint_velocities,
+        xfb=data.state.physics_model.xfb(),
+    )
+
+    terrain_height = jax.vmap(lambda x, y: model.terrain.height(x=x, y=y))(
+        W_p_Ci[0, :], W_p_Ci[1, :]
+    )
+
+    below_terrain = W_p_Ci[2, :] <= terrain_height
+
+    links_in_contact = jax.vmap(
+        lambda link_index: jnp.where(
+            model.physics_model.gc.body == link_index,
+            below_terrain,
+            jnp.zeros_like(below_terrain, dtype=bool),
+        ).any()
+    )(jnp.arange(model.number_of_links()))
+
+    return links_in_contact

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -641,7 +641,7 @@ def random_model_data(
         ).as_quaternion_xyzw()[np.array([3, 0, 1, 2])]
 
         physics_model_state.joint_positions = jaxsim.api.joint.random_joint_positions(
-            model=model
+            model=model, key=k3
         )
 
         physics_model_state.base_linear_velocity = jax.random.uniform(

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -259,6 +259,7 @@ class JaxSimModelData(JaxsimDataclass):
 
         return self.time_ns.astype(float) / 1e9
 
+    @functools.partial(jax.jit, static_argnames=["joint_names"])
     def joint_positions(
         self,
         model: jaxsim.api.model.JaxSimModel | None = None,
@@ -298,6 +299,7 @@ class JaxSimModelData(JaxsimDataclass):
             jaxsim.api.joint.names_to_idxs(joint_names=joint_names, model=model)
         ]
 
+    @functools.partial(jax.jit, static_argnames=["joint_names"])
     def joint_velocities(
         self,
         model: jaxsim.api.model.JaxSimModel | None = None,

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -246,6 +246,20 @@ class JaxSimModelData(JaxsimDataclass):
             velocity_representation=velocity_representation,
         )
 
+    # ==================
+    # Extract quantities
+    # ==================
+
+    def time(self) -> jtp.Float:
+        """
+        Get the simulated time.
+
+        Returns:
+            The simulated time in seconds.
+        """
+
+        return self.time_ns.astype(float) / 1e9
+
     def joint_positions(
         self,
         model: jaxsim.api.model.JaxSimModel | None = None,

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import functools
-from typing import ContextManager, Self, Sequence
+from typing import ContextManager, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -24,6 +24,11 @@ from jaxsim.high_level.common import VelRepr
 from jaxsim.physics.algos import soft_contacts
 from jaxsim.simulation.ode_data import ODEState
 from jaxsim.utils import JaxsimDataclass, Mutability
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 @jax_dataclasses.pytree_dataclass

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -13,7 +13,7 @@ import jaxlie
 import numpy as np
 from jax_dataclasses import Static
 
-import jaxsim.api.model
+import jaxsim.api
 import jaxsim.physics.algos.aba
 import jaxsim.physics.algos.crba
 import jaxsim.physics.algos.forward_kinematics
@@ -299,8 +299,6 @@ class JaxSimModelData(JaxsimDataclass):
             The joint positions.
         """
 
-        import jaxsim.api.joint
-
         joint_names = (
             joint_names if joint_names is not None else self.model.joint_names()
         )
@@ -323,8 +321,6 @@ class JaxSimModelData(JaxsimDataclass):
         Returns:
             The joint velocities.
         """
-
-        import jaxsim.api.joint
 
         joint_names = (
             joint_names if joint_names is not None else self.model.joint_names()

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -1,0 +1,582 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import functools
+import weakref
+from typing import ContextManager
+
+import jax
+import jax.numpy as jnp
+import jax_dataclasses
+import numpy as np
+from jax_dataclasses import Static
+
+import jaxsim.api.model
+import jaxsim.physics.algos.aba
+import jaxsim.physics.algos.crba
+import jaxsim.physics.algos.forward_kinematics
+import jaxsim.physics.algos.rnea
+import jaxsim.physics.model.physics_model
+import jaxsim.physics.model.physics_model_state
+import jaxsim.typing as jtp
+from jaxsim import sixd
+from jaxsim.high_level.common import VelRepr
+from jaxsim.physics.algos import soft_contacts
+from jaxsim.simulation.ode_data import ODEState
+from jaxsim.utils import JaxsimDataclass
+
+from . import contact as Contact
+
+
+@dataclasses.dataclass
+class HashlessReferenceType:
+    ref: weakref.ReferenceType
+
+    def __hash__(self) -> int:
+        return 0
+
+
+@jax_dataclasses.pytree_dataclass
+class JaxSimModelData(JaxsimDataclass):
+    """
+    Class containing the state of a `JaxSimModel` object.
+    """
+
+    state: ODEState
+
+    gravity: jtp.Array
+
+    soft_contacts_params: soft_contacts.SoftContactsParams = dataclasses.field(
+        repr=False
+    )
+
+    time_ns: jtp.Int = dataclasses.field(
+        default_factory=lambda: jnp.array(0, dtype=jnp.uint64)
+    )
+
+    velocity_representation: Static[VelRepr] = VelRepr.Inertial
+
+    _model_ref: Static[HashlessReferenceType] = dataclasses.field(
+        default=None, repr=False
+    )
+
+    @property
+    def model(self) -> jaxsim.api.model.JaxSimModel:
+        """
+        The model associated with the current state.
+
+        Returns:
+            The model associated with the current state.
+
+        Raises:
+            RuntimeError: If the model has been deleted.
+
+        Note:
+            The model is stored as a weak reference to prevent garbage collection
+            problems due to circular references. It is possible that the associated
+            model has been deleted.
+        """
+
+        m = self._model_ref.ref()
+
+        if m is None:
+            raise RuntimeError("The model has been deleted")
+
+        return m
+
+    def valid(self, model: jaxsim.api.model.JaxSimModel) -> bool:
+        """
+        Check if the current state is valid for the given model.
+
+        Args:
+            model: The model to check against.
+
+        Returns:
+            `True` if the current state is valid for the given model, `False` otherwise.
+        """
+
+        valid = True
+        valid = valid and self.model is not None
+        valid = valid and self.state.valid(physics_model=model.physics_model)
+
+        return valid
+
+    @contextlib.contextmanager
+    def switch_velocity_representation(
+        self, velocity_representation: VelRepr
+    ) -> ContextManager[JaxSimModelData]:
+        """
+        Context manager to temporarily switch the velocity representation.
+
+        Args:
+            velocity_representation: The new velocity representation.
+
+        Yields:
+            The same `JaxSimModelData` object with the new velocity representation.
+        """
+
+        original_representation = self.velocity_representation
+
+        try:
+
+            # First, we replace the velocity representation
+            with self.mutable_context(
+                mutability=Mutability.MUTABLE_NO_VALIDATION,
+                restore_after_exception=True,
+            ):
+                self.velocity_representation = velocity_representation
+
+            # Then, we yield the data with changed representation.
+            # We run this in a mutable context with restoration so that any exception
+            # occurring, we restore the original object in case it was modified.
+            with self.mutable_context(
+                mutability=self._mutability(), restore_after_exception=True
+            ):
+                yield self
+
+        finally:
+            with self.mutable_context(
+                mutability=Mutability.MUTABLE_NO_VALIDATION,
+                restore_after_exception=True,
+            ):
+                self.velocity_representation = original_representation
+
+    @staticmethod
+    def zero(
+        model: jaxsim.api.model.JaxSimModel,
+        velocity_representation: VelRepr = VelRepr.Inertial,
+    ) -> JaxSimModelData:
+        """
+        Create a `JaxSimModelData` object with zero state.
+
+        Args:
+            model: The model for which to create the zero state.
+            velocity_representation: The velocity representation to use.
+
+        Returns:
+            A `JaxSimModelData` object with zero state.
+        """
+
+        return JaxSimModelData.build(
+            model=model, velocity_representation=velocity_representation
+        )
+
+    @staticmethod
+    def build(
+        model: jaxsim.api.model.JaxSimModel,
+        base_position: jtp.Vector | None = None,
+        base_quaternion: jtp.Vector | None = None,
+        joint_positions: jtp.Vector | None = None,
+        base_linear_velocity: jtp.Vector | None = None,
+        base_angular_velocity: jtp.Vector | None = None,
+        joint_velocities: jtp.Vector | None = None,
+        gravity: jtp.Vector | None = None,
+        soft_contacts_state: soft_contacts.SoftContactsState | None = None,
+        soft_contacts_params: soft_contacts.SoftContactsParams | None = None,
+        velocity_representation: VelRepr = VelRepr.Inertial,
+        time: jtp.FloatLike | None = None,
+    ) -> JaxSimModelData:
+        """
+        Create a `JaxSimModelData` object with the given state.
+
+        Args:
+            model: The model for which to create the state.
+            base_position: The base position.
+            base_quaternion: The base orientation as a quaternion.
+            joint_positions: The joint positions.
+            base_linear_velocity:
+                The base linear velocity in the selected representation.
+            base_angular_velocity:
+                The base angular velocity in the selected representation.
+            joint_velocities: The joint velocities.
+            gravity: The gravity 3D vector.
+            soft_contacts_state: The state of the soft contacts.
+            soft_contacts_params: The parameters of the soft contacts.
+            velocity_representation: The velocity representation to use.
+            time: The time at which the state is created.
+
+        Returns:
+            A `JaxSimModelData` object with the given state.
+        """
+
+        base_position = jnp.array(
+            base_position if base_position is not None else jnp.zeros(3)
+        ).squeeze()
+
+        base_quaternion = jnp.array(
+            base_quaternion
+            if base_quaternion is not None
+            else jnp.array([1.0, 0, 0, 0])
+        ).squeeze()
+
+        base_linear_velocity = jnp.array(
+            base_linear_velocity if base_linear_velocity is not None else jnp.zeros(3)
+        ).squeeze()
+
+        base_angular_velocity = jnp.array(
+            base_angular_velocity if base_angular_velocity is not None else jnp.zeros(3)
+        ).squeeze()
+
+        gravity = jnp.array(
+            gravity if gravity is not None else model.physics_model.gravity[0:3]
+        ).squeeze()
+
+        joint_positions = jnp.atleast_1d(
+            joint_positions.squeeze()
+            if joint_positions is not None
+            else jnp.zeros(model.dofs())
+        )
+
+        joint_velocities = jnp.atleast_1d(
+            joint_velocities.squeeze()
+            if joint_velocities is not None
+            else jnp.zeros(model.dofs())
+        )
+
+        time_ns = (
+            jnp.array(time * 1e9, dtype=jnp.uint64)
+            if time is not None
+            else jnp.array(0, dtype=jnp.uint64)
+        )
+
+        soft_contacts_params = (
+            soft_contacts_params
+            if soft_contacts_params is not None
+            else Contact.estimate_good_soft_contacts_parameters(model=model)
+        )
+
+        W_H_B = jaxlie.SE3.from_rotation_and_translation(
+            translation=base_position,
+            rotation=jaxlie.SO3.from_quaternion_xyzw(
+                base_quaternion[jnp.array([1, 2, 3, 0])]
+            ),
+        ).as_matrix()
+
+        v_WB = JaxSimModelData.other_representation_to_inertial(
+            array=jnp.hstack([base_linear_velocity, base_angular_velocity]),
+            other_representation=velocity_representation,
+            base_transform=W_H_B,
+            is_force=False,
+        )
+
+        ode_state = ODEState.build(
+            physics_model=model.physics_model,
+            physics_model_state=jaxsim.physics.model.physics_model.PhysicsModelState(
+                base_position=base_position.astype(float),
+                base_quaternion=base_quaternion.astype(float),
+                joint_positions=joint_positions.astype(float),
+                base_linear_velocity=v_WB[0:3].astype(float),
+                base_angular_velocity=v_WB[3:6].astype(float),
+                joint_velocities=joint_velocities.astype(float),
+            ),
+            soft_contacts_state=soft_contacts_state,
+        )
+
+        if not ode_state.valid(physics_model=model.physics_model):
+            raise ValueError(ode_state)
+
+        return JaxSimModelData(
+            time_ns=time_ns,
+            state=ode_state,
+            gravity=gravity.astype(float),
+            soft_contacts_params=soft_contacts_params,
+            velocity_representation=velocity_representation,
+            _model_ref=HashlessReferenceType(ref=weakref.ref(model)),
+        )
+
+    def joint_positions(self, joint_names: tuple[str, ...] | None = None) -> jtp.Vector:
+        """
+        Get the joint positions.
+
+        Args:
+            joint_names:
+                The names of the joints for which to get the positions. If `None`, the
+                positions of all joints are returned.
+
+        Returns:
+            The joint positions.
+        """
+
+        import jaxsim.api.joint
+
+        joint_names = (
+            joint_names if joint_names is not None else self.model.joint_names()
+        )
+
+        return self.state.physics_model.joint_positions[
+            jaxsim.api.joint.names_to_idxs(joint_names=joint_names, model=self.model)
+        ]
+
+    def joint_velocities(
+        self, joint_names: tuple[str, ...] | None = None
+    ) -> jtp.Vector:
+        """
+        Get the joint velocities.
+
+        Args:
+            joint_names:
+                The names of the joints for which to get the velocities. If `None`, the
+                velocities of all joints are returned.
+
+        Returns:
+            The joint velocities.
+        """
+
+        import jaxsim.api.joint
+
+        joint_names = (
+            joint_names if joint_names is not None else self.model.joint_names()
+        )
+
+        return self.state.physics_model.joint_velocities[
+            jaxsim.api.joint.names_to_idxs(joint_names=joint_names, model=self.model)
+        ]
+
+    @jax.jit
+    def base_position(self) -> jtp.Vector:
+        """
+        Get the base position.
+
+        Returns:
+            The base position.
+        """
+
+        return self.state.physics_model.base_position.squeeze()
+
+    @functools.partial(jax.jit, static_argnames=["dcm"])
+    def base_orientation(self, dcm: jtp.BoolLike = False) -> jtp.Vector | jtp.Matrix:
+        """
+        Get the base orientation.
+
+        Args:
+            dcm: Whether to return the orientation as a SO(3) matrix or quaternion.
+
+        Returns:
+            The base orientation.
+        """
+
+        # Always normalize the quaternion to avoid numerical issues.
+        # If the active scheme does not integrate the quaternion on its manifold,
+        # we introduce a Baumgarte stabilization to let the quaternion converge to
+        # a unit quaternion. In this case, it is not guaranteed that the quaternion
+        # stored in the state is a unit quaternion.
+        base_unit_quaternion = (
+            self.state.physics_model.base_quaternion.squeeze()
+            / jnp.linalg.norm(self.state.physics_model.base_quaternion)
+        )
+
+        # Slice to convert quaternion wxyz -> xyzw
+        to_xyzw = np.array([1, 2, 3, 0])
+
+        return (
+            base_unit_quaternion
+            if not dcm
+            else sixd.so3.SO3.from_quaternion_xyzw(
+                base_unit_quaternion[to_xyzw]
+            ).as_matrix()
+        )
+
+    @jax.jit
+    def base_transform(self) -> jtp.MatrixJax:
+        """
+        Get the base transform.
+
+        Returns:
+            The base transform as an SE(3) matrix.
+        """
+
+        W_R_B = self.base_orientation(dcm=True)
+        W_p_B = jnp.vstack(self.base_position())
+
+        return jnp.vstack(
+            [
+                jnp.block([W_R_B, W_p_B]),
+                jnp.array([0, 0, 0, 1]),
+            ]
+        )
+
+    @jax.jit
+    def base_velocity(self) -> jtp.Vector:
+        """
+        Get the base 6D velocity.
+
+        Returns:
+            The base 6D velocity in the active representation.
+        """
+
+        W_v_WB = jnp.hstack(
+            [
+                self.state.physics_model.base_linear_velocity,
+                self.state.physics_model.base_angular_velocity,
+            ]
+        )
+
+        W_H_B = self.base_transform()
+
+        return (
+            JaxSimModelData.inertial_to_other_representation(
+                array=W_v_WB,
+                other_representation=self.velocity_representation,
+                base_transform=W_H_B,
+                is_force=False,
+            )
+            .squeeze()
+            .astype(float)
+        )
+
+    @jax.jit
+    def generalized_position(self) -> tuple[jtp.Matrix, jtp.Vector]:
+        """
+        Get the generalized position.
+
+        Returns:
+            A tuple containing the base transform and the joint positions.
+        """
+
+        return self.base_transform(), self.joint_positions()
+
+    @jax.jit
+    def generalized_velocity(self) -> jtp.Vector:
+        """
+        Get the generalized velocity.
+
+        Returns:
+            The generalized velocity in the active representation.
+        """
+
+        return (
+            jnp.hstack([self.base_velocity(), self.joint_velocities()])
+            .squeeze()
+            .astype(float)
+        )
+
+    @staticmethod
+    @functools.partial(jax.jit, static_argnames=["other_representation", "is_force"])
+    def inertial_to_other_representation(
+        array: jtp.Array,
+        other_representation: VelRepr,
+        base_transform: jtp.Matrix,
+        is_force: bool = False,
+    ) -> jtp.Array:
+        """
+        Convert a 6D quantity from the inertial to another representation.
+
+        Args:
+            array: The 6D quantity to convert.
+            other_representation: The representation to convert to.
+            base_transform: The base transform.
+            is_force: Whether the quantity is a 6D force or 6D velocity.
+
+        Returns:
+            The 6D quantity in the other representation.
+        """
+
+        W_array = array.squeeze()
+        W_H_B = base_transform.squeeze()
+
+        if W_array.size != 6:
+            raise ValueError(W_array.size, 6)
+
+        if W_H_B.shape != (4, 4):
+            raise ValueError(W_H_B.shape, (4, 4))
+
+        match other_representation:
+
+            case VelRepr.Inertial:
+                return W_array
+
+            case VelRepr.Body:
+
+                if not is_force:
+                    B_Xv_W = sixd.se3.SE3.from_matrix(W_H_B).inverse().adjoint()
+                    B_array = B_Xv_W @ W_array
+
+                else:
+                    B_Xf_W = sixd.se3.SE3.from_matrix(W_H_B).adjoint().T
+                    B_array = B_Xf_W @ W_array
+
+                return B_array
+
+            case VelRepr.Mixed:
+                W_p_B = W_H_B[0:3, 3]
+                W_H_BW = jnp.eye(4).at[0:3, 3].set(W_p_B)
+
+                if not is_force:
+                    BW_Xv_W = sixd.se3.SE3.from_matrix(W_H_BW).inverse().adjoint()
+                    BW_array = BW_Xv_W @ W_array
+
+                else:
+                    BW_Xf_W = sixd.se3.SE3.from_matrix(W_H_BW).adjoint().T
+                    BW_array = BW_Xf_W @ W_array
+
+                return BW_array
+
+            case _:
+                raise ValueError(other_representation)
+
+    @staticmethod
+    @functools.partial(jax.jit, static_argnames=["other_representation", "is_force"])
+    def other_representation_to_inertial(
+        array: jtp.Array,
+        other_representation: VelRepr,
+        base_transform: jtp.Matrix,
+        is_force: bool = False,
+    ) -> jtp.Array:
+        """
+        Convert a 6D quantity from another representation to the inertial.
+
+        Args:
+            array: The 6D quantity to convert.
+            other_representation: The representation to convert from.
+            base_transform: The base transform.
+            is_force: Whether the quantity is a 6D force or 6D velocity.
+
+        Returns:
+            The 6D quantity in the inertial representation.
+        """
+
+        W_array = array.squeeze()
+        W_H_B = base_transform.squeeze()
+
+        if W_array.size != 6:
+            raise ValueError(W_array.size, 6)
+
+        if W_H_B.shape != (4, 4):
+            raise ValueError(W_H_B.shape, (4, 4))
+
+        match other_representation:
+            case VelRepr.Inertial:
+                W_array = array
+                return W_array
+
+            case VelRepr.Body:
+                B_array = array
+
+                if not is_force:
+                    W_Xv_B: jtp.Array = sixd.se3.SE3.from_matrix(W_H_B).adjoint()
+                    W_array = W_Xv_B @ B_array
+
+                else:
+                    W_Xf_B = sixd.se3.SE3.from_matrix(W_H_B).inverse().adjoint().T
+                    W_array = W_Xf_B @ B_array
+
+                return W_array
+
+            case VelRepr.Mixed:
+                BW_array = array
+                W_p_B = W_H_B[0:3, 3]
+                W_H_BW = jnp.eye(4).at[0:3, 3].set(W_p_B)
+
+                if not is_force:
+                    W_Xv_BW: jtp.Array = sixd.se3.SE3.from_matrix(W_H_BW).adjoint()
+                    W_array = W_Xv_BW @ BW_array
+
+                else:
+                    W_Xf_BW = sixd.se3.SE3.from_matrix(W_H_BW).inverse().adjoint().T
+                    W_array = W_Xf_BW @ BW_array
+
+                return W_array
+
+            case _:
+                raise ValueError(other_representation)

--- a/src/jaxsim/api/joint.py
+++ b/src/jaxsim/api/joint.py
@@ -118,3 +118,31 @@ def position_limits(
 
     joint_idxs = names_to_idxs(joint_names=joint_names, model=model)
     return jax.vmap(lambda i: position_limit(model=model, joint_index=i))(joint_idxs)
+
+
+# ======================
+# Random data generation
+# ======================
+
+
+@functools.partial(jax.jit, static_argnames=["joint_names"])
+def random_joint_positions(
+    model: Model.JaxSimModel,
+    *,
+    joint_names: Sequence[str] | None = None,
+    key: jax.Array | None = None,
+) -> jtp.Vector:
+    """"""
+
+    key = key if key is not None else jax.random.PRNGKey(seed=0)
+
+    s_min, s_max = position_limits(model=model, joint_names=joint_names)
+
+    s_random = jax.random.uniform(
+        minval=s_min,
+        maxval=s_max,
+        key=key,
+        shape=s_min.shape,
+    )
+
+    return s_random

--- a/src/jaxsim/api/joint.py
+++ b/src/jaxsim/api/joint.py
@@ -1,0 +1,91 @@
+from typing import Sequence
+
+import jax
+import jax.numpy as jnp
+
+import jaxsim.typing as jtp
+
+from . import model as Model
+
+# =======================
+# Index-related functions
+# =======================
+
+
+def name_to_idx(model: Model.JaxSimModel, *, joint_name: str) -> jtp.Int:
+    """
+    Convert the name of a joint to its index.
+
+    Args:
+        model: The model to consider.
+        joint_name: The name of the joint.
+
+    Returns:
+        The index of the joint.
+    """
+
+    return jnp.array(
+        model.physics_model.description.joints_dict[joint_name].index, dtype=int
+    )
+
+
+def idx_to_name(model: Model.JaxSimModel, *, joint_index: jtp.IntLike) -> str:
+    """
+    Convert the index of a joint to its name.
+
+    Args:
+        model: The model to consider.
+        joint_index: The index of the joint.
+
+    Returns:
+        The name of the joint.
+    """
+
+    d = {j.index: j.name for j in model.physics_model.description.joints_dict.values()}
+    return d[joint_index]
+
+
+def names_to_idxs(model: Model.JaxSimModel, *, joint_names: Sequence[str]) -> jax.Array:
+    """
+    Convert a sequence of joint names to their corresponding indices.
+
+    Args:
+        model: The model to consider.
+        joint_names: The names of the joints.
+
+    Returns:
+        The indices of the joints.
+    """
+
+    return jnp.array(
+        [
+            # Note: the index of the joint for RBDAs starts from 1, but
+            # the index for accessing the right element starts from 0.
+            # Therefore, there is a -1.
+            model.physics_model.description.joints_dict[name].index - 1
+            for name in joint_names
+        ],
+        dtype=int,
+    )
+
+
+def idxs_to_names(
+    model: Model.JaxSimModel, *, joint_indices: Sequence[jtp.IntLike] | jtp.VectorLike
+) -> tuple[str, ...]:
+    """
+    Convert a sequence of joint indices to their corresponding names.
+
+    Args:
+        model: The model to consider.
+        joint_indices: The indices of the joints.
+
+    Returns:
+        The names of the joints.
+    """
+
+    d = {
+        j.index - 1: j.name
+        for j in model.physics_model.description.joints_dict.values()
+    }
+
+    return tuple(d[i] for i in joint_indices)

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 
 import jaxsim.typing as jtp
 
+from . import data as Data
 from . import model as Model
 
 # =======================
@@ -96,3 +97,24 @@ def spatial_inertia(model: Model.JaxSimModel, *, link_index: jtp.IntLike) -> jtp
     """"""
 
     return model.physics_model._link_spatial_inertias[link_index]
+
+
+@jax.jit
+def transform(
+    model: Model.JaxSimModel, data: Data.JaxSimModelData, *, link_index: jtp.IntLike
+) -> jtp.Matrix:
+    """
+    Compute the SE(3) transform from the world frame to the link frame.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        link_index: The index of the link.
+
+    Returns:
+        The 4x4 matrix representing the transform.
+    """
+
+    from jaxsim.helpers.model import forward_kinematics
+
+    return forward_kinematics(model=model, data=data)[link_index]

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -79,3 +79,20 @@ def idxs_to_names(
 
     d = {l.index: l.name for l in model.physics_model.description.links_dict.values()}
     return tuple(d[i] for i in link_indices)
+
+
+# =========
+# Link APIs
+# =========
+
+
+def mass(model: Model.JaxSimModel, *, link_index: jtp.IntLike) -> jtp.Float:
+    """"""
+
+    return model.physics_model._link_masses[link_index].astype(float)
+
+
+def spatial_inertia(model: Model.JaxSimModel, *, link_index: jtp.IntLike) -> jtp.Matrix:
+    """"""
+
+    return model.physics_model._link_spatial_inertias[link_index]

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -1,0 +1,81 @@
+from typing import Sequence
+
+import jax
+import jax.numpy as jnp
+
+import jaxsim.typing as jtp
+
+from . import model as Model
+
+# =======================
+# Index-related functions
+# =======================
+
+
+def name_to_idx(model: Model.JaxSimModel, *, link_name: str) -> jtp.Int:
+    """
+    Convert the name of a link to its index.
+
+    Args:
+        model: The model to consider.
+        link_name: The name of the link.
+
+    Returns:
+        The index of the link.
+    """
+
+    return jnp.array(
+        model.physics_model.description.links_dict[link_name].index, dtype=int
+    )
+
+
+def idx_to_name(model: Model.JaxSimModel, *, link_index: jtp.IntLike) -> str:
+    """
+    Convert the index of a link to its name.
+
+    Args:
+        model: The model to consider.
+        link_index: The index of the link.
+
+    Returns:
+        The name of the link.
+    """
+
+    d = {l.index: l.name for l in model.physics_model.description.links_dict.values()}
+    return d[link_index]
+
+
+def names_to_idxs(model: Model.JaxSimModel, *, link_names: Sequence[str]) -> jax.Array:
+    """
+    Convert a sequence of link names to their corresponding indices.
+
+    Args:
+        model: The model to consider.
+        link_names: The names of the links.
+
+    Returns:
+        The indices of the links.
+    """
+
+    return jnp.array(
+        [model.physics_model.description.links_dict[name].index for name in link_names],
+        dtype=int,
+    )
+
+
+def idxs_to_names(
+    model: Model.JaxSimModel, *, link_indices: Sequence[jtp.IntLike] | jtp.VectorLike
+) -> tuple[str, ...]:
+    """
+    Convert a sequence of link indices to their corresponding names.
+
+    Args:
+        model: The model to consider.
+        link_indices: The indices of the links.
+
+    Returns:
+        The names of the links.
+    """
+
+    d = {l.index: l.name for l in model.physics_model.description.links_dict.values()}
+    return tuple(d[i] for i in link_indices)

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -119,9 +119,7 @@ def transform(
         The 4x4 matrix representing the transform.
     """
 
-    from jaxsim.helpers.model import forward_kinematics
-
-    return forward_kinematics(model=model, data=data)[link_index]
+    return Model.forward_kinematics(model=model, data=data)[link_index]
 
 
 @jax.jit

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -961,3 +961,69 @@ def total_momentum(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Vec
         base_transform=W_H_B,
         is_force=True,
     ).astype(float)
+
+
+# ======
+# Energy
+# ======
+
+
+@jax.jit
+def mechanical_energy(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Float:
+    """
+    Compute the mechanical energy of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The mechanical energy of the model.
+    """
+
+    K = kinetic_energy(model=model, data=data)
+    U = potential_energy(model=model, data=data)
+
+    return (K + U).astype(float)
+
+
+@jax.jit
+def kinetic_energy(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Float:
+    """
+    Compute the kinetic energy of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The kinetic energy of the model.
+    """
+
+    with data.switch_velocity_representation(velocity_representation=VelRepr.Body):
+        B_ν = data.generalized_velocity()
+        M_B = free_floating_mass_matrix(model=model, data=data)
+
+    K = 0.5 * B_ν.T @ M_B @ B_ν
+    return K.squeeze().astype(float)
+
+
+@jax.jit
+def potential_energy(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Float:
+    """
+    Compute the potential energy of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The potential energy of the model.
+    """
+
+    m = total_mass(model=model)
+    gravity = data.gravity.squeeze()
+    W_p̃_CoM = jnp.hstack([com_position(model=model, data=data), 1])
+
+    U = -jnp.hstack([gravity, 0]) @ (m * W_p̃_CoM)
+    return U.squeeze().astype(float)

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -6,10 +6,12 @@ import pathlib
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
+import jaxlie
 import rod
 from jax_dataclasses import Static
 
 import jaxsim.api as js
+import jaxsim.physics.algos.aba
 import jaxsim.physics.algos.forward_kinematics
 import jaxsim.physics.model.physics_model
 import jaxsim.typing as jtp
@@ -438,3 +440,206 @@ def generalized_free_floating_jacobian(
     )(jnp.arange(model.number_of_links()))
 
     return J_free_floating
+
+
+@functools.partial(jax.jit, static_argnames=["prefer_aba"])
+def forward_dynamics(
+    model: JaxSimModel,
+    data: js.data.JaxSimModelData,
+    joint_forces: jtp.VectorLike | None = None,
+    external_forces: jtp.MatrixLike | None = None,
+    prefer_aba: float = True,
+) -> tuple[jtp.Vector, jtp.Vector]:
+    """
+    Compute the forward dynamics of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        joint_forces:
+            The joint forces to consider as a vector of shape `(dofs,)`.
+        external_forces:
+            The external forces to consider as a matrix of shape `(nL, 6)`.
+        prefer_aba: Whether to prefer the ABA algorithm over the CRB one.
+
+    Returns:
+        A tuple containing the 6D acceleration in the active representation of the
+        base link and the joint accelerations resulting from the application of the
+        considered joint forces and external forces.
+    """
+
+    forward_dynamics_fn = forward_dynamics_aba if prefer_aba else forward_dynamics_crb
+
+    return forward_dynamics_fn(
+        model=model, data=data, tau=joint_forces, external_forces=external_forces
+    )
+
+
+@jax.jit
+def forward_dynamics_aba(
+    model: JaxSimModel,
+    data: js.data.JaxSimModelData,
+    joint_forces: jtp.VectorLike | None = None,
+    external_forces: jtp.MatrixLike | None = None,
+) -> tuple[jtp.Vector, jtp.Vector]:
+    """
+    Compute the forward dynamics of the model with the ABA algorithm.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        joint_forces:
+            The joint forces to consider as a vector of shape `(dofs,)`.
+        external_forces:
+            The external forces to consider as a matrix of shape `(nL, 6)`.
+
+    Returns:
+        A tuple containing the 6D acceleration in the active representation of the
+        base link and the joint accelerations resulting from the application of the
+        considered joint forces and external forces.
+    """
+
+    # Build joint torques if not provided
+    τ = (
+        joint_forces
+        if joint_forces is not None
+        else jnp.zeros_like(data.joint_positions())
+    )
+
+    # Build external forces if not provided
+    f_ext = (
+        external_forces
+        if external_forces is not None
+        else jnp.zeros((model.number_of_links(), 6))
+    )
+
+    # Compute ABA
+    W_v̇_WB, s̈ = jaxsim.physics.algos.aba.aba(
+        model=model.physics_model,
+        xfb=data.state.physics_model.xfb(),
+        q=data.state.physics_model.joint_positions,
+        qd=data.state.physics_model.joint_velocities,
+        tau=τ,
+        f_ext=f_ext,
+    )
+
+    def to_active(W_vd_WB, W_H_C, W_v_WB, W_vl_WC):
+        C_X_W = jaxlie.SE3.from_matrix(W_H_C).inverse().adjoint()
+
+        if data.velocity_representation != VelRepr.Mixed:
+            return C_X_W @ W_vd_WB
+        else:
+            from jaxsim.math.cross import Cross
+
+            W_v_WC = jnp.hstack([W_vl_WC, jnp.zeros(3)])
+            return C_X_W @ (W_vd_WB - Cross.vx(W_v_WC) @ W_v_WB)
+
+    match data.velocity_representation:
+        case VelRepr.Inertial:
+            W_H_C = W_H_W = jnp.eye(4)
+            W_vl_WC = W_vl_WW = jnp.zeros(3)
+
+        case VelRepr.Body:
+            W_H_C = W_H_B = data.base_transform()
+            W_vl_WC = W_vl_WB = data.base_velocity()[0:3]
+
+        case VelRepr.Mixed:
+            W_H_B = data.base_transform()
+            W_H_C = W_H_BW = W_H_B.at[0:3, 0:3].set(jnp.eye(3))
+            W_vl_WC = W_vl_W_BW = data.base_velocity()[0:3]
+
+        case _:
+            raise ValueError(data.velocity_representation)
+
+    # We need to convert the derivative of the base acceleration to the active
+    # representation. In Mixed representation, this conversion is not a plain
+    # transformation with just X, but it also involves a cross product in ℝ⁶.
+    C_v̇_WB = to_active(
+        W_vd_WB=W_v̇_WB.squeeze(),
+        W_H_C=W_H_C,
+        W_v_WB=jnp.hstack(
+            [
+                data.state.physics_model.base_linear_velocity,
+                data.state.physics_model.base_angular_velocity,
+            ]
+        ),
+        W_vl_WC=W_vl_WC,
+    )
+
+    # Adjust shape
+    s̈ = jnp.atleast_1d(s̈.squeeze())
+
+    return C_v̇_WB, s̈
+
+
+@jax.jit
+def forward_dynamics_crb(
+    model: JaxSimModel,
+    data: js.data.JaxSimModelData,
+    joint_forces: jtp.MatrixLike | None = None,
+    external_forces: jtp.MatrixLike | None = None,
+) -> tuple[jtp.Vector, jtp.Vector]:
+    """
+    Compute the forward dynamics of the model with the CRB algorithm.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        joint_forces:
+            The joint forces to consider as a vector of shape `(dofs,)`.
+        external_forces:
+            The external forces to consider as a matrix of shape `(nL, 6)`.
+
+    Returns:
+        A tuple containing the 6D acceleration in the active representation of the
+        base link and the joint accelerations resulting from the application of the
+        considered joint forces and external forces.
+
+    Note:
+        Compared to ABA, this method could be significantly slower, especially for
+        models with a large number of degrees of freedom.
+    """
+
+    # Build joint torques if not provided
+    τ = (
+        joint_forces
+        if joint_forces is not None
+        else jnp.zeros_like(data.joint_positions())
+    )
+
+    # Build external forces if not provided
+    external_forces = (
+        external_forces
+        if external_forces is not None
+        else jnp.zeros(shape=(model.number_of_links(), 6))
+    )
+
+    # Handle models with zero and one DoFs
+    τ = jnp.atleast_1d(τ.squeeze())
+    τ = jnp.vstack(τ) if τ.size > 0 else jnp.empty(shape=(0, 1))
+
+    # Compute terms of the floating-base EoM
+    M = free_floating_mass_matrix(model=model, data=data)
+    h = jnp.vstack(free_floating_bias_forces(model=model, data=data))
+    J = jnp.vstack(generalized_free_floating_jacobian(model=model, data=data))
+    f_ext = jnp.vstack(external_forces.flatten())
+    S = jnp.block([jnp.zeros(shape=(model.dofs(), 6)), jnp.eye(model.dofs())]).T
+
+    # TODO: invert the Mss block exploiting sparsity defined by the parent array λ(i)
+    if model.floating_base():
+        ν̇ = jnp.linalg.inv(M) @ ((S @ τ) - h + J.T @ f_ext)
+    else:
+        v̇_WB = jnp.zeros(6)
+        s̈ = jnp.linalg.inv(M[6:, 6:]) @ ((S @ τ)[6:] - h[6:] + J[:, 6:].T @ f_ext)
+        ν̇ = jnp.hstack([v̇_WB, s̈.squeeze()])
+
+    # Extract the base acceleration in the active representation.
+    # Note that this is an apparent acceleration (relevant in Mixed representation),
+    # therefore it cannot be always expressed in different frames with just a
+    # 6D transformation X.
+    v̇_WB = ν̇[0:6].squeeze().astype(float)
+
+    # Extract the joint accelerations
+    s̈ = jnp.atleast_1d(ν̇[6:].squeeze()).astype(float)
+
+    return v̇_WB, s̈

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -478,7 +478,10 @@ def forward_dynamics(
     forward_dynamics_fn = forward_dynamics_aba if prefer_aba else forward_dynamics_crb
 
     return forward_dynamics_fn(
-        model=model, data=data, tau=joint_forces, external_forces=external_forces
+        model=model,
+        data=data,
+        joint_forces=joint_forces,
+        external_forces=external_forces,
     )
 
 
@@ -536,11 +539,11 @@ def forward_dynamics_aba(
 
         if data.velocity_representation != VelRepr.Mixed:
             return C_X_W @ W_vd_WB
-        else:
-            from jaxsim.math.cross import Cross
 
-            W_v_WC = jnp.hstack([W_vl_WC, jnp.zeros(3)])
-            return C_X_W @ (W_vd_WB - Cross.vx(W_v_WC) @ W_v_WB)
+        from jaxsim.math.cross import Cross
+
+        W_v_WC = jnp.hstack([W_vl_WC, jnp.zeros(3)])
+        return C_X_W @ (W_vd_WB - Cross.vx(W_v_WC) @ W_v_WB)
 
     match data.velocity_representation:
         case VelRepr.Inertial:

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -392,6 +392,7 @@ def forward_kinematics(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp
 def generalized_free_floating_jacobian(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
+    *,
     output_vel_repr: VelRepr | None = None,
 ) -> jtp.Matrix:
     """
@@ -450,6 +451,7 @@ def generalized_free_floating_jacobian(
 def forward_dynamics(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
+    *,
     joint_forces: jtp.VectorLike | None = None,
     external_forces: jtp.MatrixLike | None = None,
     prefer_aba: float = True,
@@ -483,6 +485,7 @@ def forward_dynamics(
 def forward_dynamics_aba(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
+    *,
     joint_forces: jtp.VectorLike | None = None,
     external_forces: jtp.MatrixLike | None = None,
 ) -> tuple[jtp.Vector, jtp.Vector]:
@@ -580,6 +583,7 @@ def forward_dynamics_aba(
 def forward_dynamics_crb(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
+    *,
     joint_forces: jtp.MatrixLike | None = None,
     external_forces: jtp.MatrixLike | None = None,
 ) -> tuple[jtp.Vector, jtp.Vector]:
@@ -708,6 +712,7 @@ def free_floating_mass_matrix(
 def inverse_dynamics(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
+    *,
     joint_accelerations: jtp.Vector | None = None,
     base_acceleration: jtp.Vector | None = None,
     external_forces: jtp.Matrix | None = None,
@@ -789,7 +794,7 @@ def inverse_dynamics(
     )
 
     # Compute RNEA
-    W_f_B, tau = jaxsim.physics.algos.rnea.rnea(
+    W_f_B, τ = jaxsim.physics.algos.rnea.rnea(
         model=model.physics_model,
         xfb=data.state.physics_model.xfb(),
         q=data.state.physics_model.joint_positions,
@@ -800,7 +805,7 @@ def inverse_dynamics(
     )
 
     # Adjust shape
-    tau = jnp.atleast_1d(tau.squeeze())
+    τ = jnp.atleast_1d(τ.squeeze())
 
     # Express W_f_B in the active representation
     f_B = js.data.JaxSimModelData.inertial_to_other_representation(
@@ -810,7 +815,7 @@ def inverse_dynamics(
         is_force=True,
     ).squeeze()
 
-    return f_B.astype(float), tau.astype(float)
+    return f_B.astype(float), τ.astype(float)
 
 
 @jax.jit

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -809,3 +809,50 @@ def inverse_dynamics(
     ).squeeze()
 
     return f_B.astype(float), tau.astype(float)
+
+
+@jax.jit
+def free_floating_gravity_forces(
+    model: JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Vector:
+    """
+    Compute the free-floating gravity forces :math:`g(\mathbf{q})` of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The free-floating gravity forces of the model.
+    """
+
+    # Build a zeroed state
+    data_rnea = js.data.JaxSimModelData.zero(model=model)
+
+    # Set just the generalized position
+    with data_rnea.mutable_context(
+        mutability=Mutability.MUTABLE, restore_after_exception=False
+    ):
+
+        data_rnea.state.physics_model.base_position = (
+            data.state.physics_model.base_position
+        )
+
+        data_rnea.state.physics_model.base_quaternion = (
+            data.state.physics_model.base_quaternion
+        )
+
+        data_rnea.state.physics_model.joint_positions = (
+            data.state.physics_model.joint_positions
+        )
+
+    return jnp.hstack(
+        inverse_dynamics(
+            model=model,
+            data=data_rnea,
+            # Set zero inputs:
+            joint_accelerations=jnp.atleast_1d(jnp.zeros(model.dofs())),
+            base_acceleration=jnp.zeros(6),
+            external_forces=jnp.zeros(shape=(model.number_of_links(), 6)),
+        )
+    ).astype(float)

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -856,3 +856,63 @@ def free_floating_gravity_forces(
             external_forces=jnp.zeros(shape=(model.number_of_links(), 6)),
         )
     ).astype(float)
+
+
+@jax.jit
+def free_floating_bias_forces(
+    model: JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Vector:
+    """
+    Compute the free-floating bias forces :math:`h(\mathbf{q}, \boldsymbol{\nu})`
+    of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The free-floating bias forces of the model.
+    """
+
+    # Build a zeroed state
+    data_rnea = js.data.JaxSimModelData.zero(model=model)
+
+    # Set the generalized position and generalized velocity
+    with data_rnea.mutable_context(
+        mutability=Mutability.MUTABLE, restore_after_exception=False
+    ):
+
+        data_rnea.state.physics_model.base_position = (
+            data.state.physics_model.base_position
+        )
+
+        data_rnea.state.physics_model.base_quaternion = (
+            data.state.physics_model.base_quaternion
+        )
+
+        data_rnea.state.physics_model.joint_positions = (
+            data.state.physics_model.joint_positions
+        )
+
+        data_rnea.state.physics_model.base_linear_velocity = (
+            data.state.physics_model.base_linear_velocity
+        )
+
+        data_rnea.state.physics_model.base_angular_velocity = (
+            data.state.physics_model.base_angular_velocity
+        )
+
+        data_rnea.state.physics_model.joint_velocities = (
+            data.state.physics_model.joint_velocities
+        )
+
+    return jnp.hstack(
+        inverse_dynamics(
+            model=model,
+            data=data_rnea,
+            # Set zero inputs:
+            joint_accelerations=jnp.atleast_1d(jnp.zeros(model.dofs())),
+            base_acceleration=jnp.zeros(6),
+            external_forces=jnp.zeros(shape=(model.number_of_links(), 6)),
+        )
+    ).astype(float)

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -10,6 +10,7 @@ import rod
 from jax_dataclasses import Static
 
 import jaxsim.api as js
+import jaxsim.physics.algos.forward_kinematics
 import jaxsim.physics.model.physics_model
 import jaxsim.typing as jtp
 from jaxsim.physics.algos.terrain import FlatTerrain, Terrain
@@ -351,3 +352,31 @@ def com_position(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Vecto
     B_p̃_CoM = B_p̃_CoM.at[3].set(1)
 
     return (W_H_B @ B_p̃_CoM)[0:3].astype(float)
+
+
+# ==============================
+# Rigid Body Dynamics Algorithms
+# ==============================
+
+
+@jax.jit
+def forward_kinematics(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Array:
+    """
+    Compute the SE(3) transforms from the world frame to the frames of all links.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        A (nL, 4, 4) array containing the stacked SE(3) transforms of the links.
+        The first axis is the link index.
+    """
+
+    W_H_LL = jaxsim.physics.algos.forward_kinematics.forward_kinematics_model(
+        model=model.physics_model,
+        q=data.state.physics_model.joint_positions,
+        xfb=data.state.physics_model.xfb(),
+    )
+
+    return jnp.atleast_3d(W_H_LL).astype(float)

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+
+import jax_dataclasses
+import rod
+from jax_dataclasses import Static
+
+import jaxsim.physics.model.physics_model
+import jaxsim.typing as jtp
+from jaxsim.physics.algos.terrain import FlatTerrain, Terrain
+from jaxsim.utils import JaxsimDataclass, Mutability
+
+
+@jax_dataclasses.pytree_dataclass
+class JaxSimModel(JaxsimDataclass):
+    """
+    The JaxSim model defining the kinematics and dynamics of a robot.
+    """
+
+    model_name: Static[str]
+
+    physics_model: jaxsim.physics.model.physics_model.PhysicsModel = dataclasses.field(
+        repr=False
+    )
+
+    terrain: Static[Terrain] = dataclasses.field(default=FlatTerrain(), repr=False)
+
+    built_from: Static[str | pathlib.Path | rod.Model | None] = dataclasses.field(
+        repr=False, default=None
+    )
+
+    _number_of_links: Static[int] = dataclasses.field(
+        init=False, repr=False, default=None
+    )
+
+    _number_of_joints: Static[int] = dataclasses.field(
+        init=False, repr=False, default=None
+    )
+
+    def __post_init__(self):
+
+        # These attributes are Static so that we can use `jax.vmap` and `jax.lax.scan`
+        # over the all links and joints
+        with self.mutable_context(
+            mutability=Mutability.MUTABLE_NO_VALIDATION,
+            restore_after_exception=False,
+        ):
+            self._number_of_links = len(self.physics_model.description.links_dict)
+            self._number_of_joints = len(self.physics_model.description.joints_dict)
+
+    # ========================
+    # Initialization and state
+    # ========================
+
+    @staticmethod
+    def build_from_model_description(
+        model_description: str | pathlib.Path | rod.Model,
+        model_name: str | None = None,
+        gravity: jtp.Array = jaxsim.physics.default_gravity(),
+        is_urdf: bool | None = None,
+        considered_joints: list[str] | None = None,
+    ) -> JaxSimModel:
+        """
+        Build a Model object from a model description.
+
+        Args:
+            model_description:
+                A path to an SDF/URDF file, a string containing
+                its content, or a pre-parsed/pre-built rod model.
+            model_name:
+                The optional name of the model that overrides the one in
+                the description.
+            gravity: The 3D gravity vector.
+            is_urdf:
+                Whether the model description is a URDF or an SDF. This is
+                automatically inferred if the model description is a path to a file.
+            considered_joints:
+                The list of joints to consider. If None, all joints are considered.
+
+        Returns:
+            The built Model object.
+        """
+
+        import jaxsim.parsers.rod
+
+        # Parse the input resource (either a path to file or a string with the URDF/SDF)
+        # and build the -intermediate- model description
+        intermediate_description = jaxsim.parsers.rod.build_model_description(
+            model_description=model_description, is_urdf=is_urdf
+        )
+
+        # Lump links together if not all joints are considered.
+        # Note: this procedure assigns a zero position to all joints not considered.
+        if considered_joints is not None:
+            intermediate_description = intermediate_description.reduce(
+                considered_joints=considered_joints
+            )
+
+        # Create the physics model from the model description
+        physics_model = jaxsim.physics.model.physics_model.PhysicsModel.build_from(
+            model_description=intermediate_description, gravity=gravity
+        )
+
+        # Build the model
+        model = JaxSimModel.build(physics_model=physics_model, model_name=model_name)
+
+        with model.mutable_context(mutability=Mutability.MUTABLE_NO_VALIDATION):
+            model.built_from = model_description
+
+        return model
+
+    @staticmethod
+    def build(
+        physics_model: jaxsim.physics.model.physics_model.PhysicsModel,
+        model_name: str | None = None,
+    ) -> JaxSimModel:
+        """
+        Build a Model object from a physics model.
+
+        Args:
+            physics_model: The physics model.
+            model_name:
+                The optional name of the model overriding the physics model name.
+
+        Returns:
+            The built Model object.
+        """
+
+        # Set the model name (if not provided, use the one from the model description)
+        model_name = (
+            model_name if model_name is not None else physics_model.description.name
+        )
+
+        # Build the model
+        model = JaxSimModel(physics_model=physics_model, model_name=model_name)  # noqa
+
+        return model
+
+    # ==========
+    # Properties
+    # ==========
+
+    def name(self) -> str:
+        """
+        Return the name of the model.
+
+        Returns:
+            The name of the model.
+        """
+
+        return self.model_name
+
+    def number_of_links(self) -> jtp.Int:
+        """
+        Return the number of links in the model.
+
+        Returns:
+            The number of links in the model.
+
+        Note:
+            The base link is included in the count and its index is always 0.
+        """
+
+        return self._number_of_links
+
+    def number_of_joints(self) -> jtp.Int:
+        """
+        Return the number of joints in the model.
+
+        Returns:
+            The number of joints in the model.
+        """
+
+        return self._number_of_joints
+
+    # =================
+    # Base link methods
+    # =================
+
+    def floating_base(self) -> bool:
+        """
+        Return whether the model has a floating base.
+
+        Returns:
+            True if the model is floating-base, False otherwise.
+        """
+
+        return self.physics_model.is_floating_base
+
+    def base_link(self) -> str:
+        """
+        Return the name of the base link.
+
+        Returns:
+            The name of the base link.
+        """
+
+        return self.physics_model.description.root.name
+
+    # =====================
+    # Joint-related methods
+    # =====================
+
+    def dofs(self) -> int:
+        """
+        Return the number of degrees of freedom of the model.
+
+        Returns:
+            The number of degrees of freedom of the model.
+
+        Note:
+            We do not yet support multi-DoF joints, therefore this is always equal to
+            the number of joints. In the future, this could be different.
+        """
+
+        return len(self.physics_model.description.joints_dict)
+
+    def joint_names(self) -> tuple[str, ...]:
+        """
+        Return the names of the joints in the model.
+
+        Returns:
+            The names of the joints in the model.
+        """
+
+        return tuple(self.physics_model.description.joints_dict.keys())
+
+    # ====================
+    # Link-related methods
+    # ====================
+
+    def link_names(self) -> tuple[str, ...]:
+        """
+        Return the names of the links in the model.
+
+        Returns:
+            The names of the links in the model.
+        """
+
+        return tuple(self.physics_model.description.links_dict.keys())

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -240,3 +240,46 @@ class JaxSimModel(JaxsimDataclass):
         """
 
         return tuple(self.physics_model.description.links_dict.keys())
+
+
+# =====================
+# Model post-processing
+# =====================
+
+
+def reduce(model: JaxSimModel, considered_joints: tuple[str, ...]) -> JaxSimModel:
+    """
+    Reduce the model by lumping together the links connected by removed joints.
+
+    Args:
+        model: The model to reduce.
+        considered_joints: The sequence of joints to consider.
+
+    Note:
+        If considered_joints contains joints not existing in the model, the method
+        will raise an exception. If considered_joints is empty, the method will
+        return a copy of the input model.
+    """
+
+    if len(considered_joints) == 0:
+        return model.copy()
+
+    # Reduce the model description.
+    # If considered_joints contains joints not existing in the model, the method
+    # will raise an exception.
+    reduced_intermediate_description = model.physics_model.description.reduce(
+        considered_joints=list(considered_joints)
+    )
+
+    # Create the physics model from the reduced model description
+    physics_model = jaxsim.physics.model.physics_model.PhysicsModel.build_from(
+        model_description=reduced_intermediate_description,
+        gravity=model.physics_model.gravity[0:3],
+    )
+
+    # Build the reduced model
+    reduced_model = JaxSimModel.build(
+        physics_model=physics_model, model_name=model.name()
+    )
+
+    return reduced_model

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -9,6 +9,7 @@ import jax_dataclasses
 import rod
 from jax_dataclasses import Static
 
+import jaxsim.api as js
 import jaxsim.physics.model.physics_model
 import jaxsim.typing as jtp
 from jaxsim.physics.algos.terrain import FlatTerrain, Terrain
@@ -311,3 +312,42 @@ def total_mass(model: JaxSimModel) -> jtp.Float:
         .sum()
         .astype(float)
     )
+
+
+# ==============
+# Center of mass
+# ==============
+
+
+@jax.jit
+def com_position(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Vector:
+    """
+    Compute the position of the center of mass of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The position of the center of mass of the model w.r.t. the world frame.
+    """
+
+    m = total_mass(model=model)
+
+    W_H_L = forward_kinematics(model=model, data=data)
+    W_H_B = data.base_transform()
+    B_H_W = jaxlie.SE3.from_matrix(W_H_B).inverse().as_matrix()
+
+    def B_p̃_LCoM(i) -> jtp.Vector:
+        m = js.link.mass(model=model, link_index=i)
+        L_p_LCoM = js.link.com_position(
+            model=model, data=data, link_index=i, in_link_frame=True
+        )
+        return m * B_H_W @ W_H_L[i] @ jnp.hstack([L_p_LCoM, 1])
+
+    com_links = jax.vmap(B_p̃_LCoM)(jnp.arange(model.number_of_links()))
+
+    B_p̃_CoM = (1 / m) * com_links.sum(axis=0)
+    B_p̃_CoM = B_p̃_CoM.at[3].set(1)
+
+    return (W_H_B @ B_p̃_CoM)[0:3].astype(float)

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -815,7 +815,7 @@ def inverse_dynamics(
     f_B = js.data.JaxSimModelData.inertial_to_other_representation(
         array=W_f_B,
         other_representation=data.velocity_representation,
-        base_transform=data.base_transform(),
+        transform=data.base_transform(),
         is_force=True,
     ).squeeze()
 
@@ -969,7 +969,7 @@ def total_momentum(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Vec
     return js.data.JaxSimModelData.inertial_to_other_representation(
         array=W_h,
         other_representation=data.velocity_representation,
-        base_transform=W_H_B,
+        transform=W_H_B,
         is_force=True,
     ).astype(float)
 

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import dataclasses
 import pathlib
 
+import jax
+import jax.numpy as jnp
 import jax_dataclasses
 import rod
 from jax_dataclasses import Static
@@ -283,3 +285,29 @@ def reduce(model: JaxSimModel, considered_joints: tuple[str, ...]) -> JaxSimMode
     )
 
     return reduced_model
+
+
+# ===================
+# Inertial properties
+# ===================
+
+
+@jax.jit
+def total_mass(model: JaxSimModel) -> jtp.Float:
+    """
+    Compute the total mass of the model.
+
+    Args:
+        model: The model to consider.
+
+    Returns:
+        The total mass of the model.
+    """
+
+    return (
+        jax.vmap(lambda idx: js.link.mass(model=model, link_index=idx))(
+            jnp.arange(model.number_of_links())
+        )
+        .sum()
+        .astype(float)
+    )

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -12,6 +12,7 @@ from jax_dataclasses import Static
 
 import jaxsim.api as js
 import jaxsim.physics.algos.aba
+import jaxsim.physics.algos.crba
 import jaxsim.physics.algos.forward_kinematics
 import jaxsim.physics.model.physics_model
 import jaxsim.typing as jtp
@@ -643,3 +644,58 @@ def forward_dynamics_crb(
     s̈ = jnp.atleast_1d(ν̇[6:].squeeze()).astype(float)
 
     return v̇_WB, s̈
+
+
+@jax.jit
+def free_floating_mass_matrix(
+    model: JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Matrix:
+    """
+    Compute the free-floating mass matrix of the model with the CRBA algorithm.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The free-floating mass matrix of the model.
+    """
+
+    M_body = jaxsim.physics.algos.crba.crba(
+        model=model.physics_model,
+        q=data.state.physics_model.joint_positions,
+    )
+
+    match data.velocity_representation:
+        case VelRepr.Body:
+            return M_body
+
+        case VelRepr.Inertial:
+            zero_6n = jnp.zeros(shape=(6, model.dofs()))
+            B_X_W = jaxlie.SE3.from_matrix(data.base_transform()).inverse().adjoint()
+
+            invT = jnp.vstack(
+                [
+                    jnp.block([B_X_W, zero_6n]),
+                    jnp.block([zero_6n.T, jnp.eye(model.dofs())]),
+                ]
+            )
+
+            return invT.T @ M_body @ invT
+
+        case VelRepr.Mixed:
+            zero_6n = jnp.zeros(shape=(6, model.dofs()))
+            W_H_BW = data.base_transform().at[0:3, 3].set(jnp.zeros(3))
+            BW_X_W = jaxlie.SE3.from_matrix(W_H_BW).inverse().adjoint()
+
+            invT = jnp.vstack(
+                [
+                    jnp.block([BW_X_W, zero_6n]),
+                    jnp.block([zero_6n.T, jnp.eye(model.dofs())]),
+                ]
+            )
+
+            return invT.T @ M_body @ invT
+
+        case _:
+            raise ValueError(data.velocity_representation)

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -380,3 +380,61 @@ def forward_kinematics(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp
     )
 
     return jnp.atleast_3d(W_H_LL).astype(float)
+
+
+@jax.jit
+def generalized_free_floating_jacobian(
+    model: JaxSimModel,
+    data: js.data.JaxSimModelData,
+    output_vel_repr: VelRepr | None = None,
+) -> jtp.Matrix:
+    """
+    Compute the free-floating jacobians of all links.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        output_vel_repr:
+            The output velocity representation of the free-floating jacobians.
+
+    Returns:
+        The (nL, 6, 6+dofs) array containing the stacked free-floating
+        jacobians of the links. The first axis is the link index.
+    """
+
+    if output_vel_repr is None:
+        output_vel_repr = data.velocity_representation
+
+    # The body frame of the Link.jacobian method is the link frame L.
+    # In this method, we want instead to use the base link B as body frame.
+    # Therefore, we always get the link jacobian having Inertial as output
+    # representation, and then we convert it to the desired output representation.
+    match output_vel_repr:
+        case VelRepr.Inertial:
+            to_output = lambda J: J
+
+        case VelRepr.Body:
+
+            def to_output(W_J_Wi):
+                W_H_B = data.base_transform()
+                B_X_W = jaxlie.SE3.from_matrix(W_H_B).inverse().adjoint()
+                return B_X_W @ W_J_Wi
+
+        case VelRepr.Mixed:
+
+            def to_output(W_J_Wi):
+                W_H_B = data.base_transform()
+                W_H_BW = jnp.array(W_H_B).at[0:3, 0:3].set(jnp.eye(3))
+                BW_X_W = jaxlie.SE3.from_matrix(W_H_BW).inverse().adjoint()
+                return BW_X_W @ W_J_Wi
+
+        case _:
+            raise ValueError(output_vel_repr)
+
+    # Get the link jacobians in Inertial representation and convert them to the
+    # target output representation in which the body frame is the base link B
+    J_free_floating = jax.vmap(
+        lambda i: to_output(js.link.jacobian(model=model, data=data, link_index=i))
+    )(jnp.arange(model.number_of_links()))
+
+    return J_free_floating

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 import pathlib
 
 import jax
@@ -17,6 +18,7 @@ import jaxsim.physics.algos.forward_kinematics
 import jaxsim.physics.algos.rnea
 import jaxsim.physics.model.physics_model
 import jaxsim.typing as jtp
+from jaxsim.high_level.common import VelRepr
 from jaxsim.physics.algos.terrain import FlatTerrain, Terrain
 from jaxsim.utils import JaxsimDataclass, Mutability
 

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -1,0 +1,280 @@
+from typing import Any, Protocol
+
+import jax
+import jax.numpy as jnp
+import jaxlie
+
+import jaxsim.physics.algos.soft_contacts
+import jaxsim.typing as jtp
+from jaxsim import VelRepr, integrators
+from jaxsim.integrators.common import Time
+from jaxsim.math.quaternion import Quaternion
+from jaxsim.physics.algos.soft_contacts import SoftContactsState
+from jaxsim.physics.model.physics_model_state import PhysicsModelState
+from jaxsim.simulation.ode_data import ODEState
+
+from . import contact as Contact
+from . import data as Data
+from . import model as Model
+
+
+class SystemDynamicsFromModelAndData(Protocol):
+    def __call__(
+        self,
+        model: Model.JaxSimModel,
+        data: Data.JaxSimModelData,
+        **kwargs: dict[str, Any],
+    ) -> tuple[ODEState, dict[str, Any]]: ...
+
+
+def wrap_system_dynamics_for_integration(
+    model: Model.JaxSimModel,
+    data: Data.JaxSimModelData,
+    *,
+    system_dynamics: SystemDynamicsFromModelAndData,
+    **kwargs,
+) -> jaxsim.integrators.common.SystemDynamics[ODEState, ODEState]:
+    """
+    Wrap generic system dynamics operating on `JaxSimModel` and `JaxSimModelData`
+    for integration with `jaxsim.integrators`.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        system_dynamics: The system dynamics to wrap.
+        **kwargs: Additional kwargs to close over the system dynamics.
+
+    Returns:
+        The system dynamics closed over the model, the data, and the additional kwargs.
+    """
+
+    # We allow to close `system_dynamics` over additional kwargs.
+    kwargs_closed = kwargs
+
+    def f(x: ODEState, t: Time, **kwargs) -> tuple[ODEState, dict[str, Any]]:
+
+        # Close f over the `data` parameter.
+        with data.editable(validate=True) as data_rw:
+            data_rw.state = x
+            data_rw.time_ns = jnp.array(t * 1e9).astype(jnp.uint64)
+
+        # Close f over the `model` parameter.
+        return system_dynamics(model=model, data=data_rw, **kwargs_closed | kwargs)
+
+    f: jaxsim.integrators.common.SystemDynamics[ODEState, ODEState]
+    return f
+
+
+# ==================================
+# Functions defining system dynamics
+# ==================================
+
+
+@jax.jit
+def system_velocity_dynamics(
+    model: Model.JaxSimModel,
+    data: Data.JaxSimModelData,
+    *,
+    joint_forces: jtp.Vector | None = None,
+    external_forces: jtp.Vector | None = None,
+) -> tuple[jtp.Vector, jtp.Vector, jtp.Matrix, dict[str, Any]]:
+    """
+    Compute the dynamics of the system velocity.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        joint_forces: The joint forces to apply.
+        external_forces: The external forces to apply to the links.
+
+    Returns:
+        A tuple containing the derivative of the base 6D velocity in inertial-fixed
+        representation, the derivative of the joint velocities, the derivative of
+        the material deformation, and the dictionary of auxiliary data returned by
+        the system dynamics evalutation.
+    """
+
+    # Build joint torques if not provided
+    τ = (
+        jnp.atleast_1d(joint_forces.squeeze())
+        if joint_forces is not None
+        else jnp.zeros_like(data.joint_positions())
+    ).astype(float)
+
+    # Build external forces if not provided
+    f_ext = (
+        jnp.atleast_2d(external_forces.squeeze())
+        if external_forces is not None
+        else jnp.zeros((model.number_of_links(), 6))
+    ).astype(float)
+
+    # ======================
+    # Compute contact forces
+    # ======================
+
+    # Initialize the 6D forces W_f ∈ ℝ^{n_L × 6} applied to links due to contact
+    # with the terrain.
+    W_f_Li_terrain = jnp.zeros_like(f_ext).astype(float)
+
+    # Initialize the 6D contact forces W_f ∈ ℝ^{n_c × 3} applied to collidable points,
+    # expressed in the world frame.
+    W_f_Ci = None
+
+    # Initialize the derivative of the tangential deformation ṁ ∈ ℝ^{n_c × 3}.
+    ṁ = jnp.zeros_like(data.state.soft_contacts.tangential_deformation).astype(float)
+
+    if model.physics_model.gc.body.size > 0:
+        # Compute the position and linear velocities (mixed representation) of
+        # all collidable points belonging to the robot.
+        W_p_Ci, W_ṗ_Ci = Contact.collidable_point_kinematics(model=model, data=data)
+
+        # Compute the 3D forces applied to each collidable point.
+        W_f_Ci, ṁ = jax.vmap(
+            lambda p, ṗ, m: jaxsim.physics.algos.soft_contacts.SoftContacts(
+                parameters=data.soft_contacts_params, terrain=model.terrain
+            ).contact_model(position=p, velocity=ṗ, tangential_deformation=m)
+        )(W_p_Ci, W_ṗ_Ci, data.state.soft_contacts.tangential_deformation.T)
+
+        # Sum the forces of all collidable points rigidly attached to a body.
+        # Since the contact forces W_f_Ci are expressed in the world frame,
+        # we don't need any coordinate transformation.
+        W_f_Li_terrain = jax.vmap(
+            lambda nc: (
+                jnp.vstack(jnp.equal(model.physics_model.gc.body, nc).astype(int))
+                * W_f_Ci
+            ).sum(axis=0)
+        )(jnp.arange(model.number_of_links()))
+
+    # ====================
+    # Enforce joint limits
+    # ====================
+
+    # TODO: enforce joint limits
+    τ_position_limit = jnp.zeros_like(τ).astype(float)
+
+    # ====================
+    # Joint friction model
+    # ====================
+
+    τ_friction = jnp.zeros_like(τ).astype(float)
+
+    if model.dofs() > 0:
+        # Static and viscous joint friction parameters
+        kc = jnp.array(list(model.physics_model._joint_friction_static.values()))
+        kv = jnp.array(list(model.physics_model._joint_friction_viscous.values()))
+
+        # Compute the joint friction torque
+        τ_friction = -(
+            jnp.diag(kc) @ jnp.sign(data.state.physics_model.joint_positions)
+            + jnp.diag(kv) @ data.state.physics_model.joint_velocities
+        )
+
+    # ========================
+    # Compute forward dynamics
+    # ========================
+
+    # Compute the total joint forces
+    τ_total = τ + τ_friction + τ_position_limit
+
+    # Compute the total external 6D forces applied to the links
+    W_f_L_total = f_ext + W_f_Li_terrain
+
+    # - Joint accelerations: s̈ ∈ ℝⁿ
+    # - Base inertial-fixed acceleration: W_v̇_WB = (W_p̈_B, W_ω̇_B) ∈ ℝ⁶
+    with data.switch_velocity_representation(velocity_representation=VelRepr.Inertial):
+        W_v̇_WB, s̈ = Model.forward_dynamics_aba(
+            model=model,
+            data=data,
+            joint_forces=τ_total,
+            external_forces=W_f_L_total,
+        )
+
+    return W_v̇_WB, s̈, ṁ.T, dict()
+
+
+@jax.jit
+def system_position_dynamics(
+    model: Model.JaxSimModel, data: Data.JaxSimModelData
+) -> tuple[jtp.Vector, jtp.Vector, jtp.Vector]:
+    """
+    Compute the dynamics of the system position.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        A tuple containing the derivative of the base position, the derivative of the
+        base quaternion, and the derivative of the joint positions.
+    """
+
+    ṡ = data.state.physics_model.joint_velocities
+    W_Q_B = data.state.physics_model.base_quaternion
+
+    with data.switch_velocity_representation(velocity_representation=VelRepr.Mixed):
+        W_ṗ_B = data.base_velocity()[0:3]
+
+    with data.switch_velocity_representation(velocity_representation=VelRepr.Inertial):
+        W_ω_WB = data.base_velocity()[3:6]
+
+    W_Q̇_B = Quaternion.derivative(
+        quaternion=W_Q_B,
+        omega=W_ω_WB,
+        omega_in_body_fixed=False,
+    ).squeeze()
+
+    return W_ṗ_B, W_Q̇_B, ṡ
+
+
+@jax.jit
+def system_dynamics(
+    model: Model.JaxSimModel,
+    data: Data.JaxSimModelData,
+    *,
+    joint_forces: jtp.Vector | None = None,
+    external_forces: jtp.Vector | None = None,
+) -> tuple[ODEState, dict[str, Any]]:
+    """
+    Compute the dynamics of the system.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        joint_forces: The joint forces to apply.
+        external_forces: The external forces to apply to the links.
+
+    Returns:
+        A tuple with an `ODEState` object storing in each of its attributes the
+        corresponding derivative, and the dictionary of auxiliary data returned
+        by the system dynamics evaluation.
+    """
+
+    # Compute the accelerations and the material deformation rate.
+    W_v̇_WB, s̈, ṁ, aux_dict = system_velocity_dynamics(
+        model=model,
+        data=data,
+        joint_forces=joint_forces,
+        external_forces=external_forces,
+    )
+
+    # Extract the velocities.
+    W_ṗ_B, W_Q̇_B, ṡ = system_position_dynamics(model=model, data=data)
+
+    # Create an ODEState object populated with the derivative of each leaf.
+    # Our integrators, operating on generic pytrees, will be able to handle it
+    # automatically as state derivative.
+    ode_state_derivative = ODEState.build(
+        physics_model_state=PhysicsModelState.build(
+            base_position=W_ṗ_B,
+            base_quaternion=W_Q̇_B,
+            joint_positions=ṡ,
+            base_linear_velocity=W_v̇_WB[0:3],
+            base_angular_velocity=W_v̇_WB[3:6],
+            joint_velocities=s̈,
+        ),
+        soft_contacts_state=SoftContactsState.build(
+            tangential_deformation=ṁ,
+        ),
+    )
+
+    return ode_state_derivative, aux_dict

--- a/src/jaxsim/integrators/__init__.py
+++ b/src/jaxsim/integrators/__init__.py
@@ -1,0 +1,2 @@
+from . import fixed_step
+from .common import Integrator, Time, TimeStep

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -1,0 +1,133 @@
+import abc
+import dataclasses
+from typing import Any, Callable, ClassVar, Generic, Self, Type, TypeVar
+
+import jax
+import jax_dataclasses
+from jax_dataclasses import Static
+
+from jaxsim.utils.jaxsim_dataclass import JaxsimDataclass, Mutability
+
+# =============
+# Generic types
+# =============
+
+Time = jax.typing.ArrayLike
+TimeStep = jax.typing.ArrayLike
+State = NextState = TypeVar("State")
+
+StateDerivative = TypeVar("StateDerivative")
+SystemDynamics = Callable[[State, Time], tuple[StateDerivative, dict[str, Any]]]
+
+# =======================
+# Base integrator classes
+# =======================
+
+
+@jax_dataclasses.pytree_dataclass
+class Integrator(JaxsimDataclass, abc.ABC, Generic[State]):
+
+    AuxDictDynamicsKey: ClassVar[str] = "aux_dict_dynamics"
+
+    dynamics: Static[SystemDynamics] = dataclasses.field(
+        repr=False, hash=False, compare=False, kw_only=True
+    )
+
+    params: dict[str, Any] = dataclasses.field(
+        default_factory=dict, repr=False, hash=False, compare=False, kw_only=True
+    )
+
+    @classmethod
+    def build(cls: Type[Self], *, dynamics: SystemDynamics, **kwargs) -> Self:
+        """
+        Build the integrator object.
+
+        Args:
+            dynamics: The system dynamics.
+            **kwargs: Additional keyword arguments to build the integrator.
+
+        Returns:
+            The integrator object.
+        """
+
+        return cls(dynamics=dynamics, **kwargs)  # noqa
+
+    def step(
+        self,
+        x0: State,
+        t0: Time,
+        dt: TimeStep,
+        *,
+        params: dict[str, Any],
+        **kwargs,
+    ) -> tuple[State, dict[str, Any]]:
+        """
+        Perform a single integration step.
+
+        Args:
+            x0: The initial state of the system.
+            t0: The initial time of the system.
+            dt: The time step of the integration.
+            params: The auxiliary dictionary of the integrator.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            The final state of the system and the updated auxiliary dictionary.
+        """
+
+        with self.editable(validate=False) as integrator:
+            integrator.params = params
+
+        with integrator.mutable_context(mutability=Mutability.MUTABLE):
+            xf = integrator(x0, t0, dt, **kwargs)
+
+        assert Integrator.AuxDictDynamicsKey in integrator.params
+
+        return xf, integrator.params
+
+    @abc.abstractmethod
+    def __call__(self, x0: State, t0: Time, dt: TimeStep, **kwargs) -> NextState:
+        pass
+
+    def init(
+        self,
+        x0: State,
+        t0: Time,
+        dt: TimeStep,
+        *,
+        key: jax.Array | None = None,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """
+        Initialize the integrator.
+
+        Args:
+            x0: The initial state of the system.
+            t0: The initial time of the system.
+            dt: The time step of the integration.
+            key: An optional random key to initialize the integrator.
+
+        Returns:
+            The auxiliary dictionary of the integrator.
+
+        Note:
+            This method should have the same signature as the inherited `__call__`
+            method, including additional kwargs.
+
+        Note:
+            If the integrator supports FSAL, the pair `(x0, t0)` must match the real
+            initial state and time of the system, otherwise the initial derivative of
+            the first step will be wrong.
+        """
+
+        _, aux_dict_dynamics = self.dynamics(x0, t0)
+
+        with self.editable(validate=False) as integrator:
+            _ = integrator(x0, t0, dt, **kwargs)
+            aux_dict_step = integrator.params
+
+        if Integrator.AuxDictDynamicsKey in aux_dict_dynamics:
+            msg = "You cannot create a key '{}' in the __call__ method."
+            raise KeyError(msg.format(Integrator.AuxDictDynamicsKey))
+
+        return {Integrator.AuxDictDynamicsKey: aux_dict_dynamics} | aux_dict_step

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -3,9 +3,11 @@ import dataclasses
 from typing import Any, Callable, ClassVar, Generic, Self, Type, TypeVar
 
 import jax
+import jax.numpy as jnp
 import jax_dataclasses
 from jax_dataclasses import Static
 
+import jaxsim.typing as jtp
 from jaxsim.utils.jaxsim_dataclass import JaxsimDataclass, Mutability
 
 # =============
@@ -131,3 +133,284 @@ class Integrator(JaxsimDataclass, abc.ABC, Generic[State]):
             raise KeyError(msg.format(Integrator.AuxDictDynamicsKey))
 
         return {Integrator.AuxDictDynamicsKey: aux_dict_dynamics} | aux_dict_step
+
+
+@jax_dataclasses.pytree_dataclass
+class ExplicitRungeKutta(Integrator[jtp.PyTree]):
+
+    # The Runge-Kutta matrix.
+    A: ClassVar[jax.typing.ArrayLike]
+
+    # The weights coefficients.
+    # Note that in practice we typically use its transpose `b.transpose()`.
+    b: ClassVar[jax.typing.ArrayLike]
+
+    # The nodes coefficients.
+    c: ClassVar[jax.typing.ArrayLike]
+
+    # Define the order of the solution.
+    # It should have as many elements as the number of rows of `b.transpose()`.
+    order_of_bT_rows: ClassVar[tuple[int, ...]]
+
+    # Define the row of the integration output corresponding to the final solution.
+    # This is the row of b.T that produces the final state.
+    row_index_of_solution: ClassVar[int]
+
+    # Attributes of FSAL (first-same-as-last) property.
+    fsal_enabled_if_supported: Static[bool] = dataclasses.field(repr=False)
+    index_of_fsal: Static[jtp.IntLike | None] = dataclasses.field(repr=False)
+
+    @property
+    def has_fsal(self) -> bool:
+        return self.fsal_enabled_if_supported and self.index_of_fsal is not None
+
+    @property
+    def order(self) -> int:
+        return self.order_of_bT_rows[self.row_index_of_solution]
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        dynamics: SystemDynamics,
+        fsal_enabled_if_supported: jtp.BoolLike = True,
+        **kwargs,
+    ) -> Self:
+        """
+        Build the integrator object.
+
+        Args:
+            dynamics: The system dynamics.
+            fsal_enabled_if_supported:
+                Whether to enable the FSAL property, if supported.
+            **kwargs: Additional keyword arguments to build the integrator.
+
+        Returns:
+            The integrator object.
+        """
+
+        # Adjust the shape of the tableau coefficients.
+        c = jnp.atleast_1d(cls.c.squeeze())
+        b = jnp.atleast_2d(jnp.vstack(cls.b.squeeze()))
+        A = jnp.atleast_2d(cls.A.squeeze())
+
+        # Check validity of the Butcher tableau.
+        if not ExplicitRungeKutta.butcher_tableau_is_valid(A=A, b=b, c=c):
+            raise ValueError("The Butcher tableau of this class is not valid.")
+
+        # Store the adjusted shapes of the tableau coefficients.
+        cls.c = c
+        cls.b = b
+        cls.A = A
+
+        # Check that b.T has enough rows based on the configured index of the solution.
+        if cls.row_index_of_solution >= cls.b.T.shape[0]:
+            msg = "The index of the solution ({}-th row of `b.T`) is out of range ({})."
+            raise ValueError(msg.format(cls.row_index_of_solution, cls.b.T.shape[0]))
+
+        # Check that the tuple containing the order of the b.T rows matches the number
+        # of the b.T rows.
+        if len(cls.order_of_bT_rows) != cls.b.T.shape[0]:
+            msg = "Wrong size of 'order_of_bT_rows' ({}), should be {}."
+            raise ValueError(msg.format(len(cls.order_of_bT_rows), cls.b.T.shape[0]))
+
+        # Check if the Butcher tableau supports FSAL (first-same-as-last).
+        # If it does, store the index of the intermediate derivative to be used as the
+        # first derivative of the next iteration.
+        has_fsal, index_of_fsal = ExplicitRungeKutta.butcher_tableau_supports_fsal(
+            A=cls.A, b=cls.b, c=cls.c, index_of_solution=cls.row_index_of_solution
+        )
+
+        # Build the integrator object.
+        integrator = super().build(
+            dynamics=dynamics,
+            index_of_fsal=index_of_fsal,
+            fsal_enabled_if_supported=bool(fsal_enabled_if_supported),
+            **kwargs,
+        )
+
+        return integrator
+
+    def __call__(self, x0: State, t0: Time, dt: TimeStep, **kwargs) -> NextState:
+
+        # Here z is a batched state with as many batch elements as b.T rows.
+        # Note that z has multiple batches only if b.T has more than one row,
+        # e.g. in Butcher tableau of embedded schemes.
+        z = self._compute_next_state(x0=x0, t0=t0, dt=dt, **kwargs)
+
+        # The next state is the batch element located at the configured index of solution.
+        return jax.tree_util.tree_map(lambda l: l[self.row_index_of_solution], z)
+
+    def _compute_next_state(
+        self, x0: State, t0: Time, dt: TimeStep, **kwargs
+    ) -> NextState:
+        """
+        Compute the next state of the system, returning all the output states.
+
+        Args:
+            x0: The initial state of the system.
+            t0: The initial time of the system.
+            dt: The time step of the integration.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A batched state with as many batch elements as `b.T` rows.
+        """
+
+        # Call variables with better symbols.
+        Δt = dt
+        c = self.c
+        b = self.b
+        A = self.A
+        f = self.dynamics
+
+        # Initialize the carry of the for loop with the stacked kᵢ vectors.
+        carry0 = jax.tree_util.tree_map(
+            lambda l: jnp.repeat(jnp.zeros_like(l)[jnp.newaxis, ...], c.size, axis=0),
+            x0,
+        )
+
+        # Apply FSAL property by passing ẋ0 = f(x0, t0) from the previous iteration.
+        get_ẋ0 = lambda: self.params.get("dxdt0", f(x0, t0)[0])
+
+        # We use a `jax.lax.scan` to compile the `f` function only once.
+        # Otherwise, if we compute e.g. for RK4 sequentially, the jit-compiled code
+        # would include 4 repetitions of the `f` logic, making everything extremely slow.
+        def scan_body(carry: jax.Array, i: int | jax.Array) -> tuple[jax.Array, None]:
+            """"""
+
+            # Unpack the carry, i.e. the stacked kᵢ vectors.
+            K = carry
+
+            # Define the computation of the Runge-Kutta stage.
+            def compute_ki() -> jax.Array:
+                ti = t0 + c[i] * Δt
+                op = lambda x0, k: x0 + Δt * jnp.dot(A[i, :], k)
+                xi = jax.tree_util.tree_map(op, x0, K)
+                return f(xi, ti)[0]
+
+            # This selector enables FSAL property in the first iteration (i=0).
+            ki = jax.lax.cond(
+                pred=jnp.logical_and(i == 0, self.has_fsal),
+                true_fun=get_ẋ0,
+                false_fun=compute_ki,
+            )
+
+            # Store the kᵢ derivative in K.
+            op = lambda l_k, l_ki: l_k.at[i].set(l_ki)
+            K = jax.tree_util.tree_map(op, K, ki)
+
+            carry = K
+            return carry, None
+
+        # Compute the state derivatives kᵢ.
+        K, _ = jax.lax.scan(
+            f=scan_body,
+            init=carry0,
+            xs=jnp.arange(c.size),
+        )
+
+        # Update the FSAL property for the next iteration.
+        if self.has_fsal:
+            self.params["dxdt0"] = jax.tree_map(lambda l: l[self.index_of_fsal], K)
+
+        # Compute the output state.
+        # Note that z contains as many new states as the rows of `b.T`.
+        op = lambda x0, ki: x0 + Δt * jnp.dot(b.T, ki)
+        z = jax.tree_util.tree_map(op, x0, K)
+
+        return z
+
+    @staticmethod
+    def butcher_tableau_is_valid(
+        A: jax.typing.ArrayLike, b: jax.typing.ArrayLike, c: jax.typing.ArrayLike
+    ) -> jtp.Bool:
+        """
+        Check if the Butcher tableau is valid.
+
+        Args:
+            A: The Runge-Kutta matrix.
+            b: The weights coefficients.
+            c: The nodes coefficients.
+
+        Returns:
+            `True` if the Butcher tableau is valid, `False` otherwise.
+        """
+
+        valid = True
+        valid = valid and A.ndim == 2
+        valid = valid and b.ndim == 2
+        valid = valid and c.ndim == 1
+        valid = valid and b.T.shape[0] <= 2
+        valid = valid and A.shape[0] == A.shape[1]
+        valid = valid and A.shape == (c.size, b.T.shape[1])
+        valid = valid and bool(jnp.all(b.T.sum(axis=1) == 1))
+
+        return valid
+
+    @staticmethod
+    def butcher_tableau_is_explicit(A: jax.typing.ArrayLike) -> jtp.Bool:
+        """
+        Check if the Butcher tableau corresponds to an explicit integration scheme.
+
+        Args:
+            A: The Runge-Kutta matrix.
+
+        Returns:
+            `True` if the Butcher tableau is explicit, `False` otherwise.
+        """
+
+        return jnp.allclose(A, jnp.tril(A, k=-1))
+
+    @staticmethod
+    def butcher_tableau_supports_fsal(
+        A: jax.typing.ArrayLike,
+        b: jax.typing.ArrayLike,
+        c: jax.typing.ArrayLike,
+        index_of_solution: jtp.IntLike = 0,
+    ) -> [bool, int | None]:
+        """
+        Check if the Butcher tableau supports the FSAL (first-same-as-last) property.
+
+        Args:
+            A: The Runge-Kutta matrix.
+            b: The weights coefficients.
+            c: The nodes coefficients.
+            index_of_solution:
+                The index of the row of `b.T` corresponding to the solution.
+
+        Returns:
+            A tuple containing a boolean indicating whether the Butcher tableau supports
+            FSAL, and the index i of the intermediate kᵢ derivative corresponding to the
+            initial derivative `f(x0, t0)` of the next step.
+        """
+
+        if not ExplicitRungeKutta.butcher_tableau_is_valid(A=A, b=b, c=c):
+            raise ValueError("The Butcher tableau is not valid.")
+
+        if not ExplicitRungeKutta.butcher_tableau_is_explicit(A=A):
+            return False
+
+        if index_of_solution >= b.T.shape[0]:
+            msg = "The index of the solution (i-th row of `b.T`) is out of range."
+            raise ValueError(msg)
+
+        if c[0] != 0:
+            return False, None
+
+        # Find all the rows of A where c = 1 (therefore at t=tf). The Butcher tableau
+        # supports FSAL if any of these rows (there might be more rows with c=1) matches
+        # the rows of b.T corresponding to the next state (marked by `index_of_solution`).
+        # This last condition means that the last kᵢ derivative is computed at (tf, xf),
+        # that corresponds to the (t0, x0) pair of the next integration call.
+        rows_of_A_with_fsal = (A == b.T[None, index_of_solution]).all(axis=1)
+        rows_of_A_with_fsal = jnp.logical_and(rows_of_A_with_fsal, (c == 1))
+
+        # If there is no match, it means that the Butcher tableau does not support FSAL.
+        if not rows_of_A_with_fsal.any():
+            return False, None
+
+        # Return the index of the row of A providing the fsal derivative (that is the
+        # possibly intermediate kᵢ derivative).
+        # Note that if multiple rows match (it should not), we return the first match.
+        return True, int(jnp.where(rows_of_A_with_fsal == True)[0].tolist()[0])

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -1,6 +1,6 @@
 import abc
 import dataclasses
-from typing import Any, ClassVar, Generic, Protocol, Self, Type, TypeVar
+from typing import Any, ClassVar, Generic, Protocol, Type, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -14,6 +14,11 @@ try:
     from typing import override
 except ImportError:
     from typing_extensions import override
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 # =============

--- a/src/jaxsim/integrators/fixed_step.py
+++ b/src/jaxsim/integrators/fixed_step.py
@@ -1,18 +1,18 @@
-from typing import ClassVar
+from typing import ClassVar, Generic
 
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
 
-from .common import ExplicitRungeKutta
+from .common import ExplicitRungeKutta, PyTreeType
 
-# ================================
-# Explicit Runge-Kutta integrators
-# ================================
+# =====================================================
+# Explicit Runge-Kutta integrators operating on PyTrees
+# =====================================================
 
 
 @jax_dataclasses.pytree_dataclass
-class ForwardEuler(ExplicitRungeKutta):
+class ForwardEuler(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
     A: ClassVar[jax.typing.ArrayLike] = jnp.array(
         [
@@ -38,7 +38,8 @@ class ForwardEuler(ExplicitRungeKutta):
     order_of_bT_rows: ClassVar[tuple[int, ...]] = (1,)
 
 
-class Heun(ExplicitRungeKutta):
+@jax_dataclasses.pytree_dataclass
+class Heun(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
     A: ClassVar[jax.typing.ArrayLike] = jnp.array(
         [
@@ -63,7 +64,8 @@ class Heun(ExplicitRungeKutta):
     order_of_bT_rows: ClassVar[tuple[int, ...]] = (2,)
 
 
-class RungeKutta4(ExplicitRungeKutta):
+@jax_dataclasses.pytree_dataclass
+class RungeKutta4(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
     A: ClassVar[jax.typing.ArrayLike] = jnp.array(
         [

--- a/src/jaxsim/integrators/fixed_step.py
+++ b/src/jaxsim/integrators/fixed_step.py
@@ -1,0 +1,90 @@
+from typing import ClassVar
+
+import jax
+import jax.numpy as jnp
+import jax_dataclasses
+
+from .common import ExplicitRungeKutta
+
+# ================================
+# Explicit Runge-Kutta integrators
+# ================================
+
+
+@jax_dataclasses.pytree_dataclass
+class ForwardEuler(ExplicitRungeKutta):
+
+    A: ClassVar[jax.typing.ArrayLike] = jnp.array(
+        [
+            [0],
+        ]
+    ).astype(float)
+
+    b: ClassVar[jax.typing.ArrayLike] = (
+        jnp.array(
+            [
+                [1],
+            ]
+        )
+        .astype(float)
+        .transpose()
+    )
+
+    c: ClassVar[jax.typing.ArrayLike] = jnp.array(
+        [0],
+    ).astype(float)
+
+    row_index_of_solution: ClassVar[int] = 0
+    order_of_bT_rows: ClassVar[tuple[int, ...]] = (1,)
+
+
+class Heun(ExplicitRungeKutta):
+
+    A: ClassVar[jax.typing.ArrayLike] = jnp.array(
+        [
+            [0, 0],
+            [1 / 2, 0],
+        ]
+    ).astype(float)
+
+    b: ClassVar[jax.typing.ArrayLike] = (
+        jnp.atleast_2d(
+            jnp.array([1 / 2, 1 / 2]),
+        )
+        .astype(float)
+        .transpose()
+    )
+
+    c: ClassVar[jax.typing.ArrayLike] = jnp.array(
+        [0, 1],
+    ).astype(float)
+
+    row_index_of_solution: ClassVar[int] = 0
+    order_of_bT_rows: ClassVar[tuple[int, ...]] = (2,)
+
+
+class RungeKutta4(ExplicitRungeKutta):
+
+    A: ClassVar[jax.typing.ArrayLike] = jnp.array(
+        [
+            [0, 0, 0, 0],
+            [1 / 2, 0, 0, 0],
+            [0, 1 / 2, 0, 0],
+            [0, 0, 1, 0],
+        ]
+    ).astype(float)
+
+    b: ClassVar[jax.typing.ArrayLike] = (
+        jnp.atleast_2d(
+            jnp.array([1 / 6, 1 / 3, 1 / 3, 1 / 6]),
+        )
+        .astype(float)
+        .transpose()
+    )
+
+    c: ClassVar[jax.typing.ArrayLike] = jnp.array(
+        [0, 1 / 2, 1 / 2, 1],
+    ).astype(float)
+
+    row_index_of_solution: ClassVar[int] = 0
+    order_of_bT_rows: ClassVar[tuple[int, ...]] = (4,)

--- a/src/jaxsim/integrators/fixed_step.py
+++ b/src/jaxsim/integrators/fixed_step.py
@@ -3,8 +3,14 @@ from typing import ClassVar, Generic
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
+import jaxlie
 
-from .common import ExplicitRungeKutta, PyTreeType
+from jaxsim.simulation.ode_data import ODEState
+
+from .common import ExplicitRungeKutta, PyTreeType, Time, TimeStep
+
+ODEStateDerivative = ODEState
+
 
 # =====================================================
 # Explicit Runge-Kutta integrators operating on PyTrees
@@ -90,3 +96,63 @@ class RungeKutta4(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
     row_index_of_solution: ClassVar[int] = 0
     order_of_bT_rows: ClassVar[tuple[int, ...]] = (4,)
+
+
+# ===============================================================================
+# Explicit Runge-Kutta integrators operating on ODEState and integrating on SO(3)
+# ===============================================================================
+
+
+class ExplicitRungeKuttaSO3Mixin:
+    """
+    Mixin class to apply over explicit RK integrators defined on
+    `PyTreeType = ODEState` to integrate the quaternion on SO(3).
+    """
+
+    @classmethod
+    def post_process_state(
+        cls, x0: ODEState, t0: Time, xf: ODEState, dt: TimeStep
+    ) -> ODEState:
+
+        # Indices to convert quaternions between serializations.
+        to_xyzw = jnp.array([1, 2, 3, 0])
+        to_wxyz = jnp.array([3, 0, 1, 2])
+
+        # Get the initial quaternion.
+        W_Q_B_t0 = jaxlie.SO3.from_quaternion_xyzw(
+            xyzw=x0.physics_model.base_quaternion[to_xyzw]
+        )
+
+        # Get the final angular velocity.
+        # This is already computed by averaging the kᵢ in RK-based schemes.
+        # Therefore, by using the ω at tf, we obtain a RK scheme operating
+        # on the SO(3) manifold.
+        W_ω_WB_tf = xf.physics_model.base_angular_velocity
+
+        # Integrate the quaternion on SO(3).
+        # Note that we left-multiply with the exponential map since the angular
+        # velocity is expressed in the inertial frame.
+        W_Q_B_tf = jaxlie.SO3.exp(tangent=dt * W_ω_WB_tf) @ W_Q_B_t0
+
+        # Replace the quaternion in the final state.
+        return xf.replace(
+            physics_model=xf.physics_model.replace(
+                base_quaternion=W_Q_B_tf.as_quaternion_xyzw()[to_wxyz]
+            ),
+            validate=True,
+        )
+
+
+@jax_dataclasses.pytree_dataclass
+class ForwardEulerSO3(ExplicitRungeKuttaSO3Mixin, Heun[ODEState]):
+    pass
+
+
+@jax_dataclasses.pytree_dataclass
+class HeunSO3(ExplicitRungeKuttaSO3Mixin, Heun[ODEState]):
+    pass
+
+
+@jax_dataclasses.pytree_dataclass
+class RungeKutta4SO3(ExplicitRungeKuttaSO3Mixin, RungeKutta4[ODEState]):
+    pass

--- a/src/jaxsim/physics/algos/soft_contacts.py
+++ b/src/jaxsim/physics/algos/soft_contacts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from typing import Tuple
 
@@ -13,38 +15,67 @@ from jaxsim.math.adjoint import Adjoint
 from jaxsim.math.skew import Skew
 from jaxsim.physics.algos.terrain import FlatTerrain, Terrain
 from jaxsim.physics.model.physics_model import PhysicsModel
+from jaxsim.utils.jaxsim_dataclass import JaxsimDataclass
 
 from . import utils
 
 
 @jax_dataclasses.pytree_dataclass
-class SoftContactsState:
+class SoftContactsState(JaxsimDataclass):
     """
     State of the soft contacts model.
 
     Attributes:
-        tangential_deformation (jtp.Matrix): The tangential deformation of the material at each collidable point.
+        tangential_deformation:
+            The tangential deformation of the material at each collidable point.
     """
 
     tangential_deformation: jtp.Matrix
 
     @staticmethod
+    def build(
+        tangential_deformation: jtp.Matrix | None = None,
+        number_of_collidable_points: int | None = None,
+    ) -> SoftContactsState:
+        """"""
+
+        tangential_deformation = (
+            tangential_deformation
+            if tangential_deformation is not None
+            else jnp.zeros(shape=(3, number_of_collidable_points))
+        )
+
+        return SoftContactsState(
+            tangential_deformation=jnp.array(tangential_deformation, dtype=float)
+        )
+
+    @staticmethod
+    def build_from_physics_model(
+        tangential_deformation: jtp.Matrix | None = None,
+        physics_model: jaxsim.physics.model.physics_model.PhysicsModel | None = None,
+    ) -> SoftContactsState:
+        """"""
+
+        return SoftContactsState.build(
+            tangential_deformation=tangential_deformation,
+            number_of_collidable_points=physics_model.gc.body.size,
+        )
+
+    @staticmethod
     def zero(
         physics_model: jaxsim.physics.model.physics_model.PhysicsModel,
-    ) -> "SoftContactsState":
+    ) -> SoftContactsState:
         """
         Modify the SoftContactsState instance imposing zero tangential deformation.
 
         Args:
-            physics_model (jaxsim.physics.model.physics_model.PhysicsModel): The physics model.
+            physics_model: The physics model.
 
         Returns:
-            SoftContactsState: A SoftContactsState instance with zero tangential deformation.
+            A SoftContactsState instance with zero tangential deformation.
         """
 
-        return SoftContactsState(
-            tangential_deformation=jnp.zeros(shape=(3, physics_model.gc.body.size))
-        )
+        return SoftContactsState.build_from_physics_model(physics_model=physics_model)
 
     def valid(
         self, physics_model: jaxsim.physics.model.physics_model.PhysicsModel
@@ -53,10 +84,10 @@ class SoftContactsState:
         Check if the soft contacts state has valid shape.
 
         Args:
-            physics_model (jaxsim.physics.model.physics_model.PhysicsModel): The physics model.
+            physics_model: The physics model.
 
         Returns:
-            bool: True if the state has a valid shape, otherwise False.
+            True if the state has a valid shape, otherwise False.
         """
 
         from jaxsim.simulation.utils import check_valid_shape
@@ -67,22 +98,6 @@ class SoftContactsState:
             expected_shape=(3, physics_model.gc.body.size),
             valid=True,
         )
-
-    def replace(self, validate: bool = True, **kwargs) -> "SoftContactsState":
-        """
-        Replace attributes of the soft contacts state.
-
-        Args:
-            validate (bool, optional): Whether to validate the state after replacement. Defaults to True.
-
-        Returns:
-            SoftContactsState: A new SoftContactsState instance with replaced attributes.
-        """
-
-        with jax_dataclasses.copy_and_mutate(self, validate=validate) as updated_state:
-            _ = [updated_state.__setattr__(k, v) for k, v in kwargs.items()]
-
-        return updated_state
 
 
 def collidable_points_pos_vel(

--- a/src/jaxsim/simulation/ode_data.py
+++ b/src/jaxsim/simulation/ode_data.py
@@ -13,7 +13,24 @@ from jaxsim.utils import JaxsimDataclass
 
 @jax_dataclasses.pytree_dataclass
 class ODEInput(JaxsimDataclass):
+    """"""
+
     physics_model: PhysicsModelInput
+
+    @staticmethod
+    def build(
+        physics_model_input: PhysicsModelInput | None = None,
+        physics_model: PhysicsModel | None = None,
+    ) -> "ODEInput":
+        """"""
+
+        physics_model_input = (
+            physics_model_input
+            if physics_model_input is not None
+            else PhysicsModelInput.zero(physics_model=physics_model)
+        )
+
+        return ODEInput(physics_model=physics_model_input)
 
     @staticmethod
     def zero(physics_model: PhysicsModel) -> "ODEInput":
@@ -27,8 +44,34 @@ class ODEInput(JaxsimDataclass):
 
 @jax_dataclasses.pytree_dataclass
 class ODEState(JaxsimDataclass):
+    """"""
+
     physics_model: PhysicsModelState
     soft_contacts: SoftContactsState
+
+    @staticmethod
+    def build(
+        physics_model_state: PhysicsModelState | None = None,
+        soft_contacts_state: SoftContactsState | None = None,
+        physics_model: PhysicsModel | None = None,
+    ) -> "ODEState":
+        """"""
+
+        physics_model_state = (
+            physics_model_state
+            if physics_model_state is not None
+            else PhysicsModelState.zero(physics_model=physics_model)
+        )
+
+        soft_contacts_state = (
+            soft_contacts_state
+            if soft_contacts_state is not None
+            else SoftContactsState.zero(physics_model=physics_model)
+        )
+
+        return ODEState(
+            physics_model=physics_model_state, soft_contacts=soft_contacts_state
+        )
 
     @staticmethod
     def deserialize(data: jtp.VectorJax, physics_model: PhysicsModel) -> "ODEState":


### PR DESCRIPTION
These new functional APIs (`jaxsim.api`) will soon replace those based on OOP (`jaxsim.high_level`).

- Switch to [kiss](https://en.wikipedia.org/wiki/KISS_principle). The former OOP pattern, although more user friendly, fights back the functional JAX approach and required complex decorators to maintain and debug.
- Easier for users to extend / modify the logic. Instead of changing something deep down in the framework, they just have to update / rewrite a single function.
- Applying jax transforms like `jax.vmap` and `jax.grad` is more simple being more vanilla.

Furthermore, this PR:

- Introduces new functions to operate on links and joints through their indices. Although I never liked this approach (and using names is still an option), having also functions operating on indices enables the use of `jax.vmap` to iterate on links and joints.
- Introduces a new logic to get a good initial set of soft-contacts parameters based on the model inertial properties. In the past, tuning these parameters by hand has been quite difficult. The new logic provides a good starting point from which users can start iterating.
- The existing fixed-step integrators have been rewritten from scratch. The new structure is now compatible with the introduction of variable-step integrators (in a future PR). So far, only the explicit schemes have been ported. This time, all of them with variants that integrate the quaternion on $\text{SO}(3)$.

Some implementation detail that might ease the review process and the transition to the new APIs:

- The key data structures are now `JaxSimModel` and `JaxSimModelData`.
- Most of API functions take them as first two arguments. In order to have more stable APIs, and allow us to change the signature of functions in future versions, all others arguments are enforced to be `kwargs`.
- The velocity representation is now part of data (still as static attribute).
- The soft-contacts parameters is now part of data. Therefore, in a vectorized scenario, there could be different parameters for each data instance, enabling domain randomization on these parameters.
- The terrain instead is global and stored inside the model (therefore, it is not possible to parallelize a model over different terrains, that makes sense at least for now).

Next steps:

- Port semi-implicit integration schemes to the new APIs.
- Introduce variable-step integrators.
- Merge `jaxsim.api.model.JaxSimModel` with `jaxsim.physics.model.PhysicsModel`.
- Introduce a new pytree `KynDynParameters` to store inside `JaxSimModel` the model parameters, so that we can differentiate against them as well (we need also decent setters/getters).
- Introduce error handling for link/joint indices out of bound, and data objects not compatible with model.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--88.org.readthedocs.build//88/

<!-- readthedocs-preview jaxsim end -->