### PR TITLE
Fix loading of jointless model

### DIFF
--- a/src/jaxsim/physics/model/physics_model.py
+++ b/src/jaxsim/physics/model/physics_model.py
@@ -100,8 +100,8 @@ class PhysicsModel(JaxsimDataclass):
                 [self._link_inertias_dict[l.index] for l in ordered_links]
             )
 
-            s_min = jnp.hstack([j.position_limit[0] for j in ordered_joints])
-            s_max = jnp.hstack([j.position_limit[1] for j in ordered_joints])
+            s_min = jnp.array([j.position_limit[0] for j in ordered_joints])
+            s_max = jnp.array([j.position_limit[1] for j in ordered_joints])
             self._joint_position_limits_min = jnp.vstack([s_min, s_max]).min(axis=0)
             self._joint_position_limits_max = jnp.vstack([s_min, s_max]).max(axis=0)
 


### PR DESCRIPTION
I tried to replicate https://github.com/ami-iit/jaxsim/issues/103, in two different environments, and without the modification in this PR the loading fail with:
~~~
(jaxsimws) traversaro@IITBMP014LW012:~/jaxsimws$ python mwe103.py
jaxsim[237017] INFO Enabling JAX to use 64bit precision
jaxsim[237017] DEBUG Found model 'box' in SDF resource
jaxsim[237017] DEBUG Model 'box' is floating-base
jaxsim[237017] DEBUG Considering 'box_link' as base link
jaxsim[237017] INFO The kinematic graph doesn't need to be reduced
Traceback (most recent call last):
  File "/home/traversaro/jaxsimws/mwe103.py", line 22, in <module>
    model1 = js.model.JaxSimModel.build_from_model_description(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/traversaro/jaxsimws/jaxsim/src/jaxsim/api/model.py", line 113, in build_from_model_description
    physics_model = jaxsim.physics.model.physics_model.PhysicsModel.build_from(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/traversaro/jaxsimws/jaxsim/src/jaxsim/physics/model/physics_model.py", line 234, in build_from
    physics_model = PhysicsModel(
                    ^^^^^^^^^^^^^
  File "<string>", line 20, in __init__
  File "/home/traversaro/jaxsimws/jaxsim/src/jaxsim/physics/model/physics_model.py", line 102, in __post_init__
    s_min = jnp.hstack([j.position_limit[0] for j in ordered_joints])
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/traversaro/jaxsimws/.pixi/envs/default/lib/python3.12/site-packages/jax/_src/numpy/lax_numpy.py", line 1926, in hstack
    arr0_ndim = arrs[0].ndim
                ~~~~^^^
IndexError: list index out of range
~~~

With the fix in this PR instead the example fails with the error in https://github.com/ami-iit/jaxsim/issues/103 .

<details>

<summary>Conda environment</summary>

~~~
(jaxsimws) traversaro@IITBMP014LW012:~/jaxsimws$ pixi list
Package                               Version       Build                     Size       Kind   Source
_libgcc_mutex                         0.1           conda_forge               2.5 KiB    conda  _libgcc_mutex-0.1-conda_forge.tar.bz2
_openmp_mutex                         4.5           2_gnu                     23.1 KiB   conda  _openmp_mutex-4.5-2_gnu.tar.bz2
absl-py                               2.1.0         pyhd8ed1ab_0              104.8 KiB  conda  absl-py-2.1.0-pyhd8ed1ab_0.conda
alsa-lib                              1.2.11        hd590300_1                541.7 KiB  conda  alsa-lib-1.2.11-hd590300_1.conda
ampl-mp                               3.1.0         h2cc385e_1006             1.1 MiB    conda  ampl-mp-3.1.0-h2cc385e_1006.tar.bz2
aom                                   3.8.1         h59595ed_0                2.6 MiB    conda  aom-3.8.1-h59595ed_0.conda
assimp                                5.3.1         hfb0e8fe_2                3.4 MiB    conda  assimp-5.3.1-hfb0e8fe_2.conda
asttokens                             2.4.1         pyhd8ed1ab_0              28.2 KiB   conda  asttokens-2.4.1-pyhd8ed1ab_0.conda
atk-1.0                               2.38.0        hd4edc92_1                539 KiB    conda  atk-1.0-2.38.0-hd4edc92_1.tar.bz2
attr                                  2.5.1         h166bdaf_1                69.4 KiB   conda  attr-2.5.1-h166bdaf_1.tar.bz2
aws-c-auth                            0.7.16        h79b3bcb_6                101 KiB    conda  aws-c-auth-0.7.16-h79b3bcb_6.conda
aws-c-cal                             0.6.10        hb29e0c7_1                53.8 KiB   conda  aws-c-cal-0.6.10-hb29e0c7_1.conda
aws-c-common                          0.9.13        hd590300_0                220.3 KiB  conda  aws-c-common-0.9.13-hd590300_0.conda
aws-c-compression                     0.2.18        hecc5fa9_1                18.7 KiB   conda  aws-c-compression-0.2.18-hecc5fa9_1.conda
aws-c-event-stream                    0.4.2         hf9b2f7b_4                52.7 KiB   conda  aws-c-event-stream-0.4.2-hf9b2f7b_4.conda
aws-c-http                            0.8.1         h5d7533a_5                190.5 KiB  conda  aws-c-http-0.8.1-h5d7533a_5.conda
aws-c-io                              0.14.5        h50678d4_1                153.5 KiB  conda  aws-c-io-0.14.5-h50678d4_1.conda
aws-c-mqtt                            0.10.2        hf479d2b_4                160.6 KiB  conda  aws-c-mqtt-0.10.2-hf479d2b_4.conda
aws-c-s3                              0.5.2         h4ad9680_0                102.8 KiB  conda  aws-c-s3-0.5.2-h4ad9680_0.conda
aws-c-sdkutils                        0.1.15        hecc5fa9_1                54.1 KiB   conda  aws-c-sdkutils-0.1.15-hecc5fa9_1.conda
aws-checksums                         0.1.18        hecc5fa9_1                49 KiB     conda  aws-checksums-0.1.18-hecc5fa9_1.conda
aws-crt-cpp                           0.26.2        h19f5d62_7                326 KiB    conda  aws-crt-cpp-0.26.2-h19f5d62_7.conda
aws-sdk-cpp                           1.11.267      h5606698_1                3.4 MiB    conda  aws-sdk-cpp-1.11.267-h5606698_1.conda
azure-core-cpp                        1.11.1        h91d86a7_1                334.6 KiB  conda  azure-core-cpp-1.11.1-h91d86a7_1.conda
azure-storage-blobs-cpp               12.10.0       h00ab1b0_1                505 KiB    conda  azure-storage-blobs-cpp-12.10.0-h00ab1b0_1.conda
azure-storage-common-cpp              12.5.0        h94269e2_4                129.3 KiB  conda  azure-storage-common-cpp-12.5.0-h94269e2_4.conda
blosc                                 1.21.5        h0f2a231_0                47.6 KiB   conda  blosc-1.21.5-h0f2a231_0.conda
brotli                                1.1.0         hd590300_1                18.9 KiB   conda  brotli-1.1.0-hd590300_1.conda
brotli-bin                            1.1.0         hd590300_1                18.5 KiB   conda  brotli-bin-1.1.0-hd590300_1.conda
bullet-cpp                            3.25          hfb8ada1_2                40.4 MiB   conda  bullet-cpp-3.25-hfb8ada1_2.conda
bzip2                                 1.0.8         hd590300_5                248.3 KiB  conda  bzip2-1.0.8-hd590300_5.conda
c-ares                                1.27.0        hd590300_0                159.7 KiB  conda  c-ares-1.27.0-hd590300_0.conda
ca-certificates                       2024.2.2      hbcca054_0                151.8 KiB  conda  ca-certificates-2024.2.2-hbcca054_0.conda
cairo                                 1.18.0        h3faef2a_0                959.3 KiB  conda  cairo-1.18.0-h3faef2a_0.conda
certifi                               2024.2.2      pyhd8ed1ab_0              156.8 KiB  conda  certifi-2024.2.2-pyhd8ed1ab_0.conda
cfitsio                               4.3.1         hbdc6101_0                854.7 KiB  conda  cfitsio-4.3.1-hbdc6101_0.conda
colorama                              0.4.6         pyhd8ed1ab_0              24.6 KiB   conda  colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
coloredlogs                           15.0.1        pyhd8ed1ab_3              39.6 KiB   conda  coloredlogs-15.0.1-pyhd8ed1ab_3.tar.bz2
console_bridge                        1.0.2         h924138e_1                18 KiB     conda  console_bridge-1.0.2-h924138e_1.tar.bz2
contourpy                             1.2.0         py312h8572e83_0           247.2 KiB  conda  contourpy-1.2.0-py312h8572e83_0.conda
cppzmq                                4.10.0        h2e2a08d_1                28.4 KiB   conda  cppzmq-4.10.0-h2e2a08d_1.conda
cuda-nvcc                             12.4.99       0                         62.6 MiB   conda  cuda-nvcc-12.4.99-0.tar.bz2
cuda-version                          11.8          h70ddcb2_3                20.5 KiB   conda  cuda-version-11.8-h70ddcb2_3.conda
cudatoolkit                           11.8.0        h4ba93d1_13               682.5 MiB  conda  cudatoolkit-11.8.0-h4ba93d1_13.conda
cudnn                                 8.8.0.121     hcdd5f01_4                456.5 MiB  conda  cudnn-8.8.0.121-hcdd5f01_4.conda
cycler                                0.12.1        pyhd8ed1ab_0              13.1 KiB   conda  cycler-0.12.1-pyhd8ed1ab_0.conda
dartsim                               6.13.1        hdbb2bd4_2                13.6 MiB   conda  dartsim-6.13.1-hdbb2bd4_2.conda
dav1d                                 1.2.1         hd590300_0                742.4 KiB  conda  dav1d-1.2.1-hd590300_0.conda
dbus                                  1.13.6        h5008d03_3                604.1 KiB  conda  dbus-1.13.6-h5008d03_3.tar.bz2
decorator                             5.1.1         pyhd8ed1ab_0              11.8 KiB   conda  decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
docstring_parser                      0.15          pyhd8ed1ab_0              29.3 KiB   conda  docstring_parser-0.15-pyhd8ed1ab_0.conda
eigen                                 3.4.0         h00ab1b0_0                1 MiB      conda  eigen-3.4.0-h00ab1b0_0.conda
etils                                 1.7.0         pyhd8ed1ab_0              758.4 KiB  conda  etils-1.7.0-pyhd8ed1ab_0.conda
exceptiongroup                        1.2.0         pyhd8ed1ab_2              20.1 KiB   conda  exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
executing                             2.0.1         pyhd8ed1ab_0              27 KiB     conda  executing-2.0.1-pyhd8ed1ab_0.conda
expat                                 2.6.1         h59595ed_0                133.6 KiB  conda  expat-2.6.1-h59595ed_0.conda
fcl                                   0.7.0         hadc09e8_4                1.5 MiB    conda  fcl-0.7.0-hadc09e8_4.conda
ffmpeg                                6.1.1         gpl_h8007c5b_104          9.3 MiB    conda  ffmpeg-6.1.1-gpl_h8007c5b_104.conda
flann                                 1.9.2         h2b5ea80_0                1.5 MiB    conda  flann-1.9.2-h2b5ea80_0.conda
fmt                                   10.2.1        h00ab1b0_0                189.3 KiB  conda  fmt-10.2.1-h00ab1b0_0.conda
font-ttf-dejavu-sans-mono             2.37          hab24e00_0                388.1 KiB  conda  font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
font-ttf-inconsolata                  3.000         h77eed37_0                94.3 KiB   conda  font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
font-ttf-source-code-pro              2.038         h77eed37_0                684.4 KiB  conda  font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
font-ttf-ubuntu                       0.83          h77eed37_1                1.5 MiB    conda  font-ttf-ubuntu-0.83-h77eed37_1.conda
fontconfig                            2.14.2        h14ed4e7_0                265.6 KiB  conda  fontconfig-2.14.2-h14ed4e7_0.conda
fonts-conda-ecosystem                 1             0                         3.6 KiB    conda  fonts-conda-ecosystem-1-0.tar.bz2
fonts-conda-forge                     1             0                         4 KiB      conda  fonts-conda-forge-1-0.tar.bz2
fonttools                             4.49.0        py312h98912ed_0           2.7 MiB    conda  fonttools-4.49.0-py312h98912ed_0.conda
freeglut                              3.2.2         hac7e632_2                139.6 KiB  conda  freeglut-3.2.2-hac7e632_2.conda
freeimage                             3.18.0        h4b96d29_20               450.6 KiB  conda  freeimage-3.18.0-h4b96d29_20.conda
freetype                              2.12.1        h267a509_2                620.1 KiB  conda  freetype-2.12.1-h267a509_2.conda
freexl                                2.0.0         h743c826_0                58.4 KiB   conda  freexl-2.0.0-h743c826_0.conda
fribidi                               1.0.10        h36c2ea0_0                111.7 KiB  conda  fribidi-1.0.10-h36c2ea0_0.tar.bz2
frozendict                            2.4.0         py312h98912ed_0           29.4 KiB   conda  frozendict-2.4.0-py312h98912ed_0.conda
fsspec                                2024.2.0      pyhca7485f_0              125.6 KiB  conda  fsspec-2024.2.0-pyhca7485f_0.conda
gazebo                                11.14.0       h3102449_8                57 MiB     conda  gazebo-11.14.0-h3102449_8.conda
gdbm                                  1.18          h0a1914f_2                190.2 KiB  conda  gdbm-1.18-h0a1914f_2.tar.bz2
gdk-pixbuf                            2.42.10       h829c605_4                558.6 KiB  conda  gdk-pixbuf-2.42.10-h829c605_4.conda
geos                                  3.12.1        h59595ed_0                1.7 MiB    conda  geos-3.12.1-h59595ed_0.conda
geotiff                               1.7.1         h6b2125f_15               130 KiB    conda  geotiff-1.7.1-h6b2125f_15.conda
gettext                               0.21.1        h27087fc_0                4.1 MiB    conda  gettext-0.21.1-h27087fc_0.tar.bz2
giflib                                5.2.1         h0b41bf4_3                75.6 KiB   conda  giflib-5.2.1-h0b41bf4_3.conda
gitdb                                 4.0.11        pyhd8ed1ab_0              51.6 KiB   conda  gitdb-4.0.11-pyhd8ed1ab_0.conda
gitpython                             3.1.42        pyhd8ed1ab_0              146.1 KiB  conda  gitpython-3.1.42-pyhd8ed1ab_0.conda
glfw                                  3.4           hd590300_0                163.5 KiB  conda  glfw-3.4-hd590300_0.conda
glib                                  2.78.4        hfc55251_4                478.5 KiB  conda  glib-2.78.4-hfc55251_4.conda
glib-tools                            2.78.4        hfc55251_4                110.4 KiB  conda  glib-tools-2.78.4-hfc55251_4.conda
gmp                                   6.3.0         h59595ed_0                549.9 KiB  conda  gmp-6.3.0-h59595ed_0.conda
gnutls                                3.7.9         hb077bed_0                1.9 MiB    conda  gnutls-3.7.9-hb077bed_0.conda
graphite2                             1.3.13        h58526e2_1001             102.2 KiB  conda  graphite2-1.3.13-h58526e2_1001.tar.bz2
graphviz                              9.0.0         h78e8752_1                2.2 MiB    conda  graphviz-9.0.0-h78e8752_1.conda
gst-plugins-base                      1.22.9        h8e1006c_0                2.6 MiB    conda  gst-plugins-base-1.22.9-h8e1006c_0.conda
gstreamer                             1.22.9        h98fc4e7_0                1.9 MiB    conda  gstreamer-1.22.9-h98fc4e7_0.conda
gtk2                                  2.24.33       h7f000aa_3                6.2 MiB    conda  gtk2-2.24.33-h7f000aa_3.conda
gts                                   0.7.6         h977cf35_4                310.9 KiB  conda  gts-0.7.6-h977cf35_4.conda
harfbuzz                              8.3.0         h3d44ed6_0                1.5 MiB    conda  harfbuzz-8.3.0-h3d44ed6_0.conda
hdf4                                  4.2.15        h2a13503_7                739 KiB    conda  hdf4-4.2.15-h2a13503_7.conda
hdf5                                  1.14.3        nompi_h4f84152_100        3.7 MiB    conda  hdf5-1.14.3-nompi_h4f84152_100.conda
humanfriendly                         10.0          pyhd8ed1ab_6              71.7 KiB   conda  humanfriendly-10.0-pyhd8ed1ab_6.conda
icdiff                                2.0.7         pyhd8ed1ab_0              24.7 KiB   conda  icdiff-2.0.7-pyhd8ed1ab_0.conda
icu                                   73.2          h59595ed_0                11.5 MiB   conda  icu-73.2-h59595ed_0.conda
idyntree                              10.3.0        py312h36ac6ef_0           2.3 MiB    conda  idyntree-10.3.0-py312h36ac6ef_0.conda
imath                                 3.1.11        hfc55251_0                158.7 KiB  conda  imath-3.1.11-hfc55251_0.conda
importlib-metadata                    7.0.2         pyha770c72_0              26.3 KiB   conda  importlib-metadata-7.0.2-pyha770c72_0.conda
importlib_metadata                    7.0.2         hd8ed1ab_0                9.2 KiB    conda  importlib_metadata-7.0.2-hd8ed1ab_0.conda
importlib_resources                   6.1.3         pyhd8ed1ab_0              29.9 KiB   conda  importlib_resources-6.1.3-pyhd8ed1ab_0.conda
iniconfig                             2.0.0         pyhd8ed1ab_0              10.8 KiB   conda  iniconfig-2.0.0-pyhd8ed1ab_0.conda
ipopt                                 3.14.14       h04b96a2_1                996.7 KiB  conda  ipopt-3.14.14-h04b96a2_1.conda
ipython                               8.22.2        pyh707e725_0              579.8 KiB  conda  ipython-8.22.2-pyh707e725_0.conda
irrlicht                              1.8.5         h2a6caf8_4                1.9 MiB    conda  irrlicht-1.8.5-h2a6caf8_4.conda
jax                                   0.4.25        pyhd8ed1ab_0              1.1 MiB    conda  jax-0.4.25-pyhd8ed1ab_0.conda
jax-dataclasses                       1.6.0         pyhd8ed1ab_0              18 KiB     conda  jax-dataclasses-1.6.0-pyhd8ed1ab_0.conda
jaxlib                                0.4.23        cuda118py312h5dcafd1_200  94.8 MiB   conda  jaxlib-0.4.23-cuda118py312h5dcafd1_200.conda
jaxlie                                1.3.4         pyhd8ed1ab_0              21.5 KiB   conda  jaxlie-1.3.4-pyhd8ed1ab_0.conda
jedi                                  0.19.1        pyhd8ed1ab_0              821.6 KiB  conda  jedi-0.19.1-pyhd8ed1ab_0.conda
json-c                                0.17          h7ab15ed_0                81.1 KiB   conda  json-c-0.17-h7ab15ed_0.conda
jsoncpp                               1.9.5         h4bd325d_1                190 KiB    conda  jsoncpp-1.9.5-h4bd325d_1.tar.bz2
jxrlib                                1.1           hd590300_3                233.5 KiB  conda  jxrlib-1.1-hd590300_3.conda
kealib                                1.5.3         h2f55d51_0                168.9 KiB  conda  kealib-1.5.3-h2f55d51_0.conda
keyutils                              1.6.1         h166bdaf_0                115.1 KiB  conda  keyutils-1.6.1-h166bdaf_0.tar.bz2
kiwisolver                            1.4.5         py312h8572e83_1           70.4 KiB   conda  kiwisolver-1.4.5-py312h8572e83_1.conda
krb5                                  1.21.2        h659d440_0                1.3 MiB    conda  krb5-1.21.2-h659d440_0.conda
lame                                  3.100         h166bdaf_1003             496.3 KiB  conda  lame-3.100-h166bdaf_1003.tar.bz2
lcms2                                 2.16          hb7c19ff_0                239.5 KiB  conda  lcms2-2.16-hb7c19ff_0.conda
ld_impl_linux-64                      2.40          h41732ed_0                688.2 KiB  conda  ld_impl_linux-64-2.40-h41732ed_0.conda
lerc                                  4.0.0         h27087fc_0                275.2 KiB  conda  lerc-4.0.0-h27087fc_0.tar.bz2
libabseil                             20240116.1    cxx17_h59595ed_2          1.2 MiB    conda  libabseil-20240116.1-cxx17_h59595ed_2.conda
libaec                                1.1.2         h59595ed_1                34.4 KiB   conda  libaec-1.1.2-h59595ed_1.conda
libarchive                            3.7.2         h2aa1ff5_1                845.9 KiB  conda  libarchive-3.7.2-h2aa1ff5_1.conda
libass                                0.17.1        h8fe9dca_1                123.9 KiB  conda  libass-0.17.1-h8fe9dca_1.conda
libblas                               3.9.0         21_linux64_openblas       14.3 KiB   conda  libblas-3.9.0-21_linux64_openblas.conda
libboost                              1.82.0        h6fcfa73_6                2.5 MiB    conda  libboost-1.82.0-h6fcfa73_6.conda
libboost-devel                        1.82.0        h00ab1b0_6                34.8 KiB   conda  libboost-devel-1.82.0-h00ab1b0_6.conda
libboost-headers                      1.82.0        ha770c72_6                13.1 MiB   conda  libboost-headers-1.82.0-ha770c72_6.conda
libbrotlicommon                       1.1.0         hd590300_1                67.8 KiB   conda  libbrotlicommon-1.1.0-hd590300_1.conda
libbrotlidec                          1.1.0         hd590300_1                32 KiB     conda  libbrotlidec-1.1.0-hd590300_1.conda
libbrotlienc                          1.1.0         hd590300_1                275.9 KiB  conda  libbrotlienc-1.1.0-hd590300_1.conda
libcap                                2.69          h0f662aa_0                98.2 KiB   conda  libcap-2.69-h0f662aa_0.conda
libcblas                              3.9.0         21_linux64_openblas       14.3 KiB   conda  libcblas-3.9.0-21_linux64_openblas.conda
libccd-double                         2.1           h59595ed_3                35.3 KiB   conda  libccd-double-2.1-h59595ed_3.conda
libclang                              15.0.7        default_hb11cfb5_4        130.3 KiB  conda  libclang-15.0.7-default_hb11cfb5_4.conda
libclang13                            15.0.7        default_ha2b6cf4_4        9.1 MiB    conda  libclang13-15.0.7-default_ha2b6cf4_4.conda
libcrc32c                             1.1.2         h9c3ff4c_0                20 KiB     conda  libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
libcups                               2.3.3         h4637d8d_4                4.3 MiB    conda  libcups-2.3.3-h4637d8d_4.conda
libcurl                               8.5.0         hca28451_0                380 KiB    conda  libcurl-8.5.0-hca28451_0.conda
libdeflate                            1.19          hd590300_0                65.5 KiB   conda  libdeflate-1.19-hd590300_0.conda
libdrm                                2.4.120       hd590300_0                296 KiB    conda  libdrm-2.4.120-hd590300_0.conda
libedit                               3.1.20191231  he28a2e2_2                121 KiB    conda  libedit-3.1.20191231-he28a2e2_2.tar.bz2
libev                                 4.33          hd590300_2                110.1 KiB  conda  libev-4.33-hd590300_2.conda
libevent                              2.1.12        hf998b51_1                417.4 KiB  conda  libevent-2.1.12-hf998b51_1.conda
libexpat                              2.6.1         h59595ed_0                71.9 KiB   conda  libexpat-2.6.1-h59595ed_0.conda
libffi                                3.4.2         h7f98852_5                56.9 KiB   conda  libffi-3.4.2-h7f98852_5.tar.bz2
libflac                               1.4.3         h59595ed_0                385.1 KiB  conda  libflac-1.4.3-h59595ed_0.conda
libgcc-ng                             13.2.0        h807b86a_5                752.4 KiB  conda  libgcc-ng-13.2.0-h807b86a_5.conda
libgcrypt                             1.10.3        hd590300_0                620 KiB    conda  libgcrypt-1.10.3-hd590300_0.conda
libgd                                 2.3.3         h119a65a_9                219.2 KiB  conda  libgd-2.3.3-h119a65a_9.conda
libgdal                               3.8.4         h13e47b0_1                10.6 MiB   conda  libgdal-3.8.4-h13e47b0_1.conda
libgfortran-ng                        13.2.0        h69a702a_5                23.3 KiB   conda  libgfortran-ng-13.2.0-h69a702a_5.conda
libgfortran5                          13.2.0        ha4646dd_5                1.4 MiB    conda  libgfortran5-13.2.0-ha4646dd_5.conda
libglib                               2.78.4        hf2295e7_4                2.6 MiB    conda  libglib-2.78.4-hf2295e7_4.conda
libglu                                9.0.0         hac7e632_1003             323.5 KiB  conda  libglu-9.0.0-hac7e632_1003.conda
libgomp                               13.2.0        h807b86a_5                409.9 KiB  conda  libgomp-13.2.0-h807b86a_5.conda
libgoogle-cloud                       2.22.0        h72bcb37_0                1.2 MiB    conda  libgoogle-cloud-2.22.0-h72bcb37_0.conda
libgoogle-cloud-storage               2.22.0        hc7a4891_0                733.3 KiB  conda  libgoogle-cloud-storage-2.22.0-hc7a4891_0.conda
libgpg-error                          1.48          h71f35ed_0                260.2 KiB  conda  libgpg-error-1.48-h71f35ed_0.conda
libgrpc                               1.61.1        h42401df_1                6.7 MiB    conda  libgrpc-1.61.1-h42401df_1.conda
libhwloc                              2.9.3         default_h554bfaf_1009     2.5 MiB    conda  libhwloc-2.9.3-default_h554bfaf_1009.conda
libiconv                              1.17          hd590300_2                689.2 KiB  conda  libiconv-1.17-hd590300_2.conda
libidn2                               2.3.7         hd590300_0                123.5 KiB  conda  libidn2-2.3.7-hd590300_0.conda
libignition-cmake2                    2.16.0        hcb278e6_1                263.9 KiB  conda  libignition-cmake2-2.16.0-hcb278e6_1.conda
libignition-common3                   3.15.1        hbcb56b1_3                627 KiB    conda  libignition-common3-3.15.1-hbcb56b1_3.conda
libignition-fuel-tools4               4.6.0         h8983a3d_8                244.5 KiB  conda  libignition-fuel-tools4-4.6.0-h8983a3d_8.conda
libignition-math6                     6.15.1        py312h365505f_1           1.1 MiB    conda  libignition-math6-6.15.1-py312h365505f_1.conda
libignition-msgs5                     5.11.0        h936fc59_8                946.8 KiB  conda  libignition-msgs5-5.11.0-h936fc59_8.conda
libignition-tools1                    1.5.0         h1caa08d_3                36.2 KiB   conda  libignition-tools1-1.5.0-h1caa08d_3.conda
libignition-transport8                8.4.0         h24168b1_10               406.3 KiB  conda  libignition-transport8-8.4.0-h24168b1_10.conda
libjpeg-turbo                         3.0.0         hd590300_1                604.1 KiB  conda  libjpeg-turbo-3.0.0-hd590300_1.conda
libkml                                1.3.0         h01aab08_1018             501.8 KiB  conda  libkml-1.3.0-h01aab08_1018.conda
liblapack                             3.9.0         21_linux64_openblas       14.3 KiB   conda  liblapack-3.9.0-21_linux64_openblas.conda
libllvm15                             15.0.7        hb3ce162_4                31.8 MiB   conda  libllvm15-15.0.7-hb3ce162_4.conda
libmujoco                             3.1.3         hfbbffa6_0                10.9 MiB   conda  libmujoco-3.1.3-hfbbffa6_0.conda
libnetcdf                             4.9.2         nompi_h9612171_113        829.1 KiB  conda  libnetcdf-4.9.2-nompi_h9612171_113.conda
libnghttp2                            1.58.0        h47da74e_1                617.1 KiB  conda  libnghttp2-1.58.0-h47da74e_1.conda
libnsl                                2.0.1         hd590300_0                32.6 KiB   conda  libnsl-2.0.1-hd590300_0.conda
libode                                0.16.2        h30efb56_12               480.2 KiB  conda  libode-0.16.2-h30efb56_12.conda
libogg                                1.3.4         h7f98852_1                205.6 KiB  conda  libogg-1.3.4-h7f98852_1.tar.bz2
libopenblas                           0.3.26        pthreads_h413a1c8_0       5.3 MiB    conda  libopenblas-0.3.26-pthreads_h413a1c8_0.conda
libopenvino                           2023.3.0      h2e90f83_2                5.7 MiB    conda  libopenvino-2023.3.0-h2e90f83_2.conda
libopenvino-auto-batch-plugin         2023.3.0      hd5fc58b_2                112.3 KiB  conda  libopenvino-auto-batch-plugin-2023.3.0-hd5fc58b_2.conda
libopenvino-auto-plugin               2023.3.0      hd5fc58b_2                232.9 KiB  conda  libopenvino-auto-plugin-2023.3.0-hd5fc58b_2.conda
libopenvino-hetero-plugin             2023.3.0      h3ecfda7_2                177.5 KiB  conda  libopenvino-hetero-plugin-2023.3.0-h3ecfda7_2.conda
libopenvino-intel-cpu-plugin          2023.3.0      h2e90f83_2                9.7 MiB    conda  libopenvino-intel-cpu-plugin-2023.3.0-h2e90f83_2.conda
libopenvino-intel-gpu-plugin          2023.3.0      h2e90f83_2                7.8 MiB    conda  libopenvino-intel-gpu-plugin-2023.3.0-h2e90f83_2.conda
libopenvino-ir-frontend               2023.3.0      h3ecfda7_2                194.2 KiB  conda  libopenvino-ir-frontend-2023.3.0-h3ecfda7_2.conda
libopenvino-onnx-frontend             2023.3.0      h469e5c9_2                1.5 MiB    conda  libopenvino-onnx-frontend-2023.3.0-h469e5c9_2.conda
libopenvino-paddle-frontend           2023.3.0      h469e5c9_2                644.1 KiB  conda  libopenvino-paddle-frontend-2023.3.0-h469e5c9_2.conda
libopenvino-pytorch-frontend          2023.3.0      h59595ed_2                937.3 KiB  conda  libopenvino-pytorch-frontend-2023.3.0-h59595ed_2.conda
libopenvino-tensorflow-frontend       2023.3.0      he1e0747_2                1.1 MiB    conda  libopenvino-tensorflow-frontend-2023.3.0-he1e0747_2.conda
libopenvino-tensorflow-lite-frontend  2023.3.0      h59595ed_2                445.7 KiB  conda  libopenvino-tensorflow-lite-frontend-2023.3.0-h59595ed_2.conda
libopus                               1.3.1         h7f98852_1                254.5 KiB  conda  libopus-1.3.1-h7f98852_1.tar.bz2
libosqp                               0.6.3         h59595ed_0                70.4 KiB   conda  libosqp-0.6.3-h59595ed_0.conda
libpciaccess                          0.18          hd590300_0                27.7 KiB   conda  libpciaccess-0.18-hd590300_0.conda
libpng                                1.6.43        h2797004_0                281.5 KiB  conda  libpng-1.6.43-h2797004_0.conda
libpq                                 16.2          h33b98f1_0                2.4 MiB    conda  libpq-16.2-h33b98f1_0.conda
libprotobuf                           4.25.2        h08a7969_1                2.7 MiB    conda  libprotobuf-4.25.2-h08a7969_1.conda
libqdldl                              0.1.5         h27087fc_1                16.5 KiB   conda  libqdldl-0.1.5-h27087fc_1.tar.bz2
libraw                                0.21.1        h2a13503_2                622.9 KiB  conda  libraw-0.21.1-h2a13503_2.conda
libre2-11                             2023.09.01    h5a48ba9_2                227.2 KiB  conda  libre2-11-2023.09.01-h5a48ba9_2.conda
librsvg                               2.56.3        he3f83f7_1                5.6 MiB    conda  librsvg-2.56.3-he3f83f7_1.conda
librttopo                             1.1.0         h8917695_15               227.7 KiB  conda  librttopo-1.1.0-h8917695_15.conda
libscotch                             7.0.4         h91e35bf_1                331.7 KiB  conda  libscotch-7.0.4-h91e35bf_1.conda
libsdformat                           9.8.0         h169342d_6                586.6 KiB  conda  libsdformat-9.8.0-h169342d_6.conda
libsndfile                            1.2.2         hc60ed4a_1                346.1 KiB  conda  libsndfile-1.2.2-hc60ed4a_1.conda
libsodium                             1.0.18        h36c2ea0_1                366.2 KiB  conda  libsodium-1.0.18-h36c2ea0_1.tar.bz2
libspatialite                         5.1.0         h7bd4643_4                3.9 MiB    conda  libspatialite-5.1.0-h7bd4643_4.conda
libspral                              2023.09.07    h6aa6db2_2                277.8 KiB  conda  libspral-2023.09.07-h6aa6db2_2.conda
libsqlite                             3.45.1        h2797004_0                839.2 KiB  conda  libsqlite-3.45.1-h2797004_0.conda
libssh2                               1.11.0        h0841786_0                264.8 KiB  conda  libssh2-1.11.0-h0841786_0.conda
libstdcxx-ng                          13.2.0        h7e041cc_5                3.7 MiB    conda  libstdcxx-ng-13.2.0-h7e041cc_5.conda
libsystemd0                           255           h3516f8a_1                393.2 KiB  conda  libsystemd0-255-h3516f8a_1.conda
libtar                                1.2.20        h7f98852_1004             46.9 KiB   conda  libtar-1.2.20-h7f98852_1004.tar.bz2
libtasn1                              4.19.0        h166bdaf_0                114.1 KiB  conda  libtasn1-4.19.0-h166bdaf_0.tar.bz2
libtiff                               4.6.0         ha9c0a0a_2                276.6 KiB  conda  libtiff-4.6.0-ha9c0a0a_2.conda
libudev1                              255           h3f72095_1                122.1 KiB  conda  libudev1-255-h3f72095_1.conda
libunistring                          0.9.10        h7f98852_0                1.4 MiB    conda  libunistring-0.9.10-h7f98852_0.tar.bz2
libusb                                1.0.27        h520f47e_100              84.2 KiB   conda  libusb-1.0.27-h520f47e_100.conda
libuuid                               2.38.1        h0b41bf4_0                32.8 KiB   conda  libuuid-2.38.1-h0b41bf4_0.conda
libva                                 2.20.0        hd590300_0                183.7 KiB  conda  libva-2.20.0-hd590300_0.conda
libvorbis                             1.3.7         h9c3ff4c_0                279.6 KiB  conda  libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
libvpx                                1.13.1        h59595ed_0                982.5 KiB  conda  libvpx-1.13.1-h59595ed_0.conda
libwebp                               1.3.2         h658648e_1                82.9 KiB   conda  libwebp-1.3.2-h658648e_1.conda
libwebp-base                          1.3.2         hd590300_0                392.4 KiB  conda  libwebp-base-1.3.2-hd590300_0.conda
libxcb                                1.15          h0b41bf4_0                375.2 KiB  conda  libxcb-1.15-h0b41bf4_0.conda
libxcrypt                             4.4.36        hd590300_1                98 KiB     conda  libxcrypt-4.4.36-hd590300_1.conda
libxkbcommon                          1.6.0         hd429924_1                561.4 KiB  conda  libxkbcommon-1.6.0-hd429924_1.conda
libxml2                               2.12.5        h232c23b_0                688.3 KiB  conda  libxml2-2.12.5-h232c23b_0.conda
libxslt                               1.1.39        h76b75d6_0                248.3 KiB  conda  libxslt-1.1.39-h76b75d6_0.conda
libzip                                1.10.1        h2629f0a_3                104.7 KiB  conda  libzip-1.10.1-h2629f0a_3.conda
libzlib                               1.2.13        hd590300_5                60.1 KiB   conda  libzlib-1.2.13-hd590300_5.conda
lodepng                               20220109      h924138e_0                99.7 KiB   conda  lodepng-20220109-h924138e_0.tar.bz2
lxml                                  5.1.0         py312h37b5203_0           1.4 MiB    conda  lxml-5.1.0-py312h37b5203_0.conda
lz4-c                                 1.9.4         hcb278e6_0                140 KiB    conda  lz4-c-1.9.4-hcb278e6_0.conda
lzo                                   2.10          h516909a_1000             313.6 KiB  conda  lzo-2.10-h516909a_1000.tar.bz2
markdown-it-py                        3.0.0         pyhd8ed1ab_0              62.8 KiB   conda  markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
mashumaro                             3.12          pyhd8ed1ab_0              69.7 KiB   conda  mashumaro-3.12-pyhd8ed1ab_0.conda
matplotlib-base                       3.8.3         py312he5832f3_0           7.5 MiB    conda  matplotlib-base-3.8.3-py312he5832f3_0.conda
matplotlib-inline                     0.1.6         pyhd8ed1ab_0              12 KiB     conda  matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
mdurl                                 0.1.2         pyhd8ed1ab_0              14.3 KiB   conda  mdurl-0.1.2-pyhd8ed1ab_0.conda
mediapy                               1.2.0         pyhd8ed1ab_0              29 KiB     conda  mediapy-1.2.0-pyhd8ed1ab_0.conda
metis                                 5.1.0         h59595ed_1007             3.7 MiB    conda  metis-5.1.0-h59595ed_1007.conda
minizip                               4.0.5         h0ab5242_0                89.1 KiB   conda  minizip-4.0.5-h0ab5242_0.conda
ml_dtypes                             0.3.2         py312hfb8ada1_0           167.9 KiB  conda  ml_dtypes-0.3.2-py312hfb8ada1_0.conda
mpg123                                1.32.4        h59595ed_0                479.6 KiB  conda  mpg123-1.32.4-h59595ed_0.conda
mujoco                                3.1.3         ha770c72_0                19.5 KiB   conda  mujoco-3.1.3-ha770c72_0.conda
mujoco-python                         3.1.3         py312h276ad9d_0           1.4 MiB    conda  mujoco-python-3.1.3-py312h276ad9d_0.conda
mujoco-samples                        3.1.3         h59595ed_0                35.9 KiB   conda  mujoco-samples-3.1.3-h59595ed_0.conda
mujoco-simulate                       3.1.3         h59595ed_0                71.9 KiB   conda  mujoco-simulate-3.1.3-h59595ed_0.conda
mumps-include                         5.6.2         ha770c72_4                26 KiB     conda  mumps-include-5.6.2-ha770c72_4.conda
mumps-seq                             5.6.2         hfef103a_4                1.9 MiB    conda  mumps-seq-5.6.2-hfef103a_4.conda
munkres                               1.1.4         pyh9f0ad1d_0              12.2 KiB   conda  munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
mysql-common                          8.0.33        hf1915f5_6                735.8 KiB  conda  mysql-common-8.0.33-hf1915f5_6.conda
mysql-libs                            8.0.33        hca2cd23_6                1.5 MiB    conda  mysql-libs-8.0.33-hca2cd23_6.conda
nccl                                  2.20.5.1      h6103f9b_0                121 MiB    conda  nccl-2.20.5.1-h6103f9b_0.conda
ncurses                               6.4           h59595ed_2                863.7 KiB  conda  ncurses-6.4-h59595ed_2.conda
nettle                                3.9.1         h7ab15ed_0                987.9 KiB  conda  nettle-3.9.1-h7ab15ed_0.conda
nspr                                  4.35          h27087fc_0                221.5 KiB  conda  nspr-4.35-h27087fc_0.conda
nss                                   3.98          h1d7d5a4_0                1.9 MiB    conda  nss-3.98-h1d7d5a4_0.conda
numpy                                 1.26.4        py312heda63a1_0           7.1 MiB    conda  numpy-1.26.4-py312heda63a1_0.conda
ocl-icd                               2.3.2         hd590300_0                133.1 KiB  conda  ocl-icd-2.3.2-hd590300_0.conda
octomap                               1.9.8         h924138e_0                258.2 KiB  conda  octomap-1.9.8-h924138e_0.tar.bz2
ogre                                  1.10.12.1     hb5e08f3_0                109.9 MiB  conda  ogre-1.10.12.1-hb5e08f3_0.conda
openal-soft                           1.23.1        h00ab1b0_0                553 KiB    conda  openal-soft-1.23.1-h00ab1b0_0.conda
openexr                               3.2.2         haf962dd_1                1.4 MiB    conda  openexr-3.2.2-haf962dd_1.conda
openh264                              2.4.1         h59595ed_0                718 KiB    conda  openh264-2.4.1-h59595ed_0.conda
openjpeg                              2.5.2         h488ebb8_0                333.6 KiB  conda  openjpeg-2.5.2-h488ebb8_0.conda
openssl                               3.2.1         hd590300_0                2.7 MiB    conda  openssl-3.2.1-hd590300_0.conda
opt-einsum                            3.3.0         hd8ed1ab_2                6.4 KiB    conda  opt-einsum-3.3.0-hd8ed1ab_2.conda
opt_einsum                            3.3.0         pyhc1e730c_2              56.6 KiB   conda  opt_einsum-3.3.0-pyhc1e730c_2.conda
osqp-eigen                            0.8.1         hdd734ac_1                34.5 KiB   conda  osqp-eigen-0.8.1-hdd734ac_1.conda
overrides                             7.7.0         pyhd8ed1ab_0              29.5 KiB   conda  overrides-7.7.0-pyhd8ed1ab_0.conda
p11-kit                               0.24.1        hc5aa10d_0                4.5 MiB    conda  p11-kit-0.24.1-hc5aa10d_0.tar.bz2
packaging                             23.2          pyhd8ed1ab_0              48.3 KiB   conda  packaging-23.2-pyhd8ed1ab_0.conda
pango                                 1.52.1        ha41ecd1_0                433.8 KiB  conda  pango-1.52.1-ha41ecd1_0.conda
parso                                 0.8.3         pyhd8ed1ab_0              69.4 KiB   conda  parso-0.8.3-pyhd8ed1ab_0.tar.bz2
pcre2                                 10.43         hcad00b1_0                928.6 KiB  conda  pcre2-10.43-hcad00b1_0.conda
pexpect                               4.9.0         pyhd8ed1ab_0              52.3 KiB   conda  pexpect-4.9.0-pyhd8ed1ab_0.conda
pickleshare                           0.7.5         py_1003                   9.1 KiB    conda  pickleshare-0.7.5-py_1003.tar.bz2
pillow                                10.2.0        py312hf3581a9_0           40.5 MiB   conda  pillow-10.2.0-py312hf3581a9_0.conda
pip                                   24.0          pyhd8ed1ab_0              1.3 MiB    conda  pip-24.0-pyhd8ed1ab_0.conda
pixman                                0.43.2        h59595ed_0                377.8 KiB  conda  pixman-0.43.2-h59595ed_0.conda
pluggy                                1.4.0         pyhd8ed1ab_0              22.8 KiB   conda  pluggy-1.4.0-pyhd8ed1ab_0.conda
poppler                               24.02.0       h590f24d_0                1.8 MiB    conda  poppler-24.02.0-h590f24d_0.conda
poppler-data                          0.4.12        hd8ed1ab_0                2.2 MiB    conda  poppler-data-0.4.12-hd8ed1ab_0.conda
postgresql                            16.2          h7387d8b_0                5.1 MiB    conda  postgresql-16.2-h7387d8b_0.conda
pprintpp                              0.4.0         pyhd8ed1ab_5              17.7 KiB   conda  pprintpp-0.4.0-pyhd8ed1ab_5.conda
pptree                                3.1           pyhd8ed1ab_0              8.7 KiB    conda  pptree-3.1-pyhd8ed1ab_0.tar.bz2
proj                                  9.3.1         h1d62c97_0                2.9 MiB    conda  proj-9.3.1-h1d62c97_0.conda
prompt-toolkit                        3.0.42        pyha770c72_0              264.1 KiB  conda  prompt-toolkit-3.0.42-pyha770c72_0.conda
pthread-stubs                         0.4           h36c2ea0_1001             5.5 KiB    conda  pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
ptyprocess                            0.7.0         pyhd3deb0d_0              16.2 KiB   conda  ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
pugixml                               1.14          h59595ed_0                112.2 KiB  conda  pugixml-1.14-h59595ed_0.conda
pulseaudio-client                     16.1          hb77b528_5                737.2 KiB  conda  pulseaudio-client-16.1-hb77b528_5.conda
pure_eval                             0.2.2         pyhd8ed1ab_0              14.2 KiB   conda  pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
py                                    1.11.0        pyh6c4a22f_0              74.3 KiB   conda  py-1.11.0-pyh6c4a22f_0.tar.bz2
pybind11-abi                          4             hd8ed1ab_3                9.7 KiB    conda  pybind11-abi-4-hd8ed1ab_3.tar.bz2
pyglfw                                2.7.0         py312h7900ff3_0           69.1 KiB   conda  pyglfw-2.7.0-py312h7900ff3_0.conda
pygments                              2.17.2        pyhd8ed1ab_0              840.3 KiB  conda  pygments-2.17.2-pyhd8ed1ab_0.conda
pyopengl                              3.1.6         pyhd8ed1ab_1              867 KiB    conda  pyopengl-3.1.6-pyhd8ed1ab_1.tar.bz2
pyparsing                             3.1.2         pyhd8ed1ab_0              87.4 KiB   conda  pyparsing-3.1.2-pyhd8ed1ab_0.conda
pytest                                8.0.2         pyhd8ed1ab_0              246 KiB    conda  pytest-8.0.2-pyhd8ed1ab_0.conda
pytest-forked                         1.6.0         pyhd8ed1ab_0              10.3 KiB   conda  pytest-forked-1.6.0-pyhd8ed1ab_0.conda
pytest-icdiff                         0.9           pyhd8ed1ab_0              10.6 KiB   conda  pytest-icdiff-0.9-pyhd8ed1ab_0.conda
python                                3.12.2        hab00c5b_0_cpython        30.8 MiB   conda  python-3.12.2-hab00c5b_0_cpython.conda
python-dateutil                       2.9.0         pyhd8ed1ab_0              217.5 KiB  conda  python-dateutil-2.9.0-pyhd8ed1ab_0.conda
python_abi                            3.12          4_cp312                   6.2 KiB    conda  python_abi-3.12-4_cp312.conda
pyyaml                                6.0.1         py312h98912ed_1           192 KiB    conda  pyyaml-6.0.1-py312h98912ed_1.conda
qhull                                 2020.2        h4bd325d_2                1.9 MiB    conda  qhull-2020.2-h4bd325d_2.tar.bz2
qt-main                               5.15.8        h5810be5_19               58.5 MiB   conda  qt-main-5.15.8-h5810be5_19.conda
qwt                                   6.2.0         h1a478b3_6                3.5 MiB    conda  qwt-6.2.0-h1a478b3_6.conda
re2                                   2023.09.01    h7f4b329_2                26 KiB     conda  re2-2023.09.01-h7f4b329_2.conda
readline                              8.2           h8228510_1                274.9 KiB  conda  readline-8.2-h8228510_1.conda
resolve-robotics-uri-py               0.2.0         pyhd8ed1ab_0              11.7 KiB   conda  resolve-robotics-uri-py-0.2.0-pyhd8ed1ab_0.conda
rich                                  13.7.1        pyhd8ed1ab_0              180 KiB    conda  rich-13.7.1-pyhd8ed1ab_0.conda
robot_descriptions                    1.8.1         pyhd8ed1ab_0              34.9 KiB   conda  robot_descriptions-1.8.1-pyhd8ed1ab_0.conda
rod                                   0.2.0         pyhd8ed1ab_0              33.6 KiB   conda  rod-0.2.0-pyhd8ed1ab_0.conda
ruby                                  3.2.2         h983345b_1                7.7 MiB    conda  ruby-3.2.2-h983345b_1.conda
s2n                                   1.4.5         h06160fa_0                330 KiB    conda  s2n-1.4.5-h06160fa_0.conda
scipy                                 1.12.0        py312heda63a1_2           16.3 MiB   conda  scipy-1.12.0-py312heda63a1_2.conda
scotch                                7.0.4         h23d43cc_1                89.9 KiB   conda  scotch-7.0.4-h23d43cc_1.conda
sdl                                   1.2.68        h293081c_0                152.5 KiB  conda  sdl-1.2.68-h293081c_0.conda
sdl2                                  2.28.5        h77f46ba_0                1.3 MiB    conda  sdl2-2.28.5-h77f46ba_0.conda
setuptools                            69.1.1        pyhd8ed1ab_0              458.6 KiB  conda  setuptools-69.1.1-pyhd8ed1ab_0.conda
shtab                                 1.7.1         pyhd8ed1ab_0              19.1 KiB   conda  shtab-1.7.1-pyhd8ed1ab_0.conda
simbody                               3.7           h64f3f5a_3                38.4 MiB   conda  simbody-3.7-h64f3f5a_3.tar.bz2
six                                   1.16.0        pyh6c4a22f_0              13.9 KiB   conda  six-1.16.0-pyh6c4a22f_0.tar.bz2
smmap                                 5.0.0         pyhd8ed1ab_0              22 KiB     conda  smmap-5.0.0-pyhd8ed1ab_0.tar.bz2
snappy                                1.1.10        h9fff704_0                38 KiB     conda  snappy-1.1.10-h9fff704_0.conda
spdlog                                1.12.0        hd2e6256_2                183.5 KiB  conda  spdlog-1.12.0-hd2e6256_2.conda
sqlite                                3.45.1        h2c6b66d_0                828.3 KiB  conda  sqlite-3.45.1-h2c6b66d_0.conda
stack_data                            0.6.2         pyhd8ed1ab_0              25.6 KiB   conda  stack_data-0.6.2-pyhd8ed1ab_0.conda
svt-av1                               1.8.0         h59595ed_0                2.5 MiB    conda  svt-av1-1.8.0-h59595ed_0.conda
swig                                  4.2.1         hc9a1274_0                1.1 MiB    conda  swig-4.2.1-hc9a1274_0.conda
tbb                                   2021.11.0     h00ab1b0_1                191 KiB    conda  tbb-2021.11.0-h00ab1b0_1.conda
tbb-devel                             2021.11.0     h5ccd973_1                1 MiB      conda  tbb-devel-2021.11.0-h5ccd973_1.conda
tiledb                                2.20.1        h7c1ff67_3                4.5 MiB    conda  tiledb-2.20.1-h7c1ff67_3.conda
tinyxml                               2.6.2         h4bd325d_2                55.2 KiB   conda  tinyxml-2.6.2-h4bd325d_2.tar.bz2
tinyxml2                              10.0.0        h59595ed_0                117.8 KiB  conda  tinyxml2-10.0.0-h59595ed_0.conda
tk                                    8.6.13        noxft_h4845f30_101        3.2 MiB    conda  tk-8.6.13-noxft_h4845f30_101.conda
tomli                                 2.0.1         pyhd8ed1ab_0              15.6 KiB   conda  tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
tqdm                                  4.66.2        pyhd8ed1ab_0              87.5 KiB   conda  tqdm-4.66.2-pyhd8ed1ab_0.conda
traitlets                             5.14.1        pyhd8ed1ab_0              107.7 KiB  conda  traitlets-5.14.1-pyhd8ed1ab_0.conda
typing-extensions                     4.10.0        hd8ed1ab_0                9.9 KiB    conda  typing-extensions-4.10.0-hd8ed1ab_0.conda
typing_extensions                     4.10.0        pyha770c72_0              36.2 KiB   conda  typing_extensions-4.10.0-pyha770c72_0.conda
typing_utils                          0.1.0         pyhd8ed1ab_0              13.5 KiB   conda  typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
tyro                                  0.7.3         pyhd8ed1ab_0              66.3 KiB   conda  tyro-0.7.3-pyhd8ed1ab_0.conda
tzcode                                2024a         h3f72095_0                68.2 KiB   conda  tzcode-2024a-h3f72095_0.conda
tzdata                                2024a         h0c530f3_0                117 KiB    conda  tzdata-2024a-h0c530f3_0.conda
unixodbc                              2.3.12        h661eb56_0                275.2 KiB  conda  unixodbc-2.3.12-h661eb56_0.conda
urdfdom                               4.0.0         hee28ff1_1                103.7 KiB  conda  urdfdom-4.0.0-hee28ff1_1.conda
urdfdom_headers                       1.1.1         h00ab1b0_0                19 KiB     conda  urdfdom_headers-1.1.1-h00ab1b0_0.conda
uriparser                             0.9.7         h59595ed_1                46.8 KiB   conda  uriparser-0.9.7-h59595ed_1.conda
wayland                               1.22.0        h8c25dac_1                299.3 KiB  conda  wayland-1.22.0-h8c25dac_1.conda
wcwidth                               0.2.13        pyhd8ed1ab_0              31.9 KiB   conda  wcwidth-0.2.13-pyhd8ed1ab_0.conda
wheel                                 0.42.0        pyhd8ed1ab_0              56.2 KiB   conda  wheel-0.42.0-pyhd8ed1ab_0.conda
x264                                  1!164.3095    h166bdaf_2                876.5 KiB  conda  x264-1!164.3095-h166bdaf_2.tar.bz2
x265                                  3.5           h924138e_3                3.2 MiB    conda  x265-3.5-h924138e_3.tar.bz2
xcb-util                              0.4.0         hd590300_1                19.3 KiB   conda  xcb-util-0.4.0-hd590300_1.conda
xcb-util-image                        0.4.0         h8ee46fc_1                23.9 KiB   conda  xcb-util-image-0.4.0-h8ee46fc_1.conda
xcb-util-keysyms                      0.4.0         h8ee46fc_1                13.9 KiB   conda  xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
xcb-util-renderutil                   0.3.9         hd590300_1                16.6 KiB   conda  xcb-util-renderutil-0.3.9-hd590300_1.conda
xcb-util-wm                           0.4.1         h8ee46fc_1                50.9 KiB   conda  xcb-util-wm-0.4.1-h8ee46fc_1.conda
xerces-c                              3.2.5         hac6953d_0                1.6 MiB    conda  xerces-c-3.2.5-hac6953d_0.conda
xkeyboard-config                      2.41          hd590300_0                877 KiB    conda  xkeyboard-config-2.41-hd590300_0.conda
xmltodict                             0.13.0        pyhd8ed1ab_0              13.3 KiB   conda  xmltodict-0.13.0-pyhd8ed1ab_0.tar.bz2
xorg-fixesproto                       5.0           h7f98852_1002             8.9 KiB    conda  xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
xorg-inputproto                       2.3.2         h7f98852_1002             19.1 KiB   conda  xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
xorg-kbproto                          1.0.7         h7f98852_1002             26.7 KiB   conda  xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
xorg-libice                           1.1.1         hd590300_0                57.1 KiB   conda  xorg-libice-1.1.1-hd590300_0.conda
xorg-libsm                            1.2.4         h7391055_0                26.8 KiB   conda  xorg-libsm-1.2.4-h7391055_0.conda
xorg-libx11                           1.8.7         h8ee46fc_0                809.3 KiB  conda  xorg-libx11-1.8.7-h8ee46fc_0.conda
xorg-libxau                           1.0.11        hd590300_0                14.1 KiB   conda  xorg-libxau-1.0.11-hd590300_0.conda
xorg-libxaw                           1.0.14        h7f98852_1                373.1 KiB  conda  xorg-libxaw-1.0.14-h7f98852_1.tar.bz2
xorg-libxdmcp                         1.1.3         h7f98852_0                18.7 KiB   conda  xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
xorg-libxext                          1.3.4         h0b41bf4_2                49 KiB     conda  xorg-libxext-1.3.4-h0b41bf4_2.conda
xorg-libxfixes                        5.0.3         h7f98852_1004             17.7 KiB   conda  xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
xorg-libxi                            1.7.10        h7f98852_0                46.2 KiB   conda  xorg-libxi-1.7.10-h7f98852_0.tar.bz2
xorg-libxinerama                      1.1.5         h27087fc_0                13 KiB     conda  xorg-libxinerama-1.1.5-h27087fc_0.tar.bz2
xorg-libxmu                           1.1.3         h7f98852_0                90.4 KiB   conda  xorg-libxmu-1.1.3-h7f98852_0.tar.bz2
xorg-libxpm                           3.5.17        hd590300_0                62.8 KiB   conda  xorg-libxpm-3.5.17-hd590300_0.conda
xorg-libxrender                       0.9.11        hd590300_0                36.9 KiB   conda  xorg-libxrender-0.9.11-hd590300_0.conda
xorg-libxt                            1.3.0         hd590300_1                370.4 KiB  conda  xorg-libxt-1.3.0-hd590300_1.conda
xorg-renderproto                      0.11.1        h7f98852_1002             9.4 KiB    conda  xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
xorg-xextproto                        7.3.0         h0b41bf4_1003             29.6 KiB   conda  xorg-xextproto-7.3.0-h0b41bf4_1003.conda
xorg-xf86vidmodeproto                 2.3.1         h7f98852_1002             23.3 KiB   conda  xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
xorg-xproto                           7.0.31        h7f98852_1007             73.2 KiB   conda  xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
xz                                    5.2.6         h166bdaf_0                408.6 KiB  conda  xz-5.2.6-h166bdaf_0.tar.bz2
yaml                                  0.2.5         h7f98852_2                87.1 KiB   conda  yaml-0.2.5-h7f98852_2.tar.bz2
zeromq                                4.3.5         h59595ed_1                335.4 KiB  conda  zeromq-4.3.5-h59595ed_1.conda
zipp                                  3.17.0        pyhd8ed1ab_0              18.5 KiB   conda  zipp-3.17.0-pyhd8ed1ab_0.conda
zlib                                  1.2.13        hd590300_5                90.6 KiB   conda  zlib-1.2.13-hd590300_5.conda
zstd                                  1.5.5         hfc55251_0                532.4 KiB  conda  zstd-1.5.5-hfc55251_0.conda
zziplib                               0.13.69       h27826a3_1                96.8 KiB   conda  zziplib-0.13.69-h27826a3_1.tar.bz2
~~~

</details>



<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--104.org.readthedocs.build//104/

<!-- readthedocs-preview jaxsim end -->