### PR TITLE
Compute link bias accelerations J̇ν

### DIFF
--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -335,3 +335,27 @@ def velocity(
 
     # Compute the link velocity in the output velocity representation.
     return O_J_WL_I @ I_ν
+
+
+@jax.jit
+def bias_acceleration(
+    model: js.model.JaxSimModel,
+    data: js.data.JaxSimModelData,
+    *,
+    link_index: jtp.IntLike,
+) -> jtp.Vector:
+    """
+    Compute the bias acceleration of the link.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+        link_index: The index of the link.
+
+    Returns:
+        The 6D bias acceleration of the link.
+    """
+
+    # Compute the bias acceleration of all links in the active representation.
+    O_v̇_WL = js.model.link_bias_accelerations(model=model, data=data)[link_index]
+    return O_v̇_WL

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -157,3 +157,35 @@ def test_link_jacobians(
         v_WL_idt = kin_dyn.frame_velocity(frame_name=link_name)
         v_WL_js = js.link.velocity(model=model, data=data, link_index=link_idx)
         assert v_WL_js == pytest.approx(v_WL_idt), link_name
+
+
+def test_link_bias_acceleration(
+    jaxsim_models_types: js.model.JaxSimModel,
+    velocity_representation: VelRepr,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_models_types
+
+    key, subkey = jax.random.split(prng_key, num=2)
+    data = js.data.random_model_data(
+        model=model,
+        key=subkey,
+        velocity_representation=velocity_representation,
+    )
+
+    kin_dyn = utils_idyntree.build_kindyncomputations_from_jaxsim_model(
+        model=model, data=data
+    )
+
+    # =====
+    # Tests
+    # =====
+
+    for name, index in zip(
+        model.link_names(),
+        js.link.names_to_idxs(model=model, link_names=model.link_names()),
+    ):
+        Jν_idt = kin_dyn.frame_bias_acc(frame_name=name)
+        Jν_js = js.link.bias_acceleration(model=model, data=data, link_index=index)
+        assert pytest.approx(Jν_idt) == Jν_js

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -161,6 +161,13 @@ def test_model_rbda(
     )
     assert pytest.approx(HH_idt) == HH_js
 
+    # Bias accelerations
+    Jν_js = js.model.link_bias_accelerations(model=model, data=data)
+    Jν_idt = jnp.stack(
+        [kin_dyn.frame_bias_acc(frame_name=name) for name in model.link_names()]
+    )
+    assert pytest.approx(Jν_idt) == Jν_js
+
 
 def test_model_jacobian(
     jaxsim_models_types: js.model.JaxSimModel,

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -290,6 +290,15 @@ class KinDynComputations:
 
         return v_WF.toNumPy()
 
+    def frame_bias_acc(self, frame_name: str) -> npt.NDArray:
+
+        if self.kin_dyn.getFrameIndex(frame_name) < 0:
+            raise ValueError(f"Frame '{frame_name}' does not exist")
+
+        J̇ν = self.kin_dyn.getFrameBiasAcc(frame_name)
+
+        return J̇ν.toNumPy()
+
     def com_position(self) -> npt.NDArray:
 
         W_p_G = self.kin_dyn.getCenterOfMassPosition()


### PR DESCRIPTION
This PR adds a new algorithm to compute the link bias accelerations $\dot{J} \boldsymbol{\nu}$, i.e. the accelerations not due to $\dot{\boldsymbol{\nu}}$.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--127.org.readthedocs.build//127/

<!-- readthedocs-preview jaxsim end -->