### PR TITLE
Fix method on `jaxsim.math.Transform`

### DIFF
--- a/src/jaxsim/math/transform.py
+++ b/src/jaxsim/math/transform.py
@@ -69,7 +69,7 @@ class Transform:
         assert A_R_B.shape == (3, 3)
 
         A_H_B = jaxlie.SE3.from_rotation_and_translation(
-            rotation=A_R_B, translation=W_p_B
+            rotation=jaxlie.SO3.from_matrix(A_R_B), translation=W_p_B
         )
 
         return A_H_B.as_matrix() if not inverse else A_H_B.inverse().as_matrix()


### PR DESCRIPTION
This pull request fixes a method on the `jaxsim.math.Transform` class. The method `from_rotation_and_translation` was updated to correctly use the `jaxlie.SO3` type for the rotation. This ensures that the method `jaxlie.SE3.from_rotation_and_translation` gets called with the correct input types

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--157.org.readthedocs.build//157/

<!-- readthedocs-preview jaxsim end -->