### PR TITLE
Add support for inclined planes and heightmap visualization

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -52,6 +52,8 @@ class JaxSimModel(JaxsimDataclass):
     def build_from_model_description(
         model_description: str | pathlib.Path | rod.Model,
         model_name: str | None = None,
+        *,
+        terrain: jaxsim.terrain.Terrain | None = None,
         is_urdf: bool | None = None,
         considered_joints: list[str] | None = None,
     ) -> JaxSimModel:
@@ -65,6 +67,8 @@ class JaxSimModel(JaxsimDataclass):
             model_name:
                 The optional name of the model that overrides the one in
                 the description.
+            terrain:
+                The optional terrain to consider.
             is_urdf:
                 Whether the model description is a URDF or an SDF. This is
                 automatically inferred if the model description is a path to a file.
@@ -92,7 +96,9 @@ class JaxSimModel(JaxsimDataclass):
 
         # Build the model
         model = JaxSimModel.build(
-            model_description=intermediate_description, model_name=model_name
+            model_description=intermediate_description,
+            model_name=model_name,
+            terrain=terrain,
         )
 
         # Store the origin of the model, in case downstream logic needs it
@@ -105,6 +111,8 @@ class JaxSimModel(JaxsimDataclass):
     def build(
         model_description: jaxsim.parsers.descriptions.ModelDescription,
         model_name: str | None = None,
+        *,
+        terrain: jaxsim.terrain.Terrain | None = None,
     ) -> JaxSimModel:
         """
         Build a Model object from an intermediate model description.
@@ -115,6 +123,8 @@ class JaxSimModel(JaxsimDataclass):
                 of the model.
             model_name:
                 The optional name of the model overriding the physics model name.
+            terrain:
+                The optional terrain to consider.
 
         Returns:
             The built Model object.
@@ -130,6 +140,7 @@ class JaxSimModel(JaxsimDataclass):
             kin_dyn_parameters=js.kin_dyn_parameters.KynDynParameters.build(
                 model_description=model_description
             ),
+            terrain=terrain or JaxSimModel.__dataclass_fields__["terrain"].default,
         )
 
         return model

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -413,8 +413,8 @@ class RodModelToMjcf:
             "camera",
             name="track",
             mode="trackcom",
-            pos="1 0 5",
-            zaxis="0 0 1",
+            pos="1.930 -2.279 0.556",
+            xyaxes="0.771 0.637 0.000 -0.116 0.140 0.983",
             fovy="60",
         )
 

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -374,6 +374,7 @@ class RodModelToMjcf:
             condim="3",
             contype="1",
             conaffinity="1",
+            zaxis=" ".join(map(str, plane_normal)),
         )
 
         _ = ET.SubElement(
@@ -449,6 +450,7 @@ class UrdfToMjcf:
         urdf: str | pathlib.Path,
         considered_joints: list[str] | None = None,
         model_name: str | None = None,
+        plane_normal: tuple[float, float, float] = (0, 0, 1),
     ) -> tuple[str, dict[str, Any]]:
         """"""
 
@@ -461,7 +463,10 @@ class UrdfToMjcf:
 
         # Convert the ROD model to MJCF.
         return RodModelToMjcf.convert(
-            rod_model=rod_model, considered_joints=considered_joints
+            rod_model=rod_model,
+            considered_joints=considered_joints,
+            plane_normal=plane_normal,
+            heightmap=heightmap,
         )
 
 
@@ -471,6 +476,7 @@ class SdfToMjcf:
         sdf: str | pathlib.Path,
         considered_joints: list[str] | None = None,
         model_name: str | None = None,
+        plane_normal: tuple[float, float, float] = (0, 0, 1),
     ) -> tuple[str, dict[str, Any]]:
         """"""
 
@@ -483,5 +489,8 @@ class SdfToMjcf:
 
         # Convert the ROD model to MJCF.
         return RodModelToMjcf.convert(
-            rod_model=rod_model, considered_joints=considered_joints
+            rod_model=rod_model,
+            considered_joints=considered_joints,
+            plane_normal=plane_normal,
+            heightmap=heightmap,
         )

--- a/src/jaxsim/terrain/__init__.py
+++ b/src/jaxsim/terrain/__init__.py
@@ -1,2 +1,2 @@
 from . import terrain
-from .terrain import FlatTerrain, Terrain
+from .terrain import FlatTerrain, PlaneTerrain, Terrain


### PR DESCRIPTION
This pull request adds support for inclined planes and heightmap visualization using the MuJoCo visualizer.

Default behavior:

https://github.com/ami-iit/jaxsim/assets/102977828/e1dc0466-c5b3-43b8-89be-bde6756de05f



To run the examples:

<details>
<summary>MWE Inclined Plane</summary>

```python
import pathlib

import jax.numpy as jnp
import numpy as np
import resolve_robotics_uri_py
import rod

import jaxsim
import jaxsim.api as js
from jaxsim import VelRepr, integrators

# Find the urdf file.
urdf_path = resolve_robotics_uri_py.resolve_robotics_uri(uri="file://stickbot.urdf")
# Build the ROD model.
rod_sdf = rod.Sdf.load(sdf=urdf_path)

# Create a terrain.
plane_normal = jnp.array([0.0, -0.1, 0.2])
terrain = jaxsim.terrain.PlaneTerrain(
    plane_normal=plane_normal,
)

# Build the model.
model = js.model.JaxSimModel.build_from_model_description(
    model_description=rod_sdf.model,
    terrain=terrain,
)


# Build the model's data.
# Set already here the initial base position.
data0 = js.data.JaxSimModelData.build(
    model=model,
    base_position=jnp.array([0, 0, 0.85]),
    velocity_representation=VelRepr.Inertial,
)

# Update the soft-contact parameters.
# By default, only 1 support point is used as worst-case scenario.
# Feel free to tune this with more points to get a less stiff system.
data0 = data0.replace(
    soft_contacts_params=js.contact.estimate_good_soft_contacts_parameters(
        model, number_of_active_collidable_points_steady_state=2
    )
)

# =====================
# Create the integrator
# =====================

# Create a RK4 integrator integrating the quaternion on SO(3).
integrator = integrators.fixed_step.RungeKutta4SO3.build(
    dynamics=js.ode.wrap_system_dynamics_for_integration(
        model=model,
        data=data0,
        system_dynamics=js.ode.system_dynamics,
    ),
)

# =========================================
# Visualization in Mujoco viewer / renderer
# =========================================

from jaxsim.mujoco import MujocoModelHelper, MujocoVideoRecorder, RodModelToMjcf

# Convert the ROD model to a Mujoco model.
mjcf_string, assets = RodModelToMjcf.convert(
    rod_model=rod_sdf.models()[0],
    considered_joints=list(model.joint_names()),
    plane_normal=plane_normal,
)

# Build the Mujoco model helper.
mj_model_helper = self = MujocoModelHelper.build_from_xml(
    mjcf_description=mjcf_string, assets=assets
)

# Create the video recorder.
recorder = MujocoVideoRecorder(
    model=mj_model_helper.model,
    data=mj_model_helper.data,
    fps=int(1 / 0.010),
    width=320 * 4,
    height=240 * 4,
)

# ==============
# Recording loop
# ==============

# Initialize the integrator.
t0 = 0.0
tf = 5.0
dt = 0.001_000
integrator_state = integrator.init(x0=data0.state, t0=t0, dt=dt)

# Initialize the loop.
data = data0.copy()
joint_names = list(model.joint_names())

while data.time_ns < tf * 1e9:

    # Integrate the dynamics.
    data, integrator_state = js.model.step(
        dt=dt,
        model=model,
        data=data,
        integrator=integrator,
        integrator_state=integrator_state,
        # Optional inputs
        joint_forces=None,
        external_forces=None,
    )

    # Extract the generalized position.
    s = data.state.physics_model.joint_positions
    W_p_B = data.state.physics_model.base_position
    W_Q_B = data.state.physics_model.base_quaternion

    # Update the data object stored in the helper, which is shared with the recorder.
    mj_model_helper.set_base_position(position=np.array(W_p_B))
    mj_model_helper.set_base_orientation(orientation=np.array(W_Q_B), dcm=False)
    mj_model_helper.set_joint_positions(positions=np.array(s), joint_names=joint_names)

    # Record the frame if the time is right to get the desired fps.
    if data.time_ns % jnp.array(1e9 / recorder.fps).astype(jnp.uint64) == 0:
        recorder.record_frame(camera_name=None)

# Store the video.
video_path = pathlib.Path("~/video.mp4").expanduser()
recorder.write_video(path=video_path, exist_ok=True)

# Clean up the recorder.
recorder.frames = []
recorder.renderer.close()
```

</details>

https://github.com/ami-iit/jaxsim/assets/102977828/c283fd84-2aff-4f41-8728-27934eb10000


<details>
<summary>MWE Heightmap</summary>

```python
# Coming soon
```
</details>

C.C. @lorycontixd 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--122.org.readthedocs.build//122/

<!-- readthedocs-preview jaxsim end -->