### PR TITLE
Improve compilation time of RBDAs for models with many DoFs

### DIFF
--- a/src/jaxsim/api/joint.py
+++ b/src/jaxsim/api/joint.py
@@ -3,7 +3,6 @@ from typing import Sequence
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
@@ -30,17 +29,9 @@ def name_to_idx(model: js.model.JaxSimModel, *, joint_name: str) -> jtp.Int:
         # Note: the index of the joint for RBDAs starts from 1, but
         # the index for accessing the right element starts from 0.
         # Therefore, there is a -1.
-        return (
-            jnp.array(
-                np.argwhere(
-                    np.array(model.kin_dyn_parameters.joint_model.joint_names)
-                    == joint_name
-                )
-                - 1
-            )
-            .squeeze()
-            .astype(int)
-        )
+        return jnp.array(
+            model.kin_dyn_parameters.joint_model.joint_names.index(joint_name) - 1
+        ).squeeze()
     return jnp.array(-1).astype(int)
 
 

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -382,11 +382,14 @@ class KynDynParameters(JaxsimDataclass):
         )
 
         # Compute the transforms and motion subspaces of the joints.
-        pre_H_suc_J, S_J = jax.vmap(supported_joint_motion)(
-            jnp.array(self.joint_model.joint_types[1:]),
-            jnp.array(self.joint_model.joint_axis),
-            jnp.array(joint_positions).astype(float),
-        )
+        if self.number_of_joints() == 0:
+            pre_H_suc_J, S_J = jnp.empty((0, 4, 4)), jnp.empty((0, 6, 1))
+        else:
+            pre_H_suc_J, S_J = jax.vmap(supported_joint_motion)(
+                jnp.array(self.joint_model.joint_types[1:]).astype(int),
+                jnp.array(self.joint_model.joint_axis),
+                jnp.array(joint_positions),
+            )
 
         # Extract the transforms and motion subspaces of the joints.
         # We stack the base transform W_H_B at index 0, and a dummy motion subspace

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -387,8 +387,8 @@ class KynDynParameters(JaxsimDataclass):
         else:
             pre_H_suc_J, S_J = jax.vmap(supported_joint_motion)(
                 jnp.array(self.joint_model.joint_types[1:]).astype(int),
-                jnp.array(self.joint_model.joint_axis),
                 jnp.array(joint_positions),
+                jnp.array(self.joint_model.joint_axis),
             )
 
         # Extract the transforms and motion subspaces of the joints.

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -394,8 +394,8 @@ class KynDynParameters(JaxsimDataclass):
         # Extract the transforms and motion subspaces of the joints.
         # We stack the base transform W_H_B at index 0, and a dummy motion subspace
         # for either the fixed or free-floating joint connecting the world to the base.
-        pre_H_suc = jnp.vstack([W_H_B[None, ...], pre_H_suc_J])
-        S = jnp.vstack([jnp.zeros((6, 1))[None, ...], S_J])
+        pre_H_suc = jnp.vstack([W_H_B[jnp.newaxis, ...], pre_H_suc_J])
+        S = jnp.vstack([jnp.zeros((6, 1))[jnp.newaxis, ...], S_J])
 
         # Extract the successor-to-child fixed transforms.
         # Note that here we include also the index 0 since suc_H_child[0] stores the

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -199,8 +199,9 @@ class JointModel:
         """
 
         pre_H_suc, S = supported_joint_motion(
-            joint_type=self.joint_types[joint_index],
-            joint_position=joint_position,
+            self.joint_types[joint_index],
+            joint_position,
+            self.joint_axis[joint_index],
         )
 
         return pre_H_suc, S
@@ -223,7 +224,10 @@ class JointModel:
 
 @jax.jit
 def supported_joint_motion(
-    joint_type: JointType, joint_axis: JointGenericAxis, joint_position: jtp.VectorLike
+    joint_type: JointType,
+    joint_position: jtp.VectorLike,
+    joint_axis: JointGenericAxis,
+    /,
 ) -> tuple[jtp.Matrix, jtp.Array]:
     """
     Compute the homogeneous transformation and motion subspace of a joint.

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -108,7 +108,7 @@ class JointModel:
             # Static attributes
             joint_dofs=tuple([base_dofs] + [int(1) for _ in ordered_joints]),
             joint_names=tuple(["world_to_base"] + [j.name for j in ordered_joints]),
-            joint_types=tuple([JointType.F] + [j.jtype for j in ordered_joints]),
+            joint_types=tuple([JointType.Fixed] + [j.jtype for j in ordered_joints]),
             joint_axis=tuple([j.axis for j in ordered_joints]),
         )
 
