### PR TITLE
Read frames from the original model description

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - jaxlie >= 1.3.0
   - jax-dataclasses >= 1.4.0
   - pptree
-  - rod >= 0.2.0
+  - rod >= 0.3.0
   - typing_extensions # python<3.12
   # ====================================
   # Optional dependencies from setup.cfg
@@ -41,18 +41,15 @@ dependencies:
   - pip
   - sphinx
   - sphinx-autodoc-typehints
+  - sphinx-book-theme
   - sphinx-copybutton
   - sphinx-design
   - sphinx_fontawesome
   - sphinx-jinja2-compat
   - sphinx-multiversion
   - sphinx_rtd_theme
-  - sphinx-book-theme
   - sphinx-toolbox
   # ========================================
   # Other dependencies for GitHub Codespaces
   # ========================================
-  # System dependencies to run the tests
-  - gz-sim7
-  # Other packages
   - ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ install_requires =
     jaxlie >= 1.3.0
     jax_dataclasses >= 1.4.0
     pptree
-    rod >= 0.2.0
+    rod >= 0.3.0
     typing_extensions ; python_version < '3.12'
 
 [options.packages.find]

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -121,7 +121,8 @@ class KinematicGraph(Sequence[descriptions.LinkDescription]):
         # Also here, we assume the model is fixed-base, therefore the first frame will
         # have last_link_idx + 1. These frames are not part of the physics model.
         for index, frame in enumerate(self.frames):
-            frame.index = index + len(self.link_names())
+            with frame.mutable_context(mutability=Mutability.MUTABLE_NO_VALIDATION):
+                frame.index = int(index + len(self.link_names()))
 
         # Number joints so that their index matches their child link index
         links_dict = {l.name: l for l in iter(self)}


### PR DESCRIPTION
This PR exploits the recent enhancement in our parser ROD (https://github.com/ami-iit/rod/pull/34) to populate the [intermediate description](https://github.com/ami-iit/jaxsim/blob/c14205a7bb1895300b00fe42e501f2c3bb2dd0bb/src/jaxsim/parsers/descriptions/model.py#L13-L14) (obtained from SDF/URDF models and used to build the `JaxSimModel`) with frame-related data.

cc @xela-95 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--150.org.readthedocs.build//150/

<!-- readthedocs-preview jaxsim end -->