### PR TITLE
Extend functional APIs

### DIFF
--- a/src/jaxsim/api/__init__.py
+++ b/src/jaxsim/api/__init__.py
@@ -1,3 +1,3 @@
 from . import common  # isort:skip
 from . import model, data  # isort:skip
-from . import contact, joint, kin_dyn_parameters, link, ode, ode_data, references
+from . import com, contact, joint, kin_dyn_parameters, link, ode, ode_data, references

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -155,3 +155,29 @@ def locked_centroidal_spatial_inertia(
     G_Xf_B = B_Xv_G.transpose()
 
     return G_Xf_B @ B_Mbb_B @ B_Xv_G
+
+
+@jax.jit
+def average_centroidal_velocity_jacobian(
+    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Matrix:
+    r"""
+    Compute the Jacobian of the average centroidal velocity of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The Jacobian of the average centroidal velocity of the model.
+
+    Note:
+        The frame corresponding to the output representation of this Jacobian is either
+        :math:`G[W]`, if the active velocity representation is inertial-fixed or mixed,
+        or :math:`G[B]`, if the active velocity representation is body-fixed.
+    """
+
+    G_J = centroidal_momentum_jacobian(model=model, data=data)
+    G_Mbb = locked_centroidal_spatial_inertia(model=model, data=data)
+
+    return jnp.linalg.inv(G_Mbb) @ G_J

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -46,6 +46,36 @@ def com_position(
 
 
 @jax.jit
+def com_linear_velocity(
+    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Vector:
+    r"""
+    Compute the linear velocity of the center of mass of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The linear velocity of the center of mass of the model in the
+        active representation.
+
+    Note:
+        The linear velocity of the center of mass  is expressed in the mixed frame
+        :math:`G = ({}^W \mathbf{p}_{\text{CoM}}, [C])`, where :math:`[C] = [W]` if the
+        active velocity representation is either inertial-fixed or mixed,
+        and :math:`[C] = [B]` if the active velocity representation is body-fixed.
+    """
+
+    # Extract the linear component of the 6D average centroidal velocity.
+    # This is expressed in G[B] in body-fixed representation, and in G[W] in
+    # inertial-fixed or mixed representation.
+    G_vl_WG = average_centroidal_velocity(model=model, data=data)[0:3]
+
+    return G_vl_WG
+
+
+@jax.jit
 def centroidal_momentum(
     model: js.model.JaxSimModel, data: js.data.JaxSimModelData
 ) -> jtp.Vector:

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -46,6 +46,33 @@ def com_position(
 
 
 @jax.jit
+def centroidal_momentum(
+    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Vector:
+    r"""
+    Compute the centroidal momentum of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The centroidal momentum of the model.
+
+    Note:
+        The centroidal momentum is expressed in the mixed frame
+        :math:`({}^W \mathbf{p}_{\text{CoM}}, [C])`, where :math:`C = W` if the
+        active velocity representation is either inertial-fixed or mixed,
+        and :math:`C = B` if the active velocity representation is body-fixed.
+    """
+
+    ν = data.generalized_velocity()
+    G_J = centroidal_momentum_jacobian(model=model, data=data)
+
+    return G_J @ ν
+
+
+@jax.jit
 def centroidal_momentum_jacobian(
     model: js.model.JaxSimModel, data: js.data.JaxSimModelData
 ) -> jtp.Matrix:

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -158,6 +158,33 @@ def locked_centroidal_spatial_inertia(
 
 
 @jax.jit
+def average_centroidal_velocity(
+    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Vector:
+    r"""
+    Compute the average centroidal velocity of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The average centroidal velocity of the model.
+
+    Note:
+        The average velocity is expressed in the mixed frame
+        :math:`G = ({}^W \mathbf{p}_{\text{CoM}}, [C])`, where :math:`[C] = [W]` if the
+        active velocity representation is either inertial-fixed or mixed,
+        and :math:`[C] = [B]` if the active velocity representation is body-fixed.
+    """
+
+    ν = data.generalized_velocity()
+    G_J = average_centroidal_velocity_jacobian(model=model, data=data)
+
+    return G_J @ ν
+
+
+@jax.jit
 def average_centroidal_velocity_jacobian(
     model: js.model.JaxSimModel, data: js.data.JaxSimModelData
 ) -> jtp.Matrix:

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -1,0 +1,42 @@
+import jax
+import jax.numpy as jnp
+import jaxlie
+
+import jaxsim.api as js
+import jaxsim.typing as jtp
+
+
+@jax.jit
+def com_position(
+    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Vector:
+    """
+    Compute the position of the center of mass of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The position of the center of mass of the model w.r.t. the world frame.
+    """
+
+    m = js.model.total_mass(model=model)
+
+    W_H_L = js.model.forward_kinematics(model=model, data=data)
+    W_H_B = data.base_transform()
+    B_H_W = jaxlie.SE3.from_matrix(W_H_B).inverse().as_matrix()
+
+    def B_p̃_LCoM(i) -> jtp.Vector:
+        m = js.link.mass(model=model, link_index=i)
+        L_p_LCoM = js.link.com_position(
+            model=model, data=data, link_index=i, in_link_frame=True
+        )
+        return m * B_H_W @ W_H_L[i] @ jnp.hstack([L_p_LCoM, 1])
+
+    com_links = jax.vmap(B_p̃_LCoM)(jnp.arange(model.number_of_links()))
+
+    B_p̃_CoM = (1 / m) * com_links.sum(axis=0)
+    B_p̃_CoM = B_p̃_CoM.at[3].set(1)
+
+    return (W_H_B @ B_p̃_CoM)[0:3].astype(float)

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -82,6 +82,58 @@ def collidable_point_velocities(
     return collidable_point_kinematics(model=model, data=data)[1]
 
 
+@jax.jit
+def collidable_point_dynamics(
+    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+) -> tuple[jtp.Matrix, jtp.Matrix]:
+    r"""
+    Compute the 6D force applied to each collidable point and the corresponding
+    material deformation rate.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The 6D force applied to each collidable point and the corresponding
+        material deformation rate.
+
+    Note:
+        The material deformation rate is always returned in the mixed frame
+        `C[W] = ({}^W \mathbf{p}_C, [W])`. This is convenient for integration purpose.
+        Instead, the 6D forces are returned in the active representation.
+    """
+
+    # Compute the position and linear velocities (mixed representation) of
+    # all collidable points belonging to the robot.
+    W_p_Ci, W_ṗ_Ci = js.contact.collidable_point_kinematics(model=model, data=data)
+
+    # Build the soft contact model.
+    soft_contacts = jaxsim.rbda.SoftContacts(
+        parameters=data.soft_contacts_params, terrain=model.terrain
+    )
+
+    # Compute the 6D force expressed in the inertial frame and applied to each
+    # collidable point, and the corresponding material deformation rate.
+    # Note that the material deformation rate is always returned in the mixed frame
+    # C[W] = (W_p_C, [W]). This is convenient for integration purpose.
+    W_f_Ci, CW_ṁ = jax.vmap(soft_contacts.contact_model)(
+        W_p_Ci, W_ṗ_Ci, data.state.soft_contacts.tangential_deformation
+    )
+
+    # Convert the 6D forces to the active representation.
+    f_Ci = jax.vmap(
+        lambda W_f_C: data.inertial_to_other_representation(
+            array=W_f_C,
+            other_representation=data.velocity_representation,
+            transform=data.base_transform(),
+            is_force=True,
+        )
+    )(W_f_Ci)
+
+    return f_Ci, CW_ṁ
+
+
 @functools.partial(jax.jit, static_argnames=["link_names"])
 def in_contact(
     model: js.model.JaxSimModel,

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -83,6 +83,27 @@ def collidable_point_velocities(
 
 
 @jax.jit
+def collidable_point_forces(
+    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Matrix:
+    """
+    Compute the 6D forces applied to each collidable point.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The 6D forces applied to each collidable point expressed in the frame
+        corresponding to the active representation.
+    """
+
+    f_Ci, _ = collidable_point_dynamics(model=model, data=data)
+
+    return f_Ci
+
+
+@jax.jit
 def collidable_point_dynamics(
     model: js.model.JaxSimModel, data: js.data.JaxSimModelData
 ) -> tuple[jtp.Matrix, jtp.Matrix]:

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -168,7 +168,7 @@ def estimate_good_soft_contacts_parameters(
             soft_contacts_params=jaxsim.rbda.soft_contacts.SoftContactsParams(),
         )
 
-        W_pz_CoM = js.model.com_position(model=model, data=zero_data)[2]
+        W_pz_CoM = js.com.com_position(model=model, data=zero_data)[2]
 
         if model.floating_base():
             W_pz_C = collidable_point_positions(model=model, data=zero_data)[:, -1]

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -479,7 +479,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         if model is None:
             return replace(s=positions)
 
-        if not self.valid(model=model):
+        if not_tracing(positions) and not self.valid(model=model):
             msg = "The data object is not compatible with the provided model"
             raise ValueError(msg)
 
@@ -525,7 +525,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         if model is None:
             return replace(ṡ=velocities)
 
-        if not self.valid(model=model):
+        if not_tracing(velocities) and not self.valid(model=model):
             msg = "The data object is not compatible with the provided model"
             raise ValueError(msg)
 

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -9,8 +9,7 @@ import jaxlie
 from jax_dataclasses import Static
 
 import jaxsim.typing as jtp
-from jaxsim.math.inertia import Inertia
-from jaxsim.math.joint_model import JointModel, supported_joint_motion
+from jaxsim.math import Inertia, JointModel, supported_joint_motion
 from jaxsim.parsers.descriptions import JointDescription, ModelDescription
 from jaxsim.utils import JaxsimDataclass
 

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1134,6 +1134,26 @@ def total_momentum_jacobian(
             raise ValueError(output_vel_repr)
 
 
+@jax.jit
+def average_velocity(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Vector:
+    """
+    Compute the average velocity of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The average velocity of the model computed in the base frame and expressed
+        in the active representation.
+    """
+
+    ν = data.generalized_velocity()
+    J = average_velocity_jacobian(model=model, data=data)
+
+    return J @ ν
+
+
 @functools.partial(jax.jit, static_argnames=["output_vel_repr"])
 def average_velocity_jacobian(
     model: JaxSimModel,

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -854,7 +854,7 @@ def inverse_dynamics(
         expressed in a generic frame C to the inertial-fixed representation W_v̇_WB.
         """
 
-        from jaxsim.math.cross import Cross
+        from jaxsim.math import Cross
 
         W_X_C = jaxlie.SE3.from_matrix(W_H_C).adjoint()
         C_X_W = jaxlie.SE3.from_matrix(W_H_C).inverse().adjoint()

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1031,6 +1031,24 @@ def free_floating_bias_forces(
 
 
 @jax.jit
+def locked_spatial_inertia(
+    model: JaxSimModel, data: js.data.JaxSimModelData
+) -> jtp.Matrix:
+    """
+    Compute the locked 6D inertia matrix of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The locked 6D inertia matrix of the model.
+    """
+
+    return total_momentum_jacobian(model=model, data=data)[:, 0:6]
+
+
+@jax.jit
 def total_momentum(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Vector:
     """
     Compute the total momentum of the model.

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -7,7 +7,7 @@ import jaxsim.api as js
 import jaxsim.rbda
 import jaxsim.typing as jtp
 from jaxsim.integrators import Time
-from jaxsim.math.quaternion import Quaternion
+from jaxsim.math import Quaternion
 from jaxsim.utils import Mutability
 
 from .common import VelRepr

--- a/src/jaxsim/math/__init__.py
+++ b/src/jaxsim/math/__init__.py
@@ -8,3 +8,4 @@ from .joint_model import JointModel, supported_joint_motion
 from .quaternion import Quaternion
 from .rotation import Rotation
 from .skew import Skew
+from .transform import Transform

--- a/src/jaxsim/math/adjoint.py
+++ b/src/jaxsim/math/adjoint.py
@@ -39,6 +39,28 @@ class Adjoint:
         )
 
     @staticmethod
+    def from_transform(transform: jtp.MatrixLike, inverse: bool = False) -> jtp.Matrix:
+        """
+        Create an adjoint matrix from a transformation matrix.
+
+        Args:
+            transform: A 4x4 transformation matrix.
+            inverse: Whether to compute the inverse adjoint.
+
+        Returns:
+            The 6x6 adjoint matrix.
+        """
+
+        A_H_B = jnp.array(transform).astype(float)
+        assert transform.shape == (4, 4)
+
+        return (
+            jaxlie.SE3.from_matrix(matrix=A_H_B).adjoint()
+            if not inverse
+            else jaxlie.SE3.from_matrix(matrix=A_H_B).inverse().adjoint()
+        )
+
+    @staticmethod
     def from_rotation_and_translation(
         rotation: jtp.Matrix = jnp.eye(3),
         translation: jtp.Vector = jnp.zeros(3),

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -9,13 +9,14 @@ import jaxlie
 from jax_dataclasses import Static
 
 import jaxsim.typing as jtp
-from jaxsim.math.rotation import Rotation
 from jaxsim.parsers.descriptions import (
     JointDescriptor,
     JointGenericAxis,
     JointType,
     ModelDescription,
 )
+
+from .rotation import Rotation
 
 
 @jax_dataclasses.pytree_dataclass

--- a/src/jaxsim/math/transform.py
+++ b/src/jaxsim/math/transform.py
@@ -1,0 +1,93 @@
+import jax
+import jax.numpy as jnp
+import jaxlie
+
+import jaxsim.typing as jtp
+
+from .quaternion import Quaternion
+
+
+class Transform:
+
+    @staticmethod
+    def from_quaternion_and_translation(
+        quaternion: jtp.VectorLike = jnp.array([1.0, 0, 0, 0]),
+        translation: jtp.VectorLike = jnp.zeros(3),
+        inverse: jtp.BoolLike = False,
+        normalize_quaternion: jtp.BoolLike = False,
+    ) -> jtp.Matrix:
+        """
+        Create a transformation matrix from a quaternion and a translation.
+
+        Args:
+            quaternion: A 4D vector representing a SO(3) orientation.
+            translation: A 3D vector representing a translation.
+            inverse: Whether to compute the inverse transformation.
+            normalize_quaternion:
+                Whether to normalize the quaternion before creating the transformation.
+
+        Returns:
+            The 4x4 transformation matrix representing the SE(3) transformation.
+        """
+
+        W_Q_B = jnp.array(quaternion).astype(float)
+        W_p_B = jnp.array(translation).astype(float)
+
+        assert W_p_B.size == 3
+        assert W_Q_B.size == 4
+
+        A_R_B = jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(W_Q_B))
+        A_R_B = A_R_B if not normalize_quaternion else A_R_B.normalize()
+
+        A_H_B = jaxlie.SE3.from_rotation_and_translation(
+            rotation=A_R_B, translation=W_p_B
+        )
+
+        return A_H_B.as_matrix() if not inverse else A_H_B.inverse().as_matrix()
+
+    @staticmethod
+    def from_rotation_and_translation(
+        rotation: jtp.MatrixLike,
+        translation: jtp.VectorLike,
+        inverse: jtp.BoolLike = False,
+    ) -> jtp.Matrix:
+        """
+        Create a transformation matrix from a rotation matrix and a translation vector.
+
+        Args:
+            rotation: A 3x3 rotation matrix representing a SO(3) orientation.
+            translation: A 3D vector representing a translation.
+            inverse: Whether to compute the inverse transformation.
+
+        Returns:
+            The 4x4 transformation matrix representing the SE(3) transformation.
+        """
+
+        A_R_B = jnp.array(rotation).astype(float)
+        W_p_B = jnp.array(translation).astype(float)
+
+        assert W_p_B.size == 3
+        assert A_R_B.shape == (3, 3)
+
+        A_H_B = jaxlie.SE3.from_rotation_and_translation(
+            rotation=A_R_B, translation=W_p_B
+        )
+
+        return A_H_B.as_matrix() if not inverse else A_H_B.inverse().as_matrix()
+
+    @staticmethod
+    def inverse(transform: jtp.MatrixLike) -> jtp.Matrix:
+        """
+        Compute the inverse transformation matrix.
+
+        Args:
+            transform: A 4x4 transformation matrix.
+
+        Returns:
+            The 4x4 inverse transformation matrix.
+        """
+
+        A_H_B = jnp.array(transform).astype(float)
+        assert A_H_B.shape == (4, 4)
+
+        return jaxlie.SE3.from_matrix(matrix=A_H_B).inverse().as_matrix()

--- a/tests/test_api_com.py
+++ b/tests/test_api_com.py
@@ -1,0 +1,33 @@
+import jax
+import pytest
+
+import jaxsim.api as js
+from jaxsim import VelRepr
+
+from . import utils_idyntree
+
+
+def test_com_properties(
+    jaxsim_models_types: js.model.JaxSimModel,
+    velocity_representation: VelRepr,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_models_types
+
+    key, subkey = jax.random.split(prng_key, num=2)
+    data = js.data.random_model_data(
+        model=model, key=subkey, velocity_representation=velocity_representation
+    )
+
+    kin_dyn = utils_idyntree.build_kindyncomputations_from_jaxsim_model(
+        model=model, data=data
+    )
+
+    # =====
+    # Tests
+    # =====
+
+    p_com_idt = kin_dyn.com_position()
+    p_com_js = js.com.com_position(model=model, data=data)
+    assert pytest.approx(p_com_idt) == p_com_js

--- a/tests/test_api_com.py
+++ b/tests/test_api_com.py
@@ -31,3 +31,33 @@ def test_com_properties(
     p_com_idt = kin_dyn.com_position()
     p_com_js = js.com.com_position(model=model, data=data)
     assert pytest.approx(p_com_idt) == p_com_js
+
+    J_Gh_idt = kin_dyn.centroidal_momentum_jacobian()
+    J_Gh_js = js.com.centroidal_momentum_jacobian(model=model, data=data)
+    assert pytest.approx(J_Gh_idt) == J_Gh_js
+
+    h_com_idt = kin_dyn.centroidal_momentum()
+    h_com_js = js.com.centroidal_momentum(model=model, data=data)
+    assert pytest.approx(h_com_idt) == h_com_js
+
+    M_com_locked_idt = kin_dyn.locked_centroidal_spatial_inertia()
+    M_com_locked_js = js.com.locked_centroidal_spatial_inertia(model=model, data=data)
+    assert pytest.approx(M_com_locked_idt) == M_com_locked_js
+
+    J_avg_com_idt = kin_dyn.average_centroidal_velocity_jacobian()
+    J_avg_com_js = js.com.average_centroidal_velocity_jacobian(model=model, data=data)
+    assert pytest.approx(J_avg_com_idt) == J_avg_com_js
+
+    v_avg_com_idt = kin_dyn.average_centroidal_velocity()
+    v_avg_com_js = js.com.average_centroidal_velocity(model=model, data=data)
+    assert pytest.approx(v_avg_com_idt) == v_avg_com_js
+
+    # https://github.com/ami-iit/jaxsim/pull/117#discussion_r1535486123
+    with data.switch_velocity_representation(
+        data.velocity_representation
+        if data.velocity_representation is not VelRepr.Body
+        else VelRepr.Mixed
+    ):
+        vl_com_idt = kin_dyn.com_velocity()
+        vl_com_js = js.com.com_linear_velocity(model=model, data=data)
+        assert pytest.approx(vl_com_idt) == vl_com_js

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -149,3 +149,11 @@ def test_link_jacobians(
     if data.velocity_representation is VelRepr.Inertial:
         J_WL_model = js.model.generalized_free_floating_jacobian(model=model, data=data)
         assert J_WL_model == pytest.approx(J_WL_links)
+
+    for link_name, link_idx in zip(
+        model.link_names(),
+        js.link.names_to_idxs(model=model, link_names=model.link_names()),
+    ):
+        v_WL_idt = kin_dyn.frame_velocity(frame_name=link_name)
+        v_WL_js = js.link.velocity(model=model, data=data, link_index=link_idx)
+        assert v_WL_js == pytest.approx(v_WL_idt), link_name

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -94,13 +94,25 @@ def test_model_properties(
     m_js = js.model.total_mass(model=model)
     assert pytest.approx(m_idt) == m_js
 
+    J_Bh_idt = kin_dyn.total_momentum_jacobian()
+    J_Bh_js = js.model.total_momentum_jacobian(model=model, data=data)
+    assert pytest.approx(J_Bh_idt) == J_Bh_js
+
     h_tot_idt = kin_dyn.total_momentum()
     h_tot_js = js.model.total_momentum(model=model, data=data)
     assert pytest.approx(h_tot_idt) == h_tot_js
 
-    Jh_idt = kin_dyn.total_momentum_jacobian()
-    Jh_js = js.model.free_floating_mass_matrix(model=model, data=data)[0:6]
-    assert pytest.approx(Jh_idt) == Jh_js
+    M_locked_idt = kin_dyn.locked_spatial_inertia()
+    M_locked_js = js.model.locked_spatial_inertia(model=model, data=data)
+    assert pytest.approx(M_locked_idt) == M_locked_js
+
+    J_avg_idt = kin_dyn.average_velocity_jacobian()
+    J_avg_js = js.model.average_velocity_jacobian(model=model, data=data)
+    assert pytest.approx(J_avg_idt) == J_avg_js
+
+    v_avg_idt = kin_dyn.average_velocity()
+    v_avg_js = js.model.average_velocity(model=model, data=data)
+    assert pytest.approx(v_avg_idt) == v_avg_js
 
 
 def test_model_rbda(

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -64,8 +64,8 @@ def test_model_creation_and_reduction(
     )
 
     # Check that the CoM position is preserved.
-    assert js.model.com_position(model=model_full, data=data) == pytest.approx(
-        js.model.com_position(model=model_reduced, data=data_reduced), abs=1e-6
+    assert js.com.com_position(model=model_full, data=data) == pytest.approx(
+        js.com.com_position(model=model_reduced, data=data_reduced), abs=1e-6
     )
 
 
@@ -93,10 +93,6 @@ def test_model_properties(
     m_idt = kin_dyn.total_mass()
     m_js = js.model.total_mass(model=model)
     assert pytest.approx(m_idt) == m_js
-
-    p_com_idt = kin_dyn.com_position()
-    p_com_js = js.model.com_position(model=model, data=data)
-    assert pytest.approx(p_com_idt) == p_com_js
 
     h_tot_idt = kin_dyn.total_momentum()
     h_tot_js = js.model.total_momentum(model=model, data=data)

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -281,10 +281,24 @@ class KinDynComputations:
 
         return nu.toNumPy()[0:6]
 
+    def frame_velocity(self, frame_name: str) -> npt.NDArray:
+
+        if self.kin_dyn.getFrameIndex(frame_name) < 0:
+            raise ValueError(f"Frame '{frame_name}' does not exist")
+
+        v_WF = self.kin_dyn.getFrameVel(frame_name)
+
+        return v_WF.toNumPy()
+
     def com_position(self) -> npt.NDArray:
 
         W_p_G = self.kin_dyn.getCenterOfMassPosition()
         return W_p_G.toNumPy()
+
+    def com_velocity(self) -> npt.NDArray:
+
+        W_ṗ_G = self.kin_dyn.getCenterOfMassVelocity()
+        return W_ṗ_G.toNumPy()
 
     def mass_matrix(self) -> npt.NDArray:
 
@@ -327,11 +341,58 @@ class KinDynComputations:
 
         return self.kin_dyn.getLinearAngularMomentum().toNumPy().flatten()
 
+    def centroidal_momentum(self) -> npt.NDArray:
+
+        return self.kin_dyn.getCentroidalTotalMomentum().toNumPy().flatten()
+
     def total_momentum_jacobian(self) -> npt.NDArray:
 
         Jh = idt.MatrixDynSize()
 
         if not self.kin_dyn.getLinearAngularMomentumJacobian(Jh):
             raise RuntimeError("Failed to get the total momentum jacobian")
+
+        return Jh.toNumPy()
+
+    def centroidal_momentum_jacobian(self) -> npt.NDArray:
+
+        Jh = idt.MatrixDynSize()
+
+        if not self.kin_dyn.getCentroidalTotalMomentumJacobian(Jh):
+            raise RuntimeError("Failed to get the centroidal momentum jacobian")
+
+        return Jh.toNumPy()
+
+    def locked_spatial_inertia(self) -> npt.NDArray:
+
+        return self.kin_dyn.getRobotLockedInertia().asMatrix().toNumPy()
+
+    def locked_centroidal_spatial_inertia(self) -> npt.NDArray:
+
+        return self.kin_dyn.getCentroidalRobotLockedInertia().asMatrix().toNumPy()
+
+    def average_velocity(self) -> npt.NDArray:
+
+        return self.kin_dyn.getAverageVelocity().toNumPy()
+
+    def average_velocity_jacobian(self) -> npt.NDArray:
+
+        Jh = idt.MatrixDynSize()
+
+        if not self.kin_dyn.getAverageVelocityJacobian(Jh):
+            raise RuntimeError("Failed to get the average velocity jacobian")
+
+        return Jh.toNumPy()
+
+    def average_centroidal_velocity(self) -> npt.NDArray:
+
+        return self.kin_dyn.getCentroidalAverageVelocity().toNumPy()
+
+    def average_centroidal_velocity_jacobian(self) -> npt.NDArray:
+
+        Jh = idt.MatrixDynSize()
+
+        if not self.kin_dyn.getCentroidalAverageVelocityJacobian(Jh):
+            raise RuntimeError("Failed to get the average centroidal velocity jacobian")
 
         return Jh.toNumPy()


### PR DESCRIPTION
This PR extends the functional APIs with a lot of new functions:

- New `jaxsim.api.com` module.
- New `jaxsim.api.com.com_linear_velocity` function.
- New `jaxsim.api.com.centroidal_momentum` function.
- New `jaxsim.api.com.centroidal_momentum_jacobian` function.
- New `jaxsim.api.com.locked_centroidal_spatial_inertia` function.
- New `jaxsim.api.com.average_centroidal_velocity` function.
- New `jaxsim.api.com.average_centroidal_velocity_jacobian` function.
- New `jaxsim.api.contact.collidable_point_forces` function.
- New `jaxsim.api.contact.collidable_point_dynamics` function.
- New `jaxsim.api.link.velocity` function.
- New `jaxsim.api.model.locked_spatial_inertia` function.
- New `jaxsim.api.model.total_momentum_jacobian` function.
- New `jaxsim.api.model.average_velocity` function.
- New `jaxsim.api.model.average_velocity_jacobian` function.
- New `jaxsim.api.model.link_contact_forces` function.
- New `jaxsim.math.transform` module.
- New `Adjoint.from_transform` method.
- Added some missing docstrings.
- Extended tests for new functions.

These are particularly useful for (differentiable) model-based control, especially in centroidal coordinates cc @DanielePucci.

Refer to `Traversaro2017a`[^1] and Section 3.9 of `Traversaro2017b`[^2] for more details.

[^1]: _Traversaro, Pucci, Nori_, A Uniﬁed View of the Equations of Motion used for Control Design of Humanoid Robots, 2017 [url](https://www.researchgate.net/publication/312200239_A_Unified_View_of_the_Equations_of_Motion_used_for_Control_Design_of_Humanoid_Robots).
[^2]: _Traversaro_, Modelling, Estimation and Identification of Humanoid Robots Dynamics, 2017, [url](https://github.com/traversaro/traversaro-phd-thesis).

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--117.org.readthedocs.build//117/

<!-- readthedocs-preview jaxsim end -->