### PR TITLE
Support reducing a model considering non-zero positions of removed joints

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - isort
   - pre-commit
   # [testing]
-  - idyntree
+  - idyntree >= 12.2.1
   - pytest
   - pytest-icdiff
   - robot_descriptions

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ style =
     isort
     pre-commit
 testing =
-    idyntree
+    idyntree >= 12.2.1
     pytest >=6.0
     pytest-icdiff
     robot-descriptions

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -4,7 +4,7 @@ import copy
 import dataclasses
 import functools
 import pathlib
-from typing import Any
+from typing import Any, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -56,7 +56,7 @@ class JaxSimModel(JaxsimDataclass):
         *,
         terrain: jaxsim.terrain.Terrain | None = None,
         is_urdf: bool | None = None,
-        considered_joints: list[str] | None = None,
+        considered_joints: Sequence[str] | None = None,
     ) -> JaxSimModel:
         """
         Build a Model object from a model description.
@@ -293,7 +293,7 @@ def reduce(
     # Update the initial position of the joints.
     # This is necessary to compute the correct pose of the link pairs connected
     # to removed joints.
-    for joint_name in model.joint_names():
+    for joint_name in set(model.joint_names()) - set(considered_joints):
         j = intermediate_description.joints_dict[joint_name]
         with j.mutable_context():
             j.initial_position = float(joint_positions_locked.get(joint_name, 0.0))

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -261,7 +261,7 @@ class JaxSimModel(JaxsimDataclass):
 def reduce(
     model: JaxSimModel,
     considered_joints: tuple[str, ...],
-    joint_positions_locked: dict[str, jtp.Float] | None = None,
+    locked_joint_positions: dict[str, jtp.Float] | None = None,
 ) -> JaxSimModel:
     """
     Reduce the model by lumping together the links connected by removed joints.
