### PR TITLE
Fix `RodModelToMjcf.convert` when no `cameras` argument is passed

### DIFF
--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -476,7 +476,7 @@ class RodModelToMjcf:
         )
 
         # Add user-defined camera
-        cameras = cameras if cameras is not None else {}
+        cameras = cameras if cameras is not None else []
         for camera in cameras if isinstance(cameras, list) else [cameras]:
             mj_camera = MujocoCamera.build(**camera)
             _ = ET.SubElement(


### PR DESCRIPTION
Regression introduced in #133.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--135.org.readthedocs.build//135/

<!-- readthedocs-preview jaxsim end -->