### PR TITLE
Support user-defined cameras in `mujoco.loaders`

### DIFF
--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -159,6 +159,9 @@ class RodModelToMjcf:
         considered_joints: list[str] | None = None,
         plane_normal: tuple[float, float, float] = (0, 0, 1),
         heightmap: bool | None = None,
+        cameras: (
+            list[dict[str, str, str, str, str]] | dict[str, str, str, str, str]
+        ) = None,
     ) -> tuple[str, dict[str, Any]]:
         """
         Converts a ROD model to a Mujoco MJCF string.
@@ -166,6 +169,9 @@ class RodModelToMjcf:
         Args:
             rod_model: The ROD model to convert.
             considered_joints: The list of joint names to consider in the conversion.
+            plane_normal: The normal vector of the plane.
+            heightmap: Whether to generate a heightmap.
+            cameras: The list of cameras to add to the scene.
 
         Returns:
             tuple: A tuple containing the MJCF string and the assets dictionary.
@@ -470,6 +476,11 @@ class RodModelToMjcf:
             fovy="60",
         )
 
+        # Add user-defined camera
+        cameras = cameras if cameras is not None else {}
+        for camera in cameras if isinstance(cameras, list) else [cameras]:
+            _ = ET.SubElement(worldbody_element, "camera", **camera)
+
         # ------------------------------------------------
         # Add a light following the  CoM of the first link
         # ------------------------------------------------
@@ -504,6 +515,9 @@ class UrdfToMjcf:
         model_name: str | None = None,
         plane_normal: tuple[float, float, float] = (0, 0, 1),
         heightmap: bool | None = None,
+        cameras: (
+            list[dict[str, str, str, str, str]] | dict[str, str, str, str, str]
+        ) = None,
     ) -> tuple[str, dict[str, Any]]:
         """
         Converts a URDF file to a Mujoco MJCF string.
@@ -512,6 +526,9 @@ class UrdfToMjcf:
             urdf: The URDF file to convert.
             considered_joints: The list of joint names to consider in the conversion.
             model_name: The name of the model to convert.
+            plane_normal: The normal vector of the plane.
+            heightmap: Whether to generate a heightmap.
+            cameras: The list of cameras to add to the scene.
 
         Returns:
             tuple: A tuple containing the MJCF string and the assets dictionary.
@@ -530,6 +547,7 @@ class UrdfToMjcf:
             considered_joints=considered_joints,
             plane_normal=plane_normal,
             heightmap=heightmap,
+            cameras=cameras,
         )
 
 
@@ -541,6 +559,9 @@ class SdfToMjcf:
         model_name: str | None = None,
         plane_normal: tuple[float, float, float] = (0, 0, 1),
         heightmap: bool | None = None,
+        cameras: (
+            list[dict[str, str, str, str, str]] | dict[str, str, str, str, str]
+        ) = None,
     ) -> tuple[str, dict[str, Any]]:
         """
         Converts a SDF file to a Mujoco MJCF string.
@@ -549,6 +570,9 @@ class SdfToMjcf:
             sdf: The SDF file to convert.
             considered_joints: The list of joint names to consider in the conversion.
             model_name: The name of the model to convert.
+            plane_normal: The normal vector of the plane.
+            heightmap: Whether to generate a heightmap.
+            cameras: The list of cameras to add to the scene.
 
         Returns:
             tuple: A tuple containing the MJCF string and the assets dictionary.
@@ -567,4 +591,5 @@ class SdfToMjcf:
             considered_joints=considered_joints,
             plane_normal=plane_normal,
             heightmap=heightmap,
+            cameras=cameras,
         )


### PR DESCRIPTION
This pull request will add support for user-defined cameras when using a `mujoco.loaders` instance. In particular, the user is required to pass a dictionary or a list of dictionaries containing 5 attributes, e.g.:

```python
camera = dict(
    name="cartpole_camera",
    mode="fixed",
    pos="3.954 3.533 2.343",
    xyaxes="-0.594 0.804 -0.000 -0.163 -0.120 0.979",
    fovy="60",
)
```

The camera can be then used inside the visualizers passing the argument `camera_name`.

```python
recorder.record_frame(camera_name="cartpole_camera")
```


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--133.org.readthedocs.build//133/

<!-- readthedocs-preview jaxsim end -->