### PR TITLE
Remove `cuda-cupti` and `cuda-nvcc` run dependencies for pixi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,7 @@ pip = "*"
 [tool.pixi.feature.gpu]
 platforms = ["linux-64"]
 system-requirements = {cuda = "12.1"}
-# cuda-nvcc and cuda-cupti are just a workaround for
-# https://github.com/conda-forge/jaxlib-feedstock/pull/241
-dependencies = {cuda-version = "12.*", cuda-nvcc  = "*", cuda-cupti = "*", jaxlib = "* *cuda*"}
+dependencies = {cuda-version = "12.*", jaxlib = "* *cuda*"}
 
 [tool.pixi.pypi-dependencies]
 jaxsim = { path = "./", editable = true}


### PR DESCRIPTION
This PR removes the aforementioned dependencies from the pixi section of `pyproject.toml`. Given that https://github.com/conda-forge/jaxlib-feedstock/pull/241 has been merged, they are not needed anymore

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--138.org.readthedocs.build//138/

<!-- readthedocs-preview jaxsim end -->