### PR TITLE
Fix typo in rbda.rst

### DIFF
--- a/docs/modules/rbda.rst
+++ b/docs/modules/rbda.rst
@@ -34,7 +34,7 @@ Composite Rigid Body Algorithm
 .. automodule:: jaxsim.rbda.crba
     :members:
 
-Forward Kinetmatics
+Forward Kinematics
 ~~~~~~~~~~~~~~~~~~~
 
 .. automodule:: jaxsim.rbda.forward_kinematics

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -417,7 +417,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def generalized_position(self) -> tuple[jtp.Matrix, jtp.Vector]:
         r"""
         Get the generalized position
-        :math:`\\mathbf{q} = ({}^W \\mathbf{H}_B, \\mathbf{s}) \\in \text{SO}(3) \times \\mathbb{R}^n`.
+        :math:`\mathbf{q} = ({}^W \mathbf{H}_B, \mathbf{s}) \in \text{SO}(3) \times \mathbb{R}^n`.
 
         Returns:
             A tuple containing the base transform and the joint positions.
@@ -429,7 +429,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def generalized_velocity(self) -> jtp.Vector:
         r"""
         Get the generalized velocity
-        :math:`\boldsymbol{\nu} = (\boldsymbol{v}_{W,B};\\, \boldsymbol{\\omega}_{W,B};\\, \\mathbf{s}) \\in \\mathbb{R}^{6+n}`
+        :math:`\boldsymbol{\nu} = (\boldsymbol{v}_{W,B};\, \boldsymbol{\omega}_{W,B};\, \mathbf{s}) \in \mathbb{R}^{6+n}`
 
         Returns:
             The generalized velocity in the active representation.


### PR DESCRIPTION
Just a typo I found when skimming through the documentation.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--145.org.readthedocs.build//145/

<!-- readthedocs-preview jaxsim end -->