@@ -269,20 +269,20 @@ def reduce(
     Args:
         model: The model to reduce.
         considered_joints: The sequence of joints to consider.
-        joint_positions_locked:
+        locked_joint_positions:
             A dictionary containing the positions of the joints to be considered
             in the reduction process. The removed joints in the reduced model
-            will have their position locked to the value in this dictionary.
-            If a joint is not present in the dictionary, its position is set to zero.
+            will have their position locked to their value in this dictionary.
+            If a joint is not part of the dictionary, its position is set to zero.
     """
 
-    joint_positions_locked = (
-        joint_positions_locked if joint_positions_locked is not None else {}
+    locked_joint_positions = (
+        locked_joint_positions if locked_joint_positions is not None else {}
     )
 
     # If locked joints are passed, make sure that they are valid.
-    if not set(joint_positions_locked).issubset(model.joint_names()):
-        new_joints = set(model.joint_names()) - set(joint_positions_locked)
+    if not set(locked_joint_positions).issubset(model.joint_names()):
+        new_joints = set(model.joint_names()) - set(locked_joint_positions)
         raise ValueError(f"Passed joints not existing in the model: {new_joints}")
 
     # Copy the model description with a deep copy of the joints.
@@ -296,7 +296,7 @@ def reduce(
     for joint_name in set(model.joint_names()) - set(considered_joints):
         j = intermediate_description.joints_dict[joint_name]
         with j.mutable_context():
-            j.initial_position = float(joint_positions_locked.get(joint_name, 0.0))
+            j.initial_position = float(locked_joint_positions.get(joint_name, 0.0))
 
     # Reduce the model description.
     # If `considered_joints` contains joints not existing in the model,

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -275,7 +275,8 @@ def supported_joint_motion(
             S = jnp.vstack(jnp.hstack([joint_type.axis.squeeze(), jnp.zeros(3)]))
 
         case JointType.F:
-            raise ValueError("Fixed joints shouldn't be here")
+            pre_H_suc = jaxlie.SE3.identity()
+            S = jnp.zeros(shape=(6, 1))
 
         case _:
             raise ValueError(joint_type)

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -242,16 +242,16 @@ def supported_joint_motion(
     """
 
     if isinstance(joint_type, JointType):
-        code = joint_type
+        type_enum = joint_type
     elif isinstance(joint_type, JointDescriptor):
-        code = joint_type.code
+        type_enum = joint_type.joint_type
     else:
         raise ValueError(joint_type)
 
     # Prepare the joint position
     s = jnp.array(joint_position).astype(float)
 
-    match code:
+    match type_enum:
 
         case JointType.R:
             joint_type: JointGenericAxis
@@ -276,57 +276,6 @@ def supported_joint_motion(
 
         case JointType.F:
             raise ValueError("Fixed joints shouldn't be here")
-
-        case JointType.Rx:
-
-            pre_H_suc = jaxlie.SE3.from_rotation(
-                rotation=jaxlie.SO3.from_x_radians(theta=s)
-            )
-
-            S = jnp.vstack([0, 0, 0, 1.0, 0, 0])
-
-        case JointType.Ry:
-
-            pre_H_suc = jaxlie.SE3.from_rotation(
-                rotation=jaxlie.SO3.from_y_radians(theta=s)
-            )
-
-            S = jnp.vstack([0, 0, 0, 0, 1.0, 0])
-
-        case JointType.Rz:
-
-            pre_H_suc = jaxlie.SE3.from_rotation(
-                rotation=jaxlie.SO3.from_z_radians(theta=s)
-            )
-
-            S = jnp.vstack([0, 0, 0, 0, 0, 1.0])
-
-        case JointType.Px:
-
-            pre_H_suc = jaxlie.SE3.from_rotation_and_translation(
-                rotation=jaxlie.SO3.identity(),
-                translation=jnp.array([s, 0.0, 0.0]),
-            )
-
-            S = jnp.vstack([1.0, 0, 0, 0, 0, 0])
-
-        case JointType.Py:
-
-            pre_H_suc = jaxlie.SE3.from_rotation_and_translation(
-                rotation=jaxlie.SO3.identity(),
-                translation=jnp.array([0.0, s, 0.0]),
-            )
-
-            S = jnp.vstack([0, 1.0, 0, 0, 0, 0])
-
-        case JointType.Pz:
-
-            pre_H_suc = jaxlie.SE3.from_rotation_and_translation(
-                rotation=jaxlie.SO3.identity(),
-                translation=jnp.array([0.0, 0.0, s]),
-            )
-
-            S = jnp.vstack([0, 0, 1.0, 0, 0, 0])
 
         case _:
             raise ValueError(joint_type)

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -15,6 +15,7 @@ from jaxsim.parsers.descriptions import (
     JointType,
     ModelDescription,
 )
+from jaxsim.parsers.kinematic_graph import KinematicGraphTransforms
 
 from .rotation import Rotation
 
@@ -87,21 +88,19 @@ class JointModel:
         # w.r.t. the implicit __model__ SDF frame is not the identity).
         suc_H_i = suc_H_i.at[0].set(ordered_links[0].pose)
 
+        # Create the object to compute forward kinematics.
+        fk = KinematicGraphTransforms(graph=description)
+
         # Compute the parent-to-predecessor and successor-to-child transforms for
         # each joint belonging to the model.
         # Note that the joint indices starts from i=1 given our joint model,
         # therefore the entries at index 0 are not updated.
         for joint in ordered_joints:
             λ_H_pre = λ_H_pre.at[joint.index].set(
-                description.relative_transform(
-                    relative_to=joint.parent.name,
-                    name=joint.name,
-                )
+                fk.relative_transform(relative_to=joint.parent.name, name=joint.name)
             )
             suc_H_i = suc_H_i.at[joint.index].set(
-                description.relative_transform(
-                    relative_to=joint.name, name=joint.child.name
-                )
+                fk.relative_transform(relative_to=joint.name, name=joint.child.name)
             )
 
         # Define the DoFs of the base link.

--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -15,7 +15,6 @@ from .link import LinkDescription
 
 
 @enum.unique
-@enum.verify(enum.CONTINUOUS)
 class JointType(enum.IntEnum):
     """
     Type of supported joints.

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -4,7 +4,7 @@ from typing import List
 
 from jaxsim import logging
 
-from ..kinematic_graph import KinematicGraph, RootPose
+from ..kinematic_graph import KinematicGraph, KinematicGraphTransforms, RootPose
 from .collision import CollidablePoint, CollisionShape
 from .joint import JointDescription
 from .link import LinkDescription
@@ -75,6 +75,9 @@ class ModelDescription(KinematicGraph):
                 considered_joints=considered_joints
             )
 
+        # Create the object to compute forward kinematics.
+        fk = KinematicGraphTransforms(graph=kinematic_graph)
+
         # Store here the final model collisions
         final_collisions: List[CollisionShape] = []
 
@@ -121,7 +124,7 @@ class ModelDescription(KinematicGraph):
                 # relative pose
                 moved_cp = cp.change_link(
                     new_link=real_parent_link_of_shape,
-                    new_H_old=kinematic_graph.relative_transform(
+                    new_H_old=fk.relative_transform(
                         relative_to=real_parent_link_of_shape.name,
                         name=cp.parent_link.name,
                     ),

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -9,6 +9,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Tuple,
     Union,
 )
@@ -41,7 +42,7 @@ class RootPose(NamedTuple):
 
 
 @dataclasses.dataclass(frozen=True)
-class KinematicGraph:
+class KinematicGraph(Sequence[descriptions.LinkDescription]):
     """
     Represents a kinematic graph of links and joints.
 
@@ -518,6 +519,10 @@ class KinematicGraph:
 
                 yield child
 
+    # =================
+    # Sequence protocol
+    # =================
+
     def __iter__(self) -> Iterable[descriptions.LinkDescription]:
         yield from KinematicGraph.breadth_first_search(root=self.root)
 
@@ -550,6 +555,14 @@ class KinematicGraph:
             return list(iter(self))[key]
 
         raise TypeError(type(key).__name__)
+
+    def count(self, value: descriptions.LinkDescription) -> int:
+        return list(iter(self)).count(value)
+
+    def index(
+        self, value: descriptions.LinkDescription, start: int = 0, stop: int = -1
+    ) -> int:
+        return list(iter(self)).index(value, start, stop)
 
 
 # ====================

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import dataclasses
 import functools
@@ -267,16 +269,22 @@ class KinematicGraph(Sequence[descriptions.LinkDescription]):
             list(set(removed_joints)),
         )
 
-    def reduce(self, considered_joints: List[str]) -> "KinematicGraph":
+    def reduce(self, considered_joints: List[str]) -> KinematicGraph:
         """
-        Reduce the kinematic graph by removing specified joints and lumping the mass and inertia of removed links into their parent links.
+        Reduce the kinematic graph by removing unspecified joints.
+
+        When a joint is removed, the mass and inertia of its child link are lumped
+        with those of its parent link, obtaining a new link that combines the two.
+        The description of the removed joint specifies the default angle (usually 0)
+        that is considered when the joint is removed.
 
         Args:
-            considered_joints (List[str]): A list of joint names to consider.
+            considered_joints: A list of joint names to consider.
 
         Returns:
-            KinematicGraph: The reduced kinematic graph.
+            The reduced kinematic graph.
         """
+
         # The current object represents the complete kinematic graph
         full_graph = self
 
@@ -430,7 +438,7 @@ class KinematicGraph(Sequence[descriptions.LinkDescription]):
         reduced_graph = KinematicGraph(
             root=reduced_root_node,
             joints=reduced_joints,
-            frames=reduced_frames,
+            frames=self.frames + reduced_frames,
             root_pose=full_graph.root_pose,
             _joints_removed=(
                 self._joints_removed

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -134,7 +134,7 @@ def extract_model_data(
                 name=j.name,
                 parent=world_link,
                 child=links_dict[j.child],
-                jtype=utils.axis_to_jtype(axis=j.axis, type=j.type),
+                jtype=utils.joint_to_joint_type(joint=j),
                 axis=(
                     np.array(j.axis.xyz.xyz)
                     if j.axis is not None
@@ -201,7 +201,7 @@ def extract_model_data(
             name=j.name,
             parent=links_dict[j.parent],
             child=links_dict[j.child],
-            jtype=utils.axis_to_jtype(axis=j.axis, type=j.type),
+            jtype=utils.joint_to_joint_type(joint=j),
             axis=(
                 np.array(j.axis.xyz.xyz)
                 if j.axis is not None

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -50,7 +50,9 @@ class JaxsimDataclass(abc.ABC):
 
     @contextlib.contextmanager
     def mutable_context(
-        self: Self, mutability: Mutability, restore_after_exception: bool = True
+        self: Self,
+        mutability: Mutability = Mutability.MUTABLE,
+        restore_after_exception: bool = True,
     ) -> Iterator[Self]:
         """
         Context manager to temporarily change the mutability of the object.
@@ -86,7 +88,7 @@ class JaxsimDataclass(abc.ABC):
                 setattr(self, f.name, getattr(self_copy, f.name))
 
         try:
-            self.set_mutability(mutability)
+            self.set_mutability(mutability=mutability)
             yield self
 
             if mutability is not Mutability.MUTABLE_NO_VALIDATION:

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -77,7 +77,7 @@ def test_model_creation_and_reduction(
     model_reduced = js.model.reduce(
         model=model_full,
         considered_joints=reduced_joints,
-        joint_positions_locked={
+        locked_joint_positions={
             name: pos
             for name, pos in zip(
                 model_full.joint_names(),

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -246,6 +246,13 @@ class KinDynComputations:
             self.kin_dyn.getFrameName(i) for i in range(self.kin_dyn.getNrOfLinks())
         ]
 
+    def frame_names(self) -> list[str]:
+
+        return [
+            self.kin_dyn.getFrameName(i)
+            for i in range(self.kin_dyn.getNrOfLinks(), self.kin_dyn.getNrOfFrames())
+        ]
+
     def joint_positions(self) -> npt.NDArray:
 
         vector = idt.VectorDynSize()
@@ -318,6 +325,26 @@ class KinDynComputations:
         H = np.eye(4)
         H[0:3, 3] = H_idt.getPosition().toNumPy()
         H[0:3, 0:3] = H_idt.getRotation().toNumPy()
+
+        return H
+
+    def frame_relative_transform(
+        self, ref_frame_name: str, frame_name: str
+    ) -> npt.NDArray:
+
+        if self.kin_dyn.getFrameIndex(ref_frame_name) < 0:
+            raise ValueError(f"Frame '{ref_frame_name}' does not exist")
+
+        if self.kin_dyn.getFrameIndex(frame_name) < 0:
+            raise ValueError(f"Frame '{frame_name}' does not exist")
+
+        ref_H_frame: idt.Transform = self.kin_dyn.getRelativeTransform(
+            ref_frame_name, frame_name
+        )
+
+        H = np.eye(4)
+        H[0:3, 3] = ref_H_frame.getPosition().toNumPy()
+        H[0:3, 0:3] = ref_H_frame.getRotation().toNumPy()
 
         return H
 

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -12,7 +12,10 @@ from jaxsim import VelRepr
 
 
 def build_kindyncomputations_from_jaxsim_model(
-    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+    model: js.model.JaxSimModel,
+    data: js.data.JaxSimModelData,
+    considered_joints: list[str] | None = None,
+    removed_joint_positions: dict[str, npt.NDArray | float | int] | None = None,
 ) -> KinDynComputations:
     """
     Build a `KinDynComputations` from `JaxSimModel` and `JaxSimModelData`.
@@ -20,6 +23,10 @@ def build_kindyncomputations_from_jaxsim_model(
     Args:
         model: The `JaxSimModel` from which to build the `KinDynComputations`.
         data: The `JaxSimModelData` from which to build the `KinDynComputations`.
+        considered_joints:
+            The list of joint names to consider in the `KinDynComputations`.
+        removed_joint_positions:
+            A dictionary defining the positions of the removed joints (default is 0).
 
     Returns:
         The `KinDynComputations` built from the `JaxSimModel` and `JaxSimModelData`.
@@ -34,12 +41,41 @@ def build_kindyncomputations_from_jaxsim_model(
     ) or (isinstance(model.built_from, str) and "<robot" not in model.built_from):
         raise ValueError("iDynTree only supports URDF models")
 
+    if not data.valid(model=model):
+        raise ValueError("Invalid data object for the provided model.")
+
+    # By default, enforce iDynTree to use the same serialization of the JaxSimModel.
+    considered_joints = (
+        considered_joints if considered_joints is not None else model.joint_names()
+    )
+
+    # Get the default positions already stored in the model description.
+    removed_joint_positions_default = {
+        str(j.name): float(j.initial_position)
+        for j in model.description.get()._joints_removed
+        if j.name not in considered_joints
+    }
+
+    # Pass this dict even if there are no removed joints.
+    removed_joint_positions = removed_joint_positions_default | (
+        removed_joint_positions
+        if removed_joint_positions is not None
+        else {
+            name: pos
+            for name, pos in zip(
+                model.joint_names(),
+                data.joint_positions(model=model, joint_names=model.joint_names()),
+            )
+        }
+    )
+
     # Create the KinDynComputations from the same URDF model.
     kin_dyn = KinDynComputations.build(
         urdf=model.built_from,
-        considered_joints=list(model.joint_names()),
+        considered_joints=considered_joints,
         vel_repr=data.velocity_representation,
         gravity=np.array(data.gravity),
+        removed_joint_positions=removed_joint_positions,
     )
 
     # Copy the state of the JaxSim model.
@@ -63,6 +99,9 @@ def store_jaxsim_data_in_kindyncomputations(
     Returns:
         The updated `KinDynComputations` with the state of `JaxSimModelData`.
     """
+
+    if kin_dyn.dofs() != data.joint_positions().size:
+        raise ValueError(data)
 
     with data.switch_velocity_representation(kin_dyn.vel_repr):
         kin_dyn.set_robot_state(
@@ -91,7 +130,8 @@ class KinDynComputations:
         gravity: npt.NDArray = dataclasses.field(
             default_factory=lambda: np.array([0, 0, -10.0])
         ),
-    ) -> "KinDynComputations":
+        removed_joint_positions: dict[str, npt.NDArray | float | int] | None = None,
+    ) -> KinDynComputations:
 
         # Read the URDF description
         urdf_string = urdf.read_text() if isinstance(urdf, pathlib.Path) else urdf
@@ -99,11 +139,20 @@ class KinDynComputations:
         # Create the model loader
         mdl_loader = idt.ModelLoader()
 
+        # Handle removed_joint_positions if None
+        removed_joint_positions = (
+            {str(name): float(pos) for name, pos in removed_joint_positions.items()}
+            if removed_joint_positions is not None
+            else dict()
+        )
+
         # Load the URDF description
         if not (
             mdl_loader.loadModelFromString(urdf_string)
             if considered_joints is None
-            else mdl_loader.loadReducedModelFromString(urdf_string, considered_joints)
+            else mdl_loader.loadReducedModelFromString(
+                urdf_string, considered_joints, removed_joint_positions
+            )
         ):
             raise RuntimeError("Failed to load URDF description")
 


### PR DESCRIPTION
- Extend `jaxsim.api.model.reduce` with a new `joint_position_locked` dictionary that specifies the angles of the removed joints. Note that, if passed, it ignores the angles of the kept joints.
- Extended the simple FK operating on a low-level `KinematicGraph` to support joint angles (it calls the jax function to compute joint transforms).
- Moved the FK operating on a low-level `KinematicGraph` to a standalone class.
- Removed support for single-axis joint types, now all joints are either fixed, revolute, or prismatic. Since [`jaxsim.math.joint_model.supported_joint_motion`](https://github.com/ami-iit/jaxsim/blob/00ab4047ec476240635a105bd62a0b5cff62709d/src/jaxsim/math/joint_model.py#L231) cannot be jit-compiled dynamically over the joint type, it should slightly speed up compilation of RBDAs. 
- Now `KinematicGraph` fully implements the `Sequence` protocol.
- Update the iDynTree version since the updated test requires https://github.com/robotology/idyntree/pull/1180.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--137.org.readthedocs.build//137/

<!-- readthedocs-preview jaxsim end -->