### PR TITLE
Remove --forked from pytest as workaround for jax 0.4.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ multi_line_output = 3
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-rsxX -v --strict-markers --forked"
+# --forked used to be passed here, but it was removed
+# as workaround for compatibility with jax 0.4.25,
+# see https://github.com/ami-iit/jaxsim/pull/92#issuecomment-1966290170 
+addopts = "-rsxX -v --strict-markers"
 testpaths = [
     "tests",
 ]


### PR DESCRIPTION


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--94.org.readthedocs.build//94/

<!-- readthedocs-preview jaxsim end -->