@@ -265,9 +265,9 @@ def supported_joint_motion(
     pre_H_suc, S = jax.lax.switch(
         index=joint_type,
         branches=(
-            compute_F,  # JointType.F
-            compute_R,  # JointType.R
-            compute_P,  # JointType.P
+            compute_F,  # JointType.Fixed
+            compute_R,  # JointType.Revolute
+            compute_P,  # JointType.Prismatic
         ),
     )
 

--- a/src/jaxsim/parsers/descriptions/__init__.py
+++ b/src/jaxsim/parsers/descriptions/__init__.py
@@ -1,4 +1,4 @@
 from .collision import BoxCollision, CollidablePoint, CollisionShape, SphereCollision
-from .joint import JointDescription, JointDescriptor, JointGenericAxis, JointType
+from .joint import JointDescription, JointGenericAxis, JointType
 from .link import LinkDescription
 from .model import ModelDescription

--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Tuple, Union
+from typing import ClassVar, Tuple, Union
 
 import jax_dataclasses
 import numpy as np
@@ -13,31 +13,11 @@ from jaxsim.utils import JaxsimDataclass, Mutability
 from .link import LinkDescription
 
 
-class _JointTypeMeta(type):
-    def __new__(cls, name, bases, dct):
-        cls_instance = super().__new__(cls, name, bases, dct)
-
-        # Assign integer values to the descriptors
-        cls_instance.F = 0
-        cls_instance.R = 1
-        cls_instance.P = 2
-
-        return cls_instance
-
-
-class JointType(metaclass=_JointTypeMeta):
-    """
-    Type of supported joints.
-    """
-
-    class F:
-        pass
-
-    class R:
-        pass
-
-    class P:
-        pass
+@dataclasses.dataclass(frozen=True)
+class JointType:
+    Fixed: ClassVar[int] = 0
+    Revolute: ClassVar[int] = 1
+    Prismatic: ClassVar[int] = 2
 
 
 @jax_dataclasses.pytree_dataclass

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -771,9 +771,7 @@ class KinematicGraphTransforms:
         import jaxsim.math
 
         return np.array(
-            jaxsim.math.supported_joint_motion(
-                joint_type=joint_type,
-                joint_axis=joint_axis,
-                joint_position=joint_position,
-            )[0]
+            jaxsim.math.supported_joint_motion(joint_type, joint_position, joint_axis)[
+                0
+            ]
         )

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -689,6 +689,7 @@ class KinematicGraphTransforms:
             # Compute the joint transform from the predecessor to the successor frame.
             pre_H_J = self.pre_H_suc(
                 joint_type=joint.jtype,
+                joint_axis=joint.axis,
                 joint_position=self._initial_joint_positions[joint.name],
             )
 
@@ -762,7 +763,8 @@ class KinematicGraphTransforms:
 
     @staticmethod
     def pre_H_suc(
-        joint_type: descriptions.JointType | descriptions.JointDescriptor,
+        joint_type: descriptions.JointType,
+        joint_axis: descriptions.JointGenericAxis,
         joint_position: float | None = None,
     ) -> npt.NDArray:
 
@@ -770,6 +772,8 @@ class KinematicGraphTransforms:
 
         return np.array(
             jaxsim.math.supported_joint_motion(
-                joint_type=joint_type, joint_position=joint_position
+                joint_type=joint_type,
+                joint_axis=joint_axis,
+                joint_position=joint_position,
             )[0]
         )

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -352,7 +352,7 @@ def build_model_description(
         considered_joints=[
             j.name
             for j in sdf_data.joint_descriptions
-            if j.jtype is not descriptions.JointType.F
+            if j.jtype is not descriptions.JointType.Fixed
         ],
     )
 

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -61,7 +61,7 @@ def from_sdf_inertial(inertial: rod.Inertial) -> jtp.Matrix:
 
 def joint_to_joint_type(
     joint: rod.Joint,
-) -> descriptions.JointType | descriptions.JointDescriptor:
+) -> descriptions.JointType:
     """
     Extract the joint type from an SDF joint.
 
@@ -86,14 +86,10 @@ def joint_to_joint_type(
     axis_xyz = axis_xyz / np.linalg.norm(axis_xyz)
 
     if joint_type in {"revolute", "continuous"}:
-        return descriptions.JointGenericAxis(
-            joint_type=descriptions.JointType.R, axis=axis_xyz
-        )
+        return descriptions.JointType.R
 
     if joint_type == "prismatic":
-        return descriptions.JointGenericAxis(
-            joint_type=descriptions.JointType.P, axis=axis_xyz
-        )
+        return descriptions.JointType.P
 
     raise ValueError("Joint not supported", axis_xyz, joint_type)
 

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -76,7 +76,7 @@ def joint_to_joint_type(
     joint_type = joint.type
 
     if joint_type == "fixed":
-        return descriptions.JointType.F
+        return descriptions.JointType.Fixed
 
     if not (axis.xyz is not None and axis.xyz.xyz is not None):
         raise ValueError("Failed to read axis xyz data")
@@ -86,10 +86,10 @@ def joint_to_joint_type(
     axis_xyz = axis_xyz / np.linalg.norm(axis_xyz)
 
     if joint_type in {"revolute", "continuous"}:
-        return descriptions.JointType.R
+        return descriptions.JointType.Revolute
 
     if joint_type == "prismatic":
-        return descriptions.JointType.P
+        return descriptions.JointType.Prismatic
 
     raise ValueError("Joint not supported", axis_xyz, joint_type)
 


### PR DESCRIPTION
This PR drastically reduces the compilation time of RBDAs and of functions that involve joint-related calculations. In particular:
- the use of `enum.IntEnum` for the `JointType` has been reprecated in favor of a leaner class that simply instanciates subclasses for which the only value is an integer representing the joint type
- the `JointDescriptor` class has been deprecated, separating the `JointGenericAxis` from the `JointType` completely. In this way, not only we avoid a circular interdependency between attributes of `JointDescription`, but we are able to pass the two objects as separate arguments to functions, making the use `vmap` more straightforward and less error-prone
- `joint_transforms_and_motion_subspaces`, which is used in every RBDA, gets compiled faster

Closes #151

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--153.org.readthedocs.build//153/

<!-- readthedocs-preview jaxsim end -->