### PR TITLE
 Fix contact params estimation in fixed-base models

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -173,7 +173,7 @@ def estimate_good_soft_contacts_parameters(
             W_pz_C = collidable_point_positions(model=model, data=zero_data)[:, -1]
             return 2 * (W_pz_CoM - W_pz_C.min())
 
-        return 2 * W_p_CoM
+        return 2 * W_pz_CoM
 
     max_δ = (
         max_penetration

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -167,11 +167,11 @@ def estimate_good_soft_contacts_parameters(
             model=model, soft_contacts_params=soft_contacts.SoftContactsParams()
         )
 
-        W_p_CoM = Model.com_position(model=model, data=zero_data)[2]
+        W_pz_CoM = Model.com_position(model=model, data=zero_data)[2]
 
         if model.physics_model.is_floating_base:
             W_pz_C = collidable_point_positions(model=model, data=zero_data)[:, -1]
-            return 2 * (W_p_CoM - W_pz_C.min())
+            return 2 * (W_pz_CoM - W_pz_C.min())
 
         return 2 * W_p_CoM
 

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -167,11 +167,11 @@ def estimate_good_soft_contacts_parameters(
             model=model, soft_contacts_params=soft_contacts.SoftContactsParams()
         )
 
-        W_p_CoM = Model.com_position(model=model, data=zero_data)
+        W_p_CoM = Model.com_position(model=model, data=zero_data)[2]
 
         if model.physics_model.is_floating_base:
             W_pz_C = collidable_point_positions(model=model, data=zero_data)[:, -1]
-            return 2 * (W_p_CoM[2] - W_pz_C.min())
+            return 2 * (W_p_CoM - W_pz_C.min())
 
         return 2 * W_p_CoM
 


### PR DESCRIPTION
If the `model.physics_model.is_floating_base` is False, with the current version, the whole `W_p_CoM` variable is returned (`shape=(3,)`), but it should have `shape=()`.
For this reason, the code has been changed such that the $z$ component of the CoM position is extracted also for fixed-base models. 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--98.org.readthedocs.build//98/

<!-- readthedocs-preview jaxsim end -->