### PR TITLE
Initialize JAX configuration as per the v0.4.25 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ package_dir =
 python_requires = >=3.11
 install_requires =
     coloredlogs
-    jax >= 0.4.13
+    jax >= 0.4.13,<0.4.25
     jaxlib
     jaxlie >= 1.3.0
     jax_dataclasses >= 1.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ python_requires = >=3.11
 install_requires =
     coloredlogs
     jax >= 0.4.13,<0.4.25
-    jaxlib
+    jaxlib >= 0.4.13,<0.4.25
     jaxlie >= 1.3.0
     jax_dataclasses >= 1.4.0
     pptree

--- a/src/jaxsim/__init__.py
+++ b/src/jaxsim/__init__.py
@@ -6,12 +6,12 @@ from ._version import __version__
 def _jnp_options() -> None:
     import os
 
-    from jax.config import config
+    import jax
 
     # Enable by default
     if not ("JAX_ENABLE_X64" in os.environ and os.environ["JAX_ENABLE_X64"] == "0"):
         logging.info("Enabling JAX to use 64bit precision")
-        config.update("jax_enable_x64", True)
+        jax.config.update("jax_enable_x64", True)
 
         import jax.numpy as jnp
         import numpy as np


### PR DESCRIPTION
This PR will update the JAX configuration initialization as per [JAX v0.4.25](https://github.com/google/jax/releases/tag/jax-v0.4.25), in which the access to `jax.config` has been deprecated, leading to `ImportError: cannot import name 'config' from 'jax.config'`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--92.org.readthedocs.build//92/

<!-- readthedocs-preview jaxsim end -->