### PR TITLE
Remove `unix` requirement from `pixi.toml`

### DIFF
--- a/examples/pixi.toml
+++ b/examples/pixi.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 
 [system-requirements]
 cuda = "12"
-unix = true
 
 [tasks]
 PD_controller = {cmd = "jupyter notebook PD_controller.ipynb", depends_on = ["install"]}


### PR DESCRIPTION
Fixes #140

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--142.org.readthedocs.build//142/

<!-- readthedocs-preview jaxsim end -->