### PR TITLE
Update `rod` deprecated method in the visualizer

### DIFF
--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -203,10 +203,8 @@ class RodModelToMjcf:
             joints_dict[joint_name].type = "fixed"
 
         # Convert the ROD model to URDF.
-        urdf_string = rod.urdf.exporter.UrdfExporter.sdf_to_urdf_string(
+        urdf_string = rod.urdf.exporter.UrdfExporter.to_urdf_string(
             sdf=rod.Sdf(model=rod_model, version="1.7"),
-            gazebo_preserve_fixed_joints=False,
-            pretty=True,
         )
 
         # -------------------------------------

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -203,7 +203,9 @@ class RodModelToMjcf:
             joints_dict[joint_name].type = "fixed"
 
         # Convert the ROD model to URDF.
-        urdf_string = rod.urdf.exporter.UrdfExporter.to_urdf_string(
+        urdf_string = rod.urdf.exporter.UrdfExporter(
+            gazebo_preserve_fixed_joints=False, pretty=True
+        ).to_urdf_string(
             sdf=rod.Sdf(model=rod_model, version="1.7"),
         )
 


### PR DESCRIPTION
This PR updates a deprecated method from `rod` in https://github.com/ami-iit/rod/pull/34 in the visualizer

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--155.org.readthedocs.build//155/

<!-- readthedocs-preview jaxsim end -->