### PR TITLE
Add `ruff`action and configuration

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -51,3 +51,16 @@ jobs:
         uses: isort/isort-action@master
         with:
           configuration: --check --diff --color
+
+  ruff:
+
+    name: ruff
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: "🔀 Checkout repository"
+        uses: actions/checkout@v2
+
+      - name: "📝 Ruff"
+        uses: chartboost/ruff-action@v1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
 
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: '🐍 Initialize Python'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
@@ -37,10 +37,10 @@ jobs:
     steps:
 
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: '🐍 Initialize Python'
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
@@ -60,7 +60,7 @@ jobs:
     steps:
 
       - name: "🔀 Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "📝 Ruff"
         uses: chartboost/ruff-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # setuptools_scm dynamic version
 src/jaxsim/_version.py
+
+# ruff
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
+    hooks:
+      - id: ruff

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,5 @@
 # Configuration file for the Sphinx documentation builder.
 import os
-import pathlib
 import sys
 
 from pkg_resources import get_distribution
@@ -22,8 +21,6 @@ def _recursive_add_annotations_import():
 
 if "READTHEDOCS" in os.environ:
     _recursive_add_annotations_import()
-
-import jaxsim
 
 # -- Version information
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,56 @@ version_file = "src/jaxsim/_version.py"
 line-length = 88
 
 [tool.isort]
-profile = "black"
 multi_line_output = 3
+profile = "black"
 
 [tool.pytest.ini_options]
+addopts = "-rsxX -v --strict-markers --forked"
 minversion = "6.0"
-addopts = "-rsxX -v --strict-markers"
 testpaths = [
-    "tests",
+  "tests",
 ]
+
+[tool.ruff]
+exclude = [
+  ".git",
+  ".pytest_cache",
+  ".ruff_cache",
+  ".vscode",
+  ".devcontainer",
+  "__pycache__",
+]
+preview = true
+
+target-version = "py311"
+
+[tool.ruff.lint]
+ignore = [
+  "B008", # Function call in default argument
+  "B024", # Abstract base class without abstract methods
+  "B904", # Raise without from inside exception
+  "B905", # Zip without explicit strict
+  "E402", # Module level import not at top of file
+  "E501", # Line too long
+  "E731", # Do not assign a `lambda` expression, use a `def`
+  "E741", # Ambiguous variable name
+  "F841", # Local variable is assigned to but never used
+  "I001", # Import block is unsorted or unformatted
+]
+select = [
+  "B",
+  "E",
+  "F",
+  "I",
+  "W",
+  "YTT",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `E402` (import violations) in all `__init__.py` files
+"**/{tests,docs,tools}/*" = ["E402"]
+"__init__.py" = ["F401"]
+# TODO: Remove these once deprecated code is removed
+"src/jaxsim/integrators/common.py" = ["E712"]
+"src/jaxsim/physics/model/physics_model.py" = ["B023"]
+"src/jaxsim/simulation/simulator_callbacks.py" = ["F821"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,4 +64,5 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` (import violations) in all `__init__.py` files
 "**/{tests,docs,tools}/*" = ["E402"]
+"**/{tests}/*" = ["B007"]
 "__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "wheel",
-    "setuptools>=64",
-    "setuptools_scm[toml]>=8",
+  "wheel",
+  "setuptools>=64",
+  "setuptools_scm[toml]>=8",
 ]
 
 [tool.setuptools_scm]
@@ -18,11 +18,14 @@ multi_line_output = 3
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = "-rsxX -v --strict-markers --forked"
+addopts = "-rsxX -v --strict-markers"
 minversion = "6.0"
+preview = true
 testpaths = [
   "tests",
 ]
+
+target-version = "py311"
 
 [tool.ruff]
 exclude = [
@@ -35,9 +38,8 @@ exclude = [
 ]
 preview = true
 
-target-version = "py311"
-
 [tool.ruff.lint]
+# https://docs.astral.sh/ruff/rules/
 ignore = [
   "B008", # Function call in default argument
   "B024", # Abstract base class without abstract methods
@@ -63,7 +65,3 @@ select = [
 # Ignore `E402` (import violations) in all `__init__.py` files
 "**/{tests,docs,tools}/*" = ["E402"]
 "__init__.py" = ["F401"]
-# TODO: Remove these once deprecated code is removed
-"src/jaxsim/integrators/common.py" = ["E712"]
-"src/jaxsim/physics/model/physics_model.py" = ["B023"]
-"src/jaxsim/simulation/simulator_callbacks.py" = ["F821"]

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -89,7 +89,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
         transform: jtp.Matrix,
         is_force: bool = False,
     ) -> jtp.Array:
-        """
+        r"""
         Convert a 6D quantity from inertial-fixed to another representation.
 
         Args:
@@ -155,7 +155,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
         transform: jtp.Matrix,
         is_force: bool = False,
     ) -> jtp.Array:
-        """
+        r"""
         Convert a 6D quantity from another representation to inertial-fixed.
 
         Args:

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -415,9 +415,9 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
 
     @jax.jit
     def generalized_position(self) -> tuple[jtp.Matrix, jtp.Vector]:
-        """
+        r"""
         Get the generalized position
-        :math:`\mathbf{q} = ({}^W \mathbf{H}_B, \mathbf{s}) \in \text{SO}(3) \times \mathbb{R}^n`.
+        :math:`\\mathbf{q} = ({}^W \\mathbf{H}_B, \\mathbf{s}) \\in \text{SO}(3) \times \\mathbb{R}^n`.
 
         Returns:
             A tuple containing the base transform and the joint positions.
@@ -427,9 +427,9 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
 
     @jax.jit
     def generalized_velocity(self) -> jtp.Vector:
-        """
+        r"""
         Get the generalized velocity
-        :math:`\boldsymbol{\nu} = (\boldsymbol{v}_{W,B};\, \boldsymbol{\omega}_{W,B};\, \mathbf{s}) \in \mathbb{R}^{6+n}`
+        :math:`\boldsymbol{\nu} = (\boldsymbol{v}_{W,B};\\, \boldsymbol{\\omega}_{W,B};\\, \\mathbf{s}) \\in \\mathbb{R}^{6+n}`
 
         Returns:
             The generalized velocity in the active representation.

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -926,7 +926,7 @@ def inverse_dynamics(
 def free_floating_gravity_forces(
     model: JaxSimModel, data: js.data.JaxSimModelData
 ) -> jtp.Vector:
-    """
+    r"""
     Compute the free-floating gravity forces :math:`g(\mathbf{q})` of the model.
 
     Args:
@@ -976,7 +976,7 @@ def free_floating_bias_forces(
     model: JaxSimModel, data: js.data.JaxSimModelData
 ) -> jtp.Vector:
     """
-    Compute the free-floating bias forces :math:`h(\mathbf{q}, \boldsymbol{\nu})`
+    Compute the free-floating bias forces :math:`h(\\mathbf{q}, \boldsymbol{\nu})`
     of the model.
 
     Args:

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -8,7 +8,6 @@ import jaxsim.rbda
 import jaxsim.typing as jtp
 from jaxsim.integrators import Time
 from jaxsim.math import Quaternion
-from jaxsim.utils import Mutability
 
 from .common import VelRepr
 from .ode_data import ODEState

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -324,7 +324,7 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
     def post_process_state(
         cls, x0: State, t0: Time, xf: NextState, dt: TimeStep
     ) -> NextState:
-        """
+        r"""
         Post-process the integrated state at :math:`t_f = t_0 + \Delta t`.
 
         Args:
@@ -529,7 +529,7 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
         # Return the index of the row of A providing the fsal derivative (that is the
         # possibly intermediate kᵢ derivative).
         # Note that if multiple rows match (it should not), we return the first match.
-        return True, int(jnp.where(rows_of_A_with_fsal == True)[0].tolist()[0])
+        return True, int(jnp.where(rows_of_A_with_fsal)[0].tolist()[0])
 
 
 class ExplicitRungeKuttaSO3Mixin:

--- a/src/jaxsim/math/transform.py
+++ b/src/jaxsim/math/transform.py
@@ -1,4 +1,3 @@
-import jax
 import jax.numpy as jnp
 import jaxlie
 

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -102,7 +102,7 @@ class RodModelToMjcf:
 
         if root.find(f".//joint[@name='{floating_joint_name}']") is not None:
             msg = f"The URDF already has a floating joint '{floating_joint_name}'"
-            warnings.warn(msg)
+            warnings.warn(msg, stacklevel=2)
             return ET.tostring(root, pretty_print=True).decode()
 
         # Create the "world" link if it doesn't exist.

--- a/src/jaxsim/mujoco/model.py
+++ b/src/jaxsim/mujoco/model.py
@@ -7,6 +7,8 @@ import numpy as np
 import numpy.typing as npt
 from scipy.spatial.transform import Rotation
 
+import jaxsim.typing as jtp
+
 HeightmapCallable = Callable[[jtp.FloatLike, jtp.FloatLike], jtp.FloatLike]
 
 

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -268,7 +268,7 @@ class KinematicGraph:
 
         # Return early if there is no action to take
         if len(joint_names_to_remove) == 0:
-            logging.info(f"The kinematic graph doesn't need to be reduced")
+            logging.info("The kinematic graph doesn't need to be reduced")
             return copy.deepcopy(self)
 
         # Check if all considered joints are part of the full kinematic graph

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -1,6 +1,5 @@
 import abc
 import contextlib
-import copy
 import dataclasses
 import functools
 from collections.abc import Iterator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import os
 import pathlib
 
 import jax
-import jax.numpy as jnp
 import pytest
 import rod
 
@@ -176,14 +175,12 @@ def jaxsim_model_ergocub() -> js.model.JaxSimModel:
         The JaxSim model of the ErgoCub robot.
     """
 
-    os_environ_original = os.environ.copy()
-
     try:
         os.environ["ROBOT_DESCRIPTION_COMMIT"] = "v0.7.1"
 
         import robot_descriptions.ergocub_description
     finally:
-        os.environ = os_environ_original
+        _ = os.environ.pop("ROBOT_DESCRIPTION_COMMIT", None)
 
     model_urdf_path = pathlib.Path(
         robot_descriptions.ergocub_description.URDF_PATH.replace(

--- a/tests/test_pytree.py
+++ b/tests/test_pytree.py
@@ -2,7 +2,6 @@ import io
 from contextlib import redirect_stdout
 
 import jax
-import jax.numpy as jnp
 import rod.builder.primitives
 import rod.urdf.exporter
 


### PR DESCRIPTION
This PR adds the `ruff` action to CIs and pre-commit, together with the configuration that has been added to the `pyproject.toml`. Finally, a full lint using the current version has been performed.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--114.org.readthedocs.build//114/

<!-- readthedocs-preview jaxsim end -->