### PR TITLE
Add workflow_dispatch and schedule events to ci_cd workflow and constraint jax<0.4.25 to be

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -89,6 +89,10 @@ jobs:
         shell: bash
         run: pip install "$(find dist/ -type f -name '*.whl')"
 
+      - name: Document installed pip packages
+        shell: bash
+        run: pip list --verbose
+      
       - name: Import the package
         run: python -c "import jaxsim"
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,11 +1,17 @@
 name: Python CI/CD
 
 on:
+  workflow_dispatch:
   push:
   pull_request:
   release:
     types:
       - published
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
+
 
 jobs:
 

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -99,32 +99,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            src: &src
-              - 'src/**'
-            tests: &tests
-              - 'tests/**'
-            src_and_tests:
-              - *src
-              - *tests
 
       - name: Install Gazebo Classic
-        if: |
-          contains(matrix.os, 'ubuntu') &&
-          (github.event_name != 'pull_request' ||
-           steps.changes.outputs.src_and_tests == 'true')
+        if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install gazebo
 
       - name: Run the Python tests
-        if: |
-          contains(matrix.os, 'ubuntu') &&
-          (github.event_name != 'pull_request' ||
-           steps.changes.outputs.src_and_tests == 'true')
+        if: contains(matrix.os, 'ubuntu')
         run: pytest
         env:
           JAX_PLATFORM_NAME: cpu

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,8 +53,8 @@ package_dir =
 python_requires = >=3.11
 install_requires =
     coloredlogs
-    jax >= 0.4.13
-    jaxlib
+    jax >= 0.4.13,< 0.4.25
+    jaxlib >= 0.4.13,< 0.4.25
     jaxlie >= 1.3.0
     jax_dataclasses >= 1.4.0
     pptree


### PR DESCRIPTION
Changes:

* The CI/CD job use a rolling release distribution for dependencies, if I am not wrong. That is fine, but in that case to track regressions it is convenient to build periodically, and permit to trigger CI jobs run manually.
* Pin jax to be < 0.4.25, as there have current jaxsim does not work fine with jax==0.4.25
* Revert https://github.com/ami-iit/jaxsim/pull/80, as we are currently installing dependencies from a rolling release distribution (PyPI) and so it is possible that there is a test failure even if nothing changed in source files. We can introduce something similar if we start using a lockfile of some kind, if we add the logic also to check changes in the lockfile.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--93.org.readthedocs.build//93/

<!-- readthedocs-preview jaxsim end -->