### PR TITLE
Improve utilities provided by `JaxsimDataclass`

### DIFF
--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -70,7 +70,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
             # We run this in a mutable context with restoration so that any exception
             # occurring, we restore the original object in case it was modified.
             with self.mutable_context(
-                mutability=self._mutability(), restore_after_exception=True
+                mutability=self.mutability(), restore_after_exception=True
             ):
                 yield self
 

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -1,6 +1,5 @@
 import abc
 import contextlib
-import copy
 import dataclasses
 from collections.abc import Iterator
 from typing import ClassVar
@@ -153,7 +152,7 @@ class JaxsimDataclass(abc.ABC):
 
     def replace(self: Self, validate: bool = True, **kwargs) -> Self:
         with self.editable(validate=validate) as obj:
-            _ = [obj.__setattr__(k, copy.copy(v)) for k, v in kwargs.items()]
+            _ = [obj.__setattr__(k, v) for k, v in kwargs.items()]
 
         obj._set_mutability(mutability=self._mutability())
         return obj

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -2,7 +2,8 @@ import abc
 import contextlib
 import copy
 import dataclasses
-from typing import ClassVar, Generator
+from collections.abc import Iterator
+from typing import ClassVar
 
 import jax.flatten_util
 import jax_dataclasses
@@ -25,7 +26,7 @@ class JaxsimDataclass(abc.ABC):
     __mutability__: ClassVar[Mutability] = Mutability.FROZEN
 
     @contextlib.contextmanager
-    def editable(self: Self, validate: bool = True) -> Generator[Self, None, None]:
+    def editable(self: Self, validate: bool = True) -> Iterator[Self]:
         """"""
 
         mutability = (
@@ -38,7 +39,7 @@ class JaxsimDataclass(abc.ABC):
     @contextlib.contextmanager
     def mutable_context(
         self: Self, mutability: Mutability, restore_after_exception: bool = True
-    ) -> Generator[Self, None, None]:
+    ) -> Iterator[Self]:
         """"""
 
         if restore_after_exception:

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -32,7 +32,7 @@ class JaxsimDataclass(abc.ABC):
             Mutability.MUTABLE if validate else Mutability.MUTABLE_NO_VALIDATION
         )
 
-        with JaxsimDataclass.mutable_context(self.copy(), mutability=mutability) as obj:
+        with self.copy().mutable_context(mutability=mutability) as obj:
             yield obj
 
     @contextlib.contextmanager

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -2,7 +2,7 @@ import abc
 import contextlib
 import dataclasses
 from collections.abc import Iterator
-from typing import ClassVar
+from typing import Callable, ClassVar, Type
 
 import jax.flatten_util
 import jax_dataclasses
@@ -158,4 +158,11 @@ class JaxsimDataclass(abc.ABC):
         return obj
 
     def flatten(self) -> jtp.VectorJax:
-        return jax.flatten_util.ravel_pytree(self)[0]
+        return self.flatten_fn()(self)
+
+    @classmethod
+    def flatten_fn(cls: Type[Self]) -> Callable[[Self], jtp.VectorJax]:
+        return lambda pytree: jax.flatten_util.ravel_pytree(pytree)[0]
+
+    def unflatten_fn(self: Self) -> Callable[[jtp.VectorJax], Self]:
+        return jax.flatten_util.ravel_pytree(self)[1]

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -1,5 +1,6 @@
 import abc
 import contextlib
+import copy
 import dataclasses
 import functools
 from collections.abc import Iterator
@@ -324,7 +325,10 @@ class JaxsimDataclass(abc.ABC):
         # Make sure that all the new leaves have the same mutability of the object.
         obj.set_mutability(mutability=self.mutability())
 
-        return obj
+        # Return a shallow copy of the object with the new fields replaced.
+        # Note that the shallow copy of the original object contains exactly the same
+        # attributes of the original object (in other words, with the same id).
+        return copy.copy(obj)
 
     def flatten(self) -> jtp.VectorJax:
         """


### PR DESCRIPTION
When I first designed this class, I wanted to keep the `Mutability` enum private. However, in practice, there are multiple use-cases in which downstream projects need to use it.

This PR:

- Adjusts methods to expose publicly the `Mutability` enum.
- Reduces the number of copies, possibly improving the memory footprint of downstream code.
- Uses stricter checks to prevent JIT recompilations. Beyond pytree structure, now also the shape  and dtype of the leaves if checked, if they are arrays.
- Adds docstrings.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--116.org.readthedocs.build//116/

<!-- readthedocs-preview jaxsim end -->