### PR TITLE
Add camera support to `jaxsim.mujoco` visualizer

### DIFF
--- a/src/jaxsim/mujoco/__init__.py
+++ b/src/jaxsim/mujoco/__init__.py
@@ -1,3 +1,3 @@
 from .loaders import RodModelToMjcf, SdfToMjcf, UrdfToMjcf
 from .model import MujocoModelHelper
-from .visualizer import MujocoVisualizer
+from .visualizer import MujocoVideoRecorder, MujocoVisualizer

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -423,6 +423,36 @@ class RodModelToMjcf:
                 pos="1 0 5",
             )
 
+        # -------------------------------------------------------
+        # Add a camera following the CoM of the worldbody element
+        # -------------------------------------------------------
+
+        worldbody_element = None
+
+        # Find the <worldbody> element of our model by searching the one that contains
+        # all the considered joints. This is needed because there might be multiple
+        # <worldbody> elements inside <mujoco>.
+        for wb in mujoco_element.findall(".//worldbody"):
+            if all(
+                wb.find(f".//joint[@name='{j}']") is not None for j in considered_joints
+            ):
+                worldbody_element = wb
+                break
+
+        if worldbody_element is None:
+            raise RuntimeError("Failed to find the <worldbody> element of the model")
+
+        # Camera attached to the model
+        _ = ET.SubElement(
+            worldbody_element,
+            "camera",
+            name="track",
+            mode="trackcom",
+            pos="1 0 5",
+            zaxis="0 0 1",
+            fovy="60",
+        )
+
         # --------------------------------
         # Return the resulting MJCF string
         # --------------------------------

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -387,42 +387,6 @@ class RodModelToMjcf:
             dir="0 0 -1",
         )
 
-        # ------------------------------------------------
-        # Add a light following the  CoM of the first link
-        # ------------------------------------------------
-
-        if not rod_model.is_fixed_base():
-
-            worldbody_element = None
-
-            # Find the <worldbody> element of our model by searching the one that contains
-            # all the considered joints. This is needed because there might be multiple
-            # <worldbody> elements inside <mujoco>.
-            for wb in mujoco_element.findall(".//worldbody"):
-                if all(
-                    wb.find(f".//joint[@name='{j}']") is not None
-                    for j in considered_joints
-                ):
-                    worldbody_element = wb
-                    break
-
-            if worldbody_element is None:
-                raise RuntimeError(
-                    "Failed to find the <worldbody> element of the model"
-                )
-
-            # Light attached to the model
-            _ = ET.SubElement(
-                worldbody_element,
-                "light",
-                name="light_model",
-                mode="targetbodycom",
-                target=worldbody_element.find(".//body").attrib["name"],
-                directional="false",
-                castshadow="true",
-                pos="1 0 5",
-            )
-
         # -------------------------------------------------------
         # Add a camera following the CoM of the worldbody element
         # -------------------------------------------------------
@@ -452,6 +416,24 @@ class RodModelToMjcf:
             zaxis="0 0 1",
             fovy="60",
         )
+
+        # ------------------------------------------------
+        # Add a light following the  CoM of the first link
+        # ------------------------------------------------
+
+        if not rod_model.is_fixed_base():
+
+            # Light attached to the model
+            _ = ET.SubElement(
+                worldbody_element,
+                "light",
+                name="light_model",
+                mode="targetbodycom",
+                target=worldbody_element.find(".//body").attrib["name"],
+                directional="false",
+                castshadow="true",
+                pos="1 0 5",
+            )
 
         # --------------------------------
         # Return the resulting MJCF string

--- a/src/jaxsim/mujoco/visualizer.py
+++ b/src/jaxsim/mujoco/visualizer.py
@@ -54,14 +54,16 @@ class MujocoVideoRecorder:
 
     def render_frame(self, camera_name: str | None = None) -> npt.NDArray:
         """"""
+        camera_name = camera_name or "track"
 
         mujoco.mj_forward(self.model, self.data)
-        self.renderer.update_scene(data=self.data)  # TODO camera name
+        self.renderer.update_scene(data=self.data, camera=camera_name)
 
         return self.renderer.render()
 
     def record_frame(self, camera_name: str | None = None) -> None:
         """"""
+        camera_name = camera_name or "track"
 
         frame = self.render_frame(camera_name=camera_name)
         self.frames.append(frame)


### PR DESCRIPTION
This PR adds support for camera visualization in `jaxsim.mujoco`. It includes the addition of a camera attribute to the worldbody element and updates to the `MujocoVideoRecorder` class to render frames using the specified camera.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--91.org.readthedocs.build//91/

<!-- readthedocs-preview jaxsim end -->