### PR TITLE
Add `jaxsim.api.references` with functional resources to handle model references

### DIFF
--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -1,0 +1,205 @@
+import abc
+import contextlib
+import dataclasses
+import functools
+from typing import ContextManager
+
+import jax
+import jax.numpy as jnp
+import jax_dataclasses
+import jaxlie
+from jax_dataclasses import Static
+
+import jaxsim.typing as jtp
+from jaxsim.high_level.common import VelRepr
+from jaxsim.utils import JaxsimDataclass, Mutability
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+
+@jax_dataclasses.pytree_dataclass
+class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
+    """
+    Base class for model data structures with velocity representation.
+    """
+
+    velocity_representation: Static[VelRepr] = dataclasses.field(
+        default=VelRepr.Inertial, kw_only=True
+    )
+
+    @contextlib.contextmanager
+    def switch_velocity_representation(
+        self, velocity_representation: VelRepr
+    ) -> ContextManager[Self]:
+        """
+        Context manager to temporarily switch the velocity representation.
+
+        Args:
+            velocity_representation: The new velocity representation.
+
+        Yields:
+            The same object with the new velocity representation.
+        """
+
+        original_representation = self.velocity_representation
+
+        try:
+
+            # First, we replace the velocity representation
+            with self.mutable_context(
+                mutability=Mutability.MUTABLE_NO_VALIDATION,
+                restore_after_exception=True,
+            ):
+                self.velocity_representation = velocity_representation
+
+            # Then, we yield the data with changed representation.
+            # We run this in a mutable context with restoration so that any exception
+            # occurring, we restore the original object in case it was modified.
+            with self.mutable_context(
+                mutability=self._mutability(), restore_after_exception=True
+            ):
+                yield self
+
+        finally:
+            with self.mutable_context(
+                mutability=Mutability.MUTABLE_NO_VALIDATION,
+                restore_after_exception=True,
+            ):
+                self.velocity_representation = original_representation
+
+    @staticmethod
+    @functools.partial(jax.jit, static_argnames=["other_representation", "is_force"])
+    def inertial_to_other_representation(
+        array: jtp.Array,
+        other_representation: VelRepr,
+        transform: jtp.Matrix,
+        is_force: bool = False,
+    ) -> jtp.Array:
+        """
+        Convert a 6D quantity from inertial-fixed to another representation.
+
+        Args:
+            array: The 6D quantity to convert.
+            other_representation: The representation to convert to.
+            transform:
+                The `math:W \mathbf{H}_O` transform, where `math:O` is the
+                reference frame of the other representation.
+            is_force: Whether the quantity is a 6D force or a 6D velocity.
+
+        Returns:
+            The 6D quantity in the other representation.
+        """
+
+        W_array = array.squeeze()
+        W_H_O = transform.squeeze()
+
+        if W_array.size != 6:
+            raise ValueError(W_array.size, 6)
+
+        if W_H_O.shape != (4, 4):
+            raise ValueError(W_H_O.shape, (4, 4))
+
+        match other_representation:
+
+            case VelRepr.Inertial:
+                return W_array
+
+            case VelRepr.Body:
+
+                if not is_force:
+                    O_Xv_W = jaxlie.SE3.from_matrix(W_H_O).inverse().adjoint()
+                    O_array = O_Xv_W @ W_array
+
+                else:
+                    O_Xf_W = jaxlie.SE3.from_matrix(W_H_O).adjoint().T
+                    O_array = O_Xf_W @ W_array
+
+                return O_array
+
+            case VelRepr.Mixed:
+                W_p_O = W_H_O[0:3, 3]
+                W_H_OW = jnp.eye(4).at[0:3, 3].set(W_p_O)
+
+                if not is_force:
+                    OW_Xv_W = jaxlie.SE3.from_matrix(W_H_OW).inverse().adjoint()
+                    OW_array = OW_Xv_W @ W_array
+
+                else:
+                    OW_Xf_W = jaxlie.SE3.from_matrix(W_H_OW).adjoint().transpose()
+                    OW_array = OW_Xf_W @ W_array
+
+                return OW_array
+
+            case _:
+                raise ValueError(other_representation)
+
+    @staticmethod
+    @functools.partial(jax.jit, static_argnames=["other_representation", "is_force"])
+    def other_representation_to_inertial(
+        array: jtp.Array,
+        other_representation: VelRepr,
+        transform: jtp.Matrix,
+        is_force: bool = False,
+    ) -> jtp.Array:
+        """
+        Convert a 6D quantity from another representation to inertial-fixed.
+
+        Args:
+            array: The 6D quantity to convert.
+            other_representation: The representation to convert from.
+            transform:
+                The `math:W \mathbf{H}_O` transform, where `math:O` is the
+                reference frame of the other representation.
+            is_force: Whether the quantity is a 6D force or a 6D velocity.
+
+        Returns:
+            The 6D quantity in the inertial-fixed representation.
+        """
+
+        W_array = array.squeeze()
+        W_H_O = transform.squeeze()
+
+        if W_array.size != 6:
+            raise ValueError(W_array.size, 6)
+
+        if W_H_O.shape != (4, 4):
+            raise ValueError(W_H_O.shape, (4, 4))
+
+        match other_representation:
+            case VelRepr.Inertial:
+                W_array = array
+                return W_array
+
+            case VelRepr.Body:
+                O_array = array
+
+                if not is_force:
+                    W_Xv_O: jtp.Array = jaxlie.SE3.from_matrix(W_H_O).adjoint()
+                    W_array = W_Xv_O @ O_array
+
+                else:
+                    W_Xf_O = jaxlie.SE3.from_matrix(W_H_O).inverse().adjoint().T
+                    W_array = W_Xf_O @ O_array
+
+                return W_array
+
+            case VelRepr.Mixed:
+                BW_array = array
+                W_p_O = W_H_O[0:3, 3]
+                W_H_OW = jnp.eye(4).at[0:3, 3].set(W_p_O)
+
+                if not is_force:
+                    W_Xv_BW: jtp.Array = jaxlie.SE3.from_matrix(W_H_OW).adjoint()
+                    W_array = W_Xv_BW @ BW_array
+
+                else:
+                    W_Xf_BW = jaxlie.SE3.from_matrix(W_H_OW).inverse().adjoint().T
+                    W_array = W_Xf_BW @ BW_array
+
+                return W_array
+
+            case _:
+                raise ValueError(other_representation)

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import contextlib
 import dataclasses
 import functools
-from typing import ContextManager, Sequence
+from typing import Sequence
 
 import jax
 import jax.numpy as jnp

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -10,7 +10,6 @@ import jax.numpy as jnp
 import jax_dataclasses
 import jaxlie
 import numpy as np
-from jax_dataclasses import Static
 
 import jaxsim.api
 import jaxsim.physics.algos.aba
@@ -23,7 +22,9 @@ import jaxsim.typing as jtp
 from jaxsim.high_level.common import VelRepr
 from jaxsim.physics.algos import soft_contacts
 from jaxsim.simulation.ode_data import ODEState
-from jaxsim.utils import JaxsimDataclass, Mutability
+from jaxsim.utils import Mutability
+
+from . import common
 
 try:
     from typing import Self
@@ -32,7 +33,7 @@ except ImportError:
 
 
 @jax_dataclasses.pytree_dataclass
-class JaxSimModelData(JaxsimDataclass):
+class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     """
     Class containing the state of a `JaxSimModel` object.
     """
@@ -47,8 +48,6 @@ class JaxSimModelData(JaxsimDataclass):
     time_ns: jtp.Int = dataclasses.field(
         default_factory=lambda: jnp.array(0, dtype=jnp.uint64)
     )
-
-    velocity_representation: Static[VelRepr] = VelRepr.Inertial
 
     def valid(self, model: jaxsim.api.model.JaxSimModel | None = None) -> bool:
         """
@@ -67,46 +66,6 @@ class JaxSimModelData(JaxsimDataclass):
             valid = valid and self.state.valid(physics_model=model.physics_model)
 
         return valid
-
-    @contextlib.contextmanager
-    def switch_velocity_representation(
-        self, velocity_representation: VelRepr
-    ) -> ContextManager[Self]:
-        """
-        Context manager to temporarily switch the velocity representation.
-
-        Args:
-            velocity_representation: The new velocity representation.
-
-        Yields:
-            The same `JaxSimModelData` object with the new velocity representation.
-        """
-
-        original_representation = self.velocity_representation
-
-        try:
-
-            # First, we replace the velocity representation
-            with self.mutable_context(
-                mutability=Mutability.MUTABLE_NO_VALIDATION,
-                restore_after_exception=True,
-            ):
-                self.velocity_representation = velocity_representation
-
-            # Then, we yield the data with changed representation.
-            # We run this in a mutable context with restoration so that any exception
-            # occurring, we restore the original object in case it was modified.
-            with self.mutable_context(
-                mutability=self._mutability(), restore_after_exception=True
-            ):
-                yield self
-
-        finally:
-            with self.mutable_context(
-                mutability=Mutability.MUTABLE_NO_VALIDATION,
-                restore_after_exception=True,
-            ):
-                self.velocity_representation = original_representation
 
     @staticmethod
     def zero(
@@ -731,144 +690,6 @@ class JaxSimModelData(JaxsimDataclass):
                 )
             ),
         )
-
-    # =============
-    # Other helpers
-    # =============
-
-    @staticmethod
-    @functools.partial(jax.jit, static_argnames=["other_representation", "is_force"])
-    def inertial_to_other_representation(
-        array: jtp.Array,
-        other_representation: VelRepr,
-        transform: jtp.Matrix,
-        is_force: bool = False,
-    ) -> jtp.Array:
-        """
-        Convert a 6D quantity from the inertial to another representation.
-
-        Args:
-            array: The 6D quantity to convert.
-            other_representation: The representation to convert to.
-            transform:
-                The `math:W \mathbf{H}_O` transform, where `math:O` is the
-                reference frame of the other representation.
-            is_force: Whether the quantity is a 6D force or 6D velocity.
-
-        Returns:
-            The 6D quantity in the other representation.
-        """
-
-        W_array = array.squeeze()
-        W_H_O = transform.squeeze()
-
-        if W_array.size != 6:
-            raise ValueError(W_array.size, 6)
-
-        if W_H_O.shape != (4, 4):
-            raise ValueError(W_H_O.shape, (4, 4))
-
-        match other_representation:
-
-            case VelRepr.Inertial:
-                return W_array
-
-            case VelRepr.Body:
-
-                if not is_force:
-                    O_Xv_W = jaxlie.SE3.from_matrix(W_H_O).inverse().adjoint()
-                    O_array = O_Xv_W @ W_array
-
-                else:
-                    O_Xf_W = jaxlie.SE3.from_matrix(W_H_O).adjoint().T
-                    O_array = O_Xf_W @ W_array
-
-                return O_array
-
-            case VelRepr.Mixed:
-                W_p_O = W_H_O[0:3, 3]
-                W_H_OW = jnp.eye(4).at[0:3, 3].set(W_p_O)
-
-                if not is_force:
-                    OW_Xv_W = jaxlie.SE3.from_matrix(W_H_OW).inverse().adjoint()
-                    OW_array = OW_Xv_W @ W_array
-
-                else:
-                    OW_Xf_W = jaxlie.SE3.from_matrix(W_H_OW).adjoint().transpose()
-                    OW_array = OW_Xf_W @ W_array
-
-                return OW_array
-
-            case _:
-                raise ValueError(other_representation)
-
-    @staticmethod
-    @functools.partial(jax.jit, static_argnames=["other_representation", "is_force"])
-    def other_representation_to_inertial(
-        array: jtp.Array,
-        other_representation: VelRepr,
-        transform: jtp.Matrix,
-        is_force: bool = False,
-    ) -> jtp.Array:
-        """
-        Convert a 6D quantity from another representation to the inertial.
-
-        Args:
-            array: The 6D quantity to convert.
-            other_representation: The representation to convert from.
-            transform:
-                The `math:W \mathbf{H}_O` transform, where `math:O` is the
-                reference frame of the other representation.
-            is_force: Whether the quantity is a 6D force or 6D velocity.
-
-        Returns:
-            The 6D quantity in the inertial representation.
-        """
-
-        W_array = array.squeeze()
-        W_H_O = transform.squeeze()
-
-        if W_array.size != 6:
-            raise ValueError(W_array.size, 6)
-
-        if W_H_O.shape != (4, 4):
-            raise ValueError(W_H_O.shape, (4, 4))
-
-        match other_representation:
-            case VelRepr.Inertial:
-                W_array = array
-                return W_array
-
-            case VelRepr.Body:
-                O_array = array
-
-                if not is_force:
-                    W_Xv_O: jtp.Array = jaxlie.SE3.from_matrix(W_H_O).adjoint()
-                    W_array = W_Xv_O @ O_array
-
-                else:
-                    W_Xf_O = jaxlie.SE3.from_matrix(W_H_O).inverse().adjoint().T
-                    W_array = W_Xf_O @ O_array
-
-                return W_array
-
-            case VelRepr.Mixed:
-                BW_array = array
-                W_p_O = W_H_O[0:3, 3]
-                W_H_OW = jnp.eye(4).at[0:3, 3].set(W_p_O)
-
-                if not is_force:
-                    W_Xv_BW: jtp.Array = jaxlie.SE3.from_matrix(W_H_OW).adjoint()
-                    W_array = W_Xv_BW @ BW_array
-
-                else:
-                    W_Xf_BW = jaxlie.SE3.from_matrix(W_H_OW).inverse().adjoint().T
-                    W_array = W_Xf_BW @ BW_array
-
-                return W_array
-
-            case _:
-                raise ValueError(other_representation)
 
 
 def random_model_data(

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.numpy as jnp
+import jax_dataclasses
+
+import jaxsim.api as js
+import jaxsim.physics.model.physics_model_state
+import jaxsim.typing as jtp
+from jaxsim import VelRepr
+from jaxsim.simulation.ode_data import ODEInput
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+
+@jax_dataclasses.pytree_dataclass
+class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
+    """
+    Class containing the references for a `JaxSimModel` object.
+    """
+
+    input: ODEInput
+
+    @staticmethod
+    def zero(
+        model: js.model.JaxSimModel,
+        velocity_representation: VelRepr = VelRepr.Inertial,
+    ) -> JaxSimModelReferences:
+        """
+        Create a `JaxSimModelReferences` object with zero references.
+
+        Args:
+            model: The model for which to create the zero references.
+            velocity_representation: The velocity representation to use.
+
+        Returns:
+            A `JaxSimModelReferences` object with zero state.
+        """
+
+        return JaxSimModelReferences.build(
+            model=model, velocity_representation=velocity_representation
+        )
+
+    @staticmethod
+    def build(
+        model: js.model.JaxSimModel,
+        joint_force_references: jtp.Vector | None = None,
+        link_forces: jtp.Matrix | None = None,
+        data: js.data.JaxSimModelData | None = None,
+        velocity_representation: VelRepr = VelRepr.Inertial,
+    ) -> JaxSimModelReferences:
+        """
+        Create a `JaxSimModelReferences` object with the given references.
+
+        Args:
+            model: The model for which to create the state.
+            joint_force_references: The joint force references.
+            link_forces: The link 6D forces in the desired representation.
+            data:
+                The data of the model, only needed if the velocity representation is
+                not inertial-fixed.
+            velocity_representation: The velocity representation to use.
+
+        Returns:
+            A `JaxSimModelReferences` object with the given references.
+        """
+
+        # Create or adjust joint force references.
+        joint_force_references = jnp.atleast_1d(
+            joint_force_references.squeeze()
+            if joint_force_references is not None
+            else jnp.zeros(model.dofs())
+        ).astype(float)
+
+        # Create or adjust link forces.
+        f_L = jnp.atleast_2d(
+            link_forces.squeeze()
+            if link_forces is not None
+            else jnp.zeros((model.number_of_links(), 6))
+        ).astype(float)
+
+        # Create a zero references object.
+        references = JaxSimModelReferences(
+            input=ODEInput.zero(physics_model=model.physics_model),
+            velocity_representation=velocity_representation,
+        )
+
+        # Store the joint force references.
+        references = references.set_joint_force_references(
+            forces=joint_force_references,
+            model=model,
+            joint_names=model.joint_names(),
+        )
+
+        # Apply the link forces.
+        references = references.apply_link_forces(
+            forces=f_L,
+            model=model,
+            data=data,
+            link_names=model.link_names(),
+            additive=False,
+        )
+
+        return references
+
+    def valid(self, model: js.model.JaxSimModel | None = None) -> bool:
+        """
+        Check if the current references are valid for the given model.
+
+        Args:
+            model: The model to check against.
+
+        Returns:
+            `True` if the current references are valid for the given model,
+            `False` otherwise.
+        """
+
+        valid = True
+
+        if model is not None:
+            valid = valid and self.input.valid(physics_model=model.physics_model)
+
+        return valid
+
+    # ==================
+    # Extract quantities
+    # ==================
+
+    @functools.partial(jax.jit, static_argnames=["link_names"])
+    def link_forces(
+        self,
+        model: js.model.JaxSimModel | None = None,
+        data: js.data.JaxSimModelData | None = None,
+        link_names: tuple[str, ...] | None = None,
+    ) -> jtp.Matrix:
+        """
+        Return the link forces expressed in the frame of the active representation.
+
+        Args:
+            model: The model to consider.
+            data: The data of the considered model.
+            link_names: The names of the links corresponding to the forces.
+
+        Returns:
+            If no model and no link names are provided, the link forces as a
+            `(n_links,6)` matrix corresponding to the default link serialization
+            of the original model used to build the actuation object.
+            If a model is provided and no link names are provided, the link forces
+            as a `(n_links,6)` matrix corresponding to the serialization of the
+            provided model.
+            If both a model and link names are provided, the link forces as a
+            `(len(link_names),6)` matrix corresponding to the serialization of
+            the passed link names vector.
+
+        Note:
+            The returned link forces are those passed as user inputs when integrating
+            the dynamics of the model. They are summed with other forces related
+            e.g. to the contact model and other kinematic constraints.
+        """
+
+        W_f_L = self.input.physics_model.f_ext
+
+        # Helper function to convert a single 6D force to the active representation.
+        def convert(f_L: jtp.Vector, W_H_L: jtp.Matrix) -> jtp.Vector:
+            return JaxSimModelReferences.inertial_to_other_representation(
+                array=f_L,
+                other_representation=self.velocity_representation,
+                transform=W_H_L,
+                is_force=True,
+            )
+
+        # Return all link forces in inertial-fixed representation using the implicit
+        # serialization.
+        if model is None:
+            if self.velocity_representation is not VelRepr.Inertial:
+                msg = "Missing model to use a representation different from {}"
+                raise ValueError(msg.format(VelRepr.Inertial.name))
+
+            if link_names is not None:
+                raise ValueError("Link names cannot be provided without a model")
+
+            return self.input.physics_model.f_ext
+
+        # If we have the model, we can extract the link names, if not provided.
+        link_names = link_names if link_names is not None else model.link_names()
+        link_idxs = jaxsim.api.link.names_to_idxs(link_names=link_names, model=model)
+
+        # In inertial-fixed representation, we already have the link forces.
+        if self.velocity_representation is VelRepr.Inertial:
+            return W_f_L[link_idxs, :]
+
+        if data is None:
+            msg = "Missing model data to use a representation different from {}"
+            raise ValueError(msg.format(VelRepr.Inertial.name))
+
+        if not data.valid(model=model):
+            raise ValueError("The provided data is not valid for the model")
+
+        # Convert to the desired representation.
+        W_H_L = js.model.forward_kinematics(model=model, data=data)
+        f_L = jax.vmap(convert)(W_f_L[link_idxs, :], W_H_L[link_idxs, :, :])
+
+        return f_L
+
+    def joint_force_references(
+        self,
+        model: js.model.JaxSimModel | None = None,
+        joint_names: tuple[str, ...] | None = None,
+    ) -> jtp.Vector:
+        """
+        Return the joint force references.
+
+        Args:
+            model: The model to consider.
+            joint_names: The names of the joints corresponding to the forces.
+
+        Returns:
+            If no model and no joint names are provided, the joint forces as a
+            `(DoFs,)` vector corresponding to the default joint serialization
+            of the original model used to build the actuation object.
+            If a model is provided and no joint names are provided, the joint forces
+            as a `(DoFs,)` vector corresponding to the serialization of the
+            provided model.
+            If both a model and joint names are provided, the joint forces as a
+            `(len(joint_names),)` vector corresponding to the serialization of
+            the passed joint names vector.
+
+        Note:
+            The returned joint forces are those passed as user inputs when integrating
+            the dynamics of the model. They are summed with other joint forces related
+            e.g. to the enforcement of other kinematic constraints. Keep also in mind
+            that the presence of joint friction and other similar effects can make the
+            actual joint forces different from the references.
+        """
+
+        if model is None:
+            if joint_names is not None:
+                raise ValueError("Joint names cannot be provided without a model")
+
+            return self.input.physics_model.tau
+
+        if not self.valid(model=model):
+            msg = "The actuation object is not compatible with the provided model"
+            raise ValueError(msg)
+
+        joint_names = joint_names if joint_names is not None else model.joint_names()
+        joint_idxs = js.joint.names_to_idxs(joint_names=joint_names, model=model)
+
+        return jnp.atleast_1d(
+            self.input.physics_model.tau[joint_idxs].squeeze()
+        ).astype(float)
+
+    # ================
+    # Store quantities
+    # ================
+
+    @functools.partial(jax.jit, static_argnames=["joint_names"])
+    def set_joint_force_references(
+        self,
+        forces: jtp.VectorLike,
+        model: js.model.JaxSimModel | None = None,
+        joint_names: tuple[str, ...] | None = None,
+    ) -> Self:
+        """
+        Set the joint force references.
+
+        Args:
+            forces: The joint force references.
+            model:
+                The model to consider, only needed if a joint serialization different
+                from the implicit one is used.
+            joint_names: The names of the joints corresponding to the forces.
+
+        Returns:
+            A new `JaxSimModelReferences` object with the given joint force references.
+        """
+
+        forces = jnp.array(forces)
+
+        def replace(forces: jtp.VectorLike) -> JaxSimModelReferences:
+            return self.replace(
+                validate=True,
+                input=self.input.replace(
+                    physics_model=self.input.physics_model.replace(
+                        tau=jnp.atleast_1d(forces.squeeze()).astype(float)
+                    )
+                ),
+            )
+
+        if model is None:
+            return replace(forces=forces)
+
+        if not self.valid(model=model):
+            msg = "The references object is not compatible with the provided model"
+            raise ValueError(msg)
+
+        joint_names = joint_names if joint_names is not None else model.joint_names()
+        joint_idxs = js.joint.names_to_idxs(joint_names=joint_names, model=model)
+
+        return replace(forces=self.input.physics_model.tau.at[joint_idxs].set(forces))
+
+    @functools.partial(jax.jit, static_argnames=["link_names", "additive"])
+    def apply_link_forces(
+        self,
+        forces: jtp.MatrixLike,
+        model: js.model.JaxSimModel | None = None,
+        data: js.data.JaxSimModelData | None = None,
+        link_names: tuple[str, ...] | None = None,
+        additive: bool = False,
+    ) -> Self:
+        """
+        Apply the link forces.
+
+        Args:
+            forces: The link 6D forces in the active representation.
+            model:
+                The model to consider, only needed if a link serialization different
+                from the implicit one is used.
+            data:
+                The data of the considered model, only needed if the velocity
+                representation is not inertial-fixed.
+            link_names: The names of the links corresponding to the forces.
+            additive:
+                Whether to add the forces to the existing ones instead of replacing them.
+
+        Returns:
+            A new `JaxSimModelReferences` object with the given link forces.
+
+        Note:
+            The link forces must be expressed in the active representation.
+            Then, we always convert and store forces in inertial-fixed representation.
+        """
+
+        f_L = jnp.array(forces)
+
+        # Helper function to replace the link forces.
+        def replace(forces: jtp.MatrixLike) -> JaxSimModelReferences:
+            return self.replace(
+                validate=True,
+                input=self.input.replace(
+                    physics_model=self.input.physics_model.replace(
+                        f_ext=jnp.atleast_2d(forces.squeeze()).astype(float)
+                    )
+                ),
+            )
+
+        # Helper function to convert a single 6D force to the inertial representation.
+        def convert(f_L: jtp.Vector, W_H_L: jtp.Matrix) -> jtp.Vector:
+            return JaxSimModelReferences.other_representation_to_inertial(
+                array=f_L,
+                other_representation=self.velocity_representation,
+                transform=W_H_L,
+                is_force=True,
+            )
+
+        # In this case, we allow only to set the inertial 6D forces to all links
+        # using the implicit link serialization.
+        if model is None:
+            if self.velocity_representation is not VelRepr.Inertial:
+                msg = "Missing model to use a representation different from {}"
+                raise ValueError(msg.format(VelRepr.Inertial.name))
+
+            if link_names is not None:
+                raise ValueError("Link names cannot be provided without a model")
+
+            W_f_L = f_L
+
+            W_f0_L = (
+                jnp.zeros_like(W_f_L)
+                if not additive
+                else self.input.physics_model.f_ext
+            )
+
+            return replace(forces=W_f0_L + W_f_L)
+
+        # If we have the model, we can extract the link names if not provided.
+        link_names = link_names if link_names is not None else model.link_names()
+        link_idxs = jaxsim.api.link.names_to_idxs(link_names=link_names, model=model)
+
+        # Compute the bias depending on whether we either set or add the link forces.
+        W_f0_L = (
+            jnp.zeros_like(f_L)
+            if not additive
+            else self.input.physics_model.f_ext[link_idxs, :]
+        )
+
+        # If inertial-fixed representation, we can directly store the link forces.
+        if self.velocity_representation is VelRepr.Inertial:
+            W_f_L = f_L
+            return replace(
+                forces=self.input.physics_model.f_ext.at[link_idxs, :].set(
+                    W_f0_L + W_f_L
+                )
+            )
+
+        if data is None:
+            msg = "Missing model data to use a representation different from {}"
+            raise ValueError(msg.format(VelRepr.Inertial.name))
+
+        if not data.valid(model=model):
+            raise ValueError("The provided data is not valid for the model")
+
+        # Convert to the inertial-fixed representation.
+        W_H_L = js.model.forward_kinematics(model=model, data=data)
+        W_f_L = jax.vmap(convert)(f_L, W_H_L[link_idxs, :, :])
+
+        return replace(
+            forces=self.input.physics_model.f_ext.at[link_idxs, :].set(W_f0_L + W_f_L)
+        )


### PR DESCRIPTION
This PR introduces helpers to manipulate the following inputs of a simulated model:

- **Joint force references:** these are the torques (or linear forces) references synthesized by a joint controller from the user. They are not guaranteed to be the same as those actuated since there might be friction or other contributions e.g. for enforcing joint limits.
- **Link forces:** these are the 6D forces applied to the origin ${}^W \mathbf{o}_{L_i}$ of each link frame $L_i$. The coordinates of the 6D forces are expressed in the active `JaxSimModelReferences.velocity_representation`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--96.org.readthedocs.build//96/

<!-- readthedocs-preview jaxsim end -->