### PR TITLE
Document maintainers in CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,2 @@
+*       @diegoferigo @flferretti
+*.ipynb  @flferretti


### PR DESCRIPTION
This PR will add a CODEOWNERS file to assign maintainers automatically when PRs are opened.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--90.org.readthedocs.build//90/

<!-- readthedocs-preview jaxsim end -->