### PR TITLE
Refactor velocity representations as integers

### DIFF
--- a/docs/modules/api.rst
+++ b/docs/modules/api.rst
@@ -94,7 +94,7 @@ References
 Common
 ~~~~~~
 
-.. autoflag:: jaxsim.api.common.VelRepr
+.. autoclass:: jaxsim.api.common.VelRepr
     :members:
 
 .. autoclass:: jaxsim.api.common.ModelDataWithVelocityRepresentation

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -422,7 +422,7 @@ def bias_acceleration(
         # G := G[B] = (W_p_CoM, [B])
 
         GB_Xf_W = Adjoint.from_transform(
-            transform=data.base_transform().at[0:3].set(W_p_CoM)
+            transform=data.base_transform().at[0:3, 3].set(W_p_CoM)
         ).T
 
         GB_ḣ_bias = GB_Xf_W @ W_ḣ_bias

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -112,19 +112,21 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
         if W_H_O.shape != (4, 4):
             raise ValueError(W_H_O.shape, (4, 4))
 
-        def to_inertial():
+        def to_inertial() -> jtp.Array:
+
             return W_array
 
-        def to_body():
+        def to_body() -> jtp.Array:
             if not is_force:
                 O_Xv_W = Adjoint.from_transform(transform=W_H_O, inverse=True)
                 O_array = O_Xv_W @ W_array
             else:
                 O_Xf_W = Adjoint.from_transform(transform=W_H_O).T
                 O_array = O_Xf_W @ W_array
+
             return O_array
 
-        def to_mixed():
+        def to_mixed() -> jtp.Array:
             W_p_O = W_H_O[0:3, 3]
             W_H_OW = jnp.eye(4).at[0:3, 3].set(W_p_O)
             if not is_force:
@@ -133,6 +135,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
             else:
                 OW_Xf_W = Adjoint.from_transform(transform=W_H_OW).T
                 OW_array = OW_Xf_W @ W_array
+
             return OW_array
 
         return jax.lax.switch(

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -1,9 +1,8 @@
 import abc
 import contextlib
 import dataclasses
-import enum
 import functools
-from typing import ContextManager
+from typing import ClassVar, ContextManager
 
 import jax
 import jax.numpy as jnp
@@ -20,15 +19,15 @@ except ImportError:
     from typing_extensions import Self
 
 
-@enum.unique
-class VelRepr(enum.IntEnum):
+@dataclasses.dataclass(frozen=True)
+class VelRepr:
     """
     Enumeration of all supported 6D velocity representations.
     """
 
-    Body = enum.auto()
-    Mixed = enum.auto()
-    Inertial = enum.auto()
+    Body: ClassVar[int] = 0
+    Mixed: ClassVar[int] = 1
+    Inertial: ClassVar[int] = 2
 
 
 @jax_dataclasses.pytree_dataclass

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -35,13 +35,13 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     Base class for model data structures with velocity representation.
     """
 
-    velocity_representation: VelRepr = dataclasses.field(
+    velocity_representation: int = dataclasses.field(
         default=VelRepr.Inertial, kw_only=True
     )
 
     @contextlib.contextmanager
     def switch_velocity_representation(
-        self, velocity_representation: VelRepr
+        self, velocity_representation: int
     ) -> ContextManager[Self]:
         """
         Context manager to temporarily switch the velocity representation.
@@ -83,7 +83,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     @functools.partial(jax.jit, static_argnames=["is_force"])
     def inertial_to_other_representation(
         array: jtp.Array,
-        other_representation: VelRepr,
+        other_representation: int,
         transform: jtp.Matrix,
         *,
         is_force: bool,
@@ -148,7 +148,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     @functools.partial(jax.jit, static_argnames=["is_force"])
     def other_representation_to_inertial(
         array: jtp.Array,
-        other_representation: VelRepr,
+        other_representation: int,
         transform: jtp.Matrix,
         *,
         is_force: bool,

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -35,13 +35,13 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     Base class for model data structures with velocity representation.
     """
 
-    velocity_representation: int = dataclasses.field(
+    velocity_representation: jtp.VelRepr = dataclasses.field(
         default=VelRepr.Inertial, kw_only=True
     )
 
     @contextlib.contextmanager
     def switch_velocity_representation(
-        self, velocity_representation: int
+        self, velocity_representation: jtp.VelRepr
     ) -> ContextManager[Self]:
         """
         Context manager to temporarily switch the velocity representation.
@@ -83,7 +83,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     @functools.partial(jax.jit, static_argnames=["is_force"])
     def inertial_to_other_representation(
         array: jtp.Array,
-        other_representation: int,
+        other_representation: jtp.VelRepr,
         transform: jtp.Matrix,
         *,
         is_force: bool,
@@ -148,7 +148,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     @functools.partial(jax.jit, static_argnames=["is_force"])
     def other_representation_to_inertial(
         array: jtp.Array,
-        other_representation: int,
+        other_representation: jtp.VelRepr,
         transform: jtp.Matrix,
         *,
         is_force: bool,

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -7,7 +7,6 @@ from typing import ClassVar, ContextManager
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
-from jax_dataclasses import Static
 
 import jaxsim.typing as jtp
 from jaxsim.math import Adjoint
@@ -36,7 +35,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     Base class for model data structures with velocity representation.
     """
 
-    velocity_representation: Static[VelRepr] = dataclasses.field(
+    velocity_representation: VelRepr = dataclasses.field(
         default=VelRepr.Inertial, kw_only=True
     )
 

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -373,8 +373,8 @@ def jacobian(
     )
 
     def to_inertial() -> jtp.Matrix:
-        O_J_WC = W_J_WC
-        return O_J_WC
+
+        return W_J_WC
 
     def to_body() -> jtp.Matrix:
 
@@ -385,8 +385,9 @@ def jacobian(
             C_J_WC = C_X_W @ W_J_WC
             return C_J_WC
 
-        O_J_WC = jax.vmap(jacobian)(W_H_C, W_J_WC)
-        return O_J_WC
+        C_J_WC = jax.vmap(jacobian)(W_H_C, W_J_WC)
+
+        return C_J_WC
 
     def to_mixed() -> jtp.Matrix:
 
@@ -401,8 +402,9 @@ def jacobian(
             CW_J_WC = CW_X_W @ W_J_WC
             return CW_J_WC
 
-        O_J_WC = jax.vmap(jacobian)(W_H_C, W_J_WC)
-        return O_J_WC
+        CW_J_WC = jax.vmap(jacobian)(W_H_C, W_J_WC)
+
+        return CW_J_WC
 
     # Adjust the output representation.
     O_J_WC = jax.lax.switch(
@@ -548,13 +550,13 @@ def jacobian_derivative(
 
         parent_link_idx = parent_link_idxs[contact_idx]
 
-        def to_inertial():
+        def to_inertial() -> tuple[jtp.Matrix, jtp.Matrix]:
             W_X_W = Adjoint.from_transform(transform=jnp.eye(4))
             W_Ẋ_W = jnp.zeros((6, 6))
 
             return W_X_W, W_Ẋ_W
 
-        def to_body():
+        def to_body() -> tuple[jtp.Matrix, jtp.Matrix]:
             L_H_C = Transform.from_rotation_and_translation(translation=L_p_C)
             W_H_C = W_H_L[parent_link_idx] @ L_H_C
             C_X_W = Adjoint.from_transform(transform=W_H_C, inverse=True)
@@ -566,7 +568,7 @@ def jacobian_derivative(
 
             return C_X_W, C_Ẋ_W
 
-        def to_mixed():
+        def to_mixed() -> tuple[jtp.Matrix, jtp.Matrix]:
             L_H_C = Transform.from_rotation_and_translation(translation=L_p_C)
             W_H_C = W_H_L[parent_link_idx] @ L_H_C
             W_H_CW = W_H_C.at[0:3, 0:3].set(jnp.eye(3))

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -334,7 +334,7 @@ def jacobian(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Array:
     r"""
     Return the free-floating Jacobian of the collidable points.

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -334,7 +334,7 @@ def jacobian(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Array:
     r"""
     Return the free-floating Jacobian of the collidable points.

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -621,7 +621,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             base_quaternion=W_Q_B
         )
 
-    @functools.partial(jax.jit, static_argnames=["velocity_representation"])
+    @jax.jit
     def reset_base_linear_velocity(
         self,
         linear_velocity: jtp.VectorLike,
@@ -652,7 +652,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             velocity_representation=velocity_representation,
         )
 
-    @functools.partial(jax.jit, static_argnames=["velocity_representation"])
+    @jax.jit
     def reset_base_angular_velocity(
         self,
         angular_velocity: jtp.VectorLike,
@@ -683,7 +683,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             velocity_representation=velocity_representation,
         )
 
-    @functools.partial(jax.jit, static_argnames=["velocity_representation"])
+    @jax.jit
     def reset_base_velocity(
         self,
         base_velocity: jtp.VectorLike,

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -84,7 +84,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     @staticmethod
     def zero(
         model: js.model.JaxSimModel,
-        velocity_representation: int = VelRepr.Inertial,
+        velocity_representation: jtp.VelRepr = VelRepr.Inertial,
     ) -> JaxSimModelData:
         """
         Create a `JaxSimModelData` object with zero state.
@@ -113,7 +113,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         standard_gravity: jtp.FloatLike = jaxsim.math.StandardGravity,
         contact: jaxsim.rbda.ContactsState | None = None,
         contacts_params: jaxsim.rbda.ContactsParams | None = None,
-        velocity_representation: int = VelRepr.Inertial,
+        velocity_representation: jtp.VelRepr = VelRepr.Inertial,
         time: jtp.FloatLike | None = None,
     ) -> JaxSimModelData:
         """
@@ -625,7 +625,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def reset_base_linear_velocity(
         self,
         linear_velocity: jtp.VectorLike,
-        velocity_representation: int | None = None,
+        velocity_representation: jtp.VelRepr | None = None,
     ) -> Self:
         """
         Reset the base linear velocity.
@@ -656,7 +656,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def reset_base_angular_velocity(
         self,
         angular_velocity: jtp.VectorLike,
-        velocity_representation: int | None = None,
+        velocity_representation: jtp.VelRepr | None = None,
     ) -> Self:
         """
         Reset the base angular velocity.
@@ -687,7 +687,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def reset_base_velocity(
         self,
         base_velocity: jtp.VectorLike,
-        velocity_representation: int | None = None,
+        velocity_representation: jtp.VelRepr | None = None,
     ) -> Self:
         """
         Reset the base 6D velocity.
@@ -732,7 +732,7 @@ def random_model_data(
     model: js.model.JaxSimModel,
     *,
     key: jax.Array | None = None,
-    velocity_representation: int | None = None,
+    velocity_representation: jtp.VelRepr | None = None,
     base_pos_bounds: tuple[
         jtp.FloatLike | Sequence[jtp.FloatLike],
         jtp.FloatLike | Sequence[jtp.FloatLike],

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -84,7 +84,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     @staticmethod
     def zero(
         model: js.model.JaxSimModel,
-        velocity_representation: VelRepr = VelRepr.Inertial,
+        velocity_representation: int = VelRepr.Inertial,
     ) -> JaxSimModelData:
         """
         Create a `JaxSimModelData` object with zero state.
@@ -113,7 +113,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         standard_gravity: jtp.FloatLike = jaxsim.math.StandardGravity,
         contact: jaxsim.rbda.ContactsState | None = None,
         contacts_params: jaxsim.rbda.ContactsParams | None = None,
-        velocity_representation: VelRepr = VelRepr.Inertial,
+        velocity_representation: int = VelRepr.Inertial,
         time: jtp.FloatLike | None = None,
     ) -> JaxSimModelData:
         """
@@ -625,7 +625,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def reset_base_linear_velocity(
         self,
         linear_velocity: jtp.VectorLike,
-        velocity_representation: VelRepr | None = None,
+        velocity_representation: int | None = None,
     ) -> Self:
         """
         Reset the base linear velocity.
@@ -656,7 +656,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def reset_base_angular_velocity(
         self,
         angular_velocity: jtp.VectorLike,
-        velocity_representation: VelRepr | None = None,
+        velocity_representation: int | None = None,
     ) -> Self:
         """
         Reset the base angular velocity.
@@ -687,7 +687,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     def reset_base_velocity(
         self,
         base_velocity: jtp.VectorLike,
-        velocity_representation: VelRepr | None = None,
+        velocity_representation: int | None = None,
     ) -> Self:
         """
         Reset the base 6D velocity.
@@ -732,7 +732,7 @@ def random_model_data(
     model: js.model.JaxSimModel,
     *,
     key: jax.Array | None = None,
-    velocity_representation: VelRepr | None = None,
+    velocity_representation: int | None = None,
     base_pos_bounds: tuple[
         jtp.FloatLike | Sequence[jtp.FloatLike],
         jtp.FloatLike | Sequence[jtp.FloatLike],

--- a/src/jaxsim/api/frame.py
+++ b/src/jaxsim/api/frame.py
@@ -180,7 +180,7 @@ def transform(
     return W_H_L @ L_H_F
 
 
-@functools.partial(jax.jit, static_argnames=["output_vel_repr"])
+@jax.jit
 def jacobian(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,

--- a/src/jaxsim/api/frame.py
+++ b/src/jaxsim/api/frame.py
@@ -231,6 +231,7 @@ def jacobian(
         W_H_L = js.link.transform(model=model, data=data, link_index=L)
         W_X_L = Adjoint.from_transform(transform=W_H_L)
         W_J_WL = W_X_L @ L_J_WL
+
         return W_J_WL
 
     def to_body() -> jtp.Matrix:
@@ -239,6 +240,7 @@ def jacobian(
         F_H_L = Transform.inverse(W_H_F) @ W_H_L
         F_X_L = Adjoint.from_transform(transform=F_H_L)
         F_J_WL = F_X_L @ L_J_WL
+
         return F_J_WL
 
     def to_mixed() -> jtp.Matrix:
@@ -249,6 +251,7 @@ def jacobian(
         FW_H_L = FW_H_F @ F_H_L
         FW_X_L = Adjoint.from_transform(transform=FW_H_L)
         FW_J_WL = FW_X_L @ L_J_WL
+
         return FW_J_WL
 
     # Adjust the output representation
@@ -388,13 +391,13 @@ def jacobian_derivative(
     # Compute quantities to adjust the output representation
     # =====================================================
 
-    def to_inertial():
+    def to_inertial() -> tuple[jtp.Matrix, jtp.Matrix]:
         W_X_W = Adjoint.from_transform(transform=jnp.eye(4))
         W_Ẋ_W = jnp.zeros((6, 6))
 
         return W_X_W, W_Ẋ_W
 
-    def to_body():
+    def to_body() -> tuple[jtp.Matrix, jtp.Matrix]:
         W_H_F = transform(model=model, data=data, frame_index=frame_index)
         F_X_W = Adjoint.from_transform(transform=W_H_F, inverse=True)
         with data.switch_velocity_representation(VelRepr.Inertial):
@@ -405,7 +408,7 @@ def jacobian_derivative(
 
         return F_X_W, F_Ẋ_W
 
-    def to_mixed():
+    def to_mixed() -> tuple[jtp.Matrix, jtp.Matrix]:
         W_H_F = transform(model=model, data=data, frame_index=frame_index)
         W_H_FW = W_H_F.at[0:3, 0:3].set(jnp.eye(3))
         FW_H_W = Transform.inverse(W_H_FW)

--- a/src/jaxsim/api/frame.py
+++ b/src/jaxsim/api/frame.py
@@ -186,7 +186,7 @@ def jacobian(
     data: js.data.JaxSimModelData,
     *,
     frame_index: jtp.IntLike,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Matrix:
     r"""
     Compute the free-floating jacobian of the frame.

--- a/src/jaxsim/api/frame.py
+++ b/src/jaxsim/api/frame.py
@@ -186,7 +186,7 @@ def jacobian(
     data: js.data.JaxSimModelData,
     *,
     frame_index: jtp.IntLike,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Matrix:
     r"""
     Compute the free-floating jacobian of the frame.

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -241,7 +241,7 @@ def jacobian(
     data: js.data.JaxSimModelData,
     *,
     link_index: jtp.IntLike,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Matrix:
     r"""
     Compute the free-floating jacobian of the link.
@@ -354,7 +354,7 @@ def velocity(
     data: js.data.JaxSimModelData,
     *,
     link_index: jtp.IntLike,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Vector:
     """
     Compute the 6D velocity of the link.
@@ -404,7 +404,7 @@ def jacobian_derivative(
     data: js.data.JaxSimModelData,
     *,
     link_index: jtp.IntLike,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Matrix:
     r"""
     Compute the derivative of the free-floating jacobian of the link.

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -9,7 +9,7 @@ import jaxsim.api as js
 import jaxsim.rbda
 import jaxsim.typing as jtp
 from jaxsim import exceptions
-from jaxsim.math import Adjoint
+from jaxsim.math import Adjoint, Transform
 
 from .common import VelRepr
 
@@ -284,53 +284,66 @@ def jacobian(
     B_J_WL_B = jnp.hstack([jnp.ones(5), κb]) * B_J_full_WX_B
 
     # Adjust the input representation such that `J_WL_I @ I_ν`.
-    match data.velocity_representation:
-        case VelRepr.Inertial:
-            W_H_B = data.base_transform()
-            B_X_W = Adjoint.from_transform(transform=W_H_B, inverse=True)
-            B_J_WL_I = B_J_WL_W = B_J_WL_B @ jax.scipy.linalg.block_diag(  # noqa: F841
-                B_X_W, jnp.eye(model.dofs())
-            )
+    def to_inertial() -> jtp.Matrix:
+        W_H_B = data.base_transform()
+        B_X_W = Adjoint.from_transform(transform=W_H_B, inverse=True)
+        B_J_WL_I = B_J_WL_W = B_J_WL_B @ jax.scipy.linalg.block_diag(  # noqa: F841
+            B_X_W, jnp.eye(model.dofs())
+        )
+        return B_J_WL_W
 
-        case VelRepr.Body:
-            B_J_WL_I = B_J_WL_B
+    def to_body() -> jtp.Matrix:
+        return B_J_WL_B
 
-        case VelRepr.Mixed:
-            W_R_B = data.base_orientation(dcm=True)
-            BW_H_B = jnp.eye(4).at[0:3, 0:3].set(W_R_B)
-            B_X_BW = Adjoint.from_transform(transform=BW_H_B, inverse=True)
-            B_J_WL_I = B_J_WL_BW = B_J_WL_B @ jax.scipy.linalg.block_diag(  # noqa: F841
-                B_X_BW, jnp.eye(model.dofs())
-            )
+    def to_mixed() -> jtp.Matrix:
+        W_R_B = data.base_orientation(dcm=True)
+        BW_H_B = jnp.eye(4).at[0:3, 0:3].set(W_R_B)
+        B_X_BW = Adjoint.from_transform(transform=BW_H_B, inverse=True)
+        B_J_WL_I = B_J_WL_BW = B_J_WL_B @ jax.scipy.linalg.block_diag(  # noqa: F841
+            B_X_BW, jnp.eye(model.dofs())
+        )
+        return B_J_WL_BW
 
-        case _:
-            raise ValueError(data.velocity_representation)
+    B_J_WL_I = jax.lax.switch(
+        index=data.velocity_representation,
+        branches=(
+            to_body,  # VelRepr.Body
+            to_mixed,  # VelRepr.Mixed
+            to_inertial,  # VelRepr.Inertial
+        ),
+    )
 
     B_H_L = B_H_Li[link_index]
 
+    def to_inertial() -> jtp.Matrix:
+        W_H_B = data.base_transform()
+        W_X_B = Adjoint.from_transform(transform=W_H_B)
+        W_J_WL_I = W_X_B @ B_J_WL_I
+        return W_J_WL_I
+
+    def to_body() -> jtp.Matrix:
+        L_X_B = Adjoint.from_transform(transform=B_H_L, inverse=True)
+        L_J_WL_I = L_X_B @ B_J_WL_I
+        return L_J_WL_I
+
+    def to_mixed() -> jtp.Matrix:
+        W_H_B = data.base_transform()
+        W_H_L = W_H_B @ B_H_L
+        LW_H_L = W_H_L.at[0:3, 3].set(jnp.zeros(3))
+        LW_H_B = LW_H_L @ Transform.inverse(B_H_L)
+        LW_X_B = Adjoint.from_transform(transform=LW_H_B)
+        LW_J_WL_I = LW_X_B @ B_J_WL_I
+        return LW_J_WL_I
+
     # Adjust the output representation such that `O_v_WL_I = O_J_WL_I @ I_ν`.
-    match output_vel_repr:
-        case VelRepr.Inertial:
-            W_H_B = data.base_transform()
-            W_X_B = Adjoint.from_transform(transform=W_H_B)
-            O_J_WL_I = W_J_WL_I = W_X_B @ B_J_WL_I  # noqa: F841
-
-        case VelRepr.Body:
-            L_X_B = Adjoint.from_transform(transform=B_H_L, inverse=True)
-            L_J_WL_I = L_X_B @ B_J_WL_I
-            O_J_WL_I = L_J_WL_I
-
-        case VelRepr.Mixed:
-            W_H_B = data.base_transform()
-            W_H_L = W_H_B @ B_H_L
-            LW_H_L = W_H_L.at[0:3, 3].set(jnp.zeros(3))
-            LW_H_B = LW_H_L @ jaxsim.math.Transform.inverse(B_H_L)
-            LW_X_B = Adjoint.from_transform(transform=LW_H_B)
-            LW_J_WL_I = LW_X_B @ B_J_WL_I
-            O_J_WL_I = LW_J_WL_I
-
-        case _:
-            raise ValueError(output_vel_repr)
+    O_J_WL_I = jax.lax.switch(
+        index=output_vel_repr,
+        branches=(
+            to_body,  # VelRepr.Body
+            to_mixed,  # VelRepr.Mixed
+            to_inertial,  # VelRepr.Inertial
+        ),
+    )
 
     return O_J_WL_I
 
@@ -445,7 +458,7 @@ def jacobian_derivative(
     def from_inertial() -> jtp.Matrix:
 
         W_H_B = data.base_transform()
-        B_X_W = jaxsim.math.Adjoint.from_transform(transform=W_H_B, inverse=True)
+        B_X_W = Adjoint.from_transform(transform=W_H_B, inverse=True)
 
         with data.switch_velocity_representation(VelRepr.Inertial):
             W_v_WB = data.base_velocity()
@@ -459,7 +472,7 @@ def jacobian_derivative(
 
     def from_body() -> jtp.Matrix:
 
-        B_X_B = jaxsim.math.Adjoint.from_rotation_and_translation(
+        B_X_B = Adjoint.from_rotation_and_translation(
             translation=jnp.zeros(3), rotation=jnp.eye(3)
         )
 
@@ -474,7 +487,7 @@ def jacobian_derivative(
     def from_mixed() -> jtp.Matrix:
 
         BW_H_B = data.base_transform().at[0:3, 3].set(jnp.zeros(3))
-        B_X_BW = jaxsim.math.Adjoint.from_transform(transform=BW_H_B, inverse=True)
+        B_X_BW = Adjoint.from_transform(transform=BW_H_B, inverse=True)
 
         with data.switch_velocity_representation(VelRepr.Mixed):
             BW_v_WB = data.base_velocity()
@@ -505,7 +518,7 @@ def jacobian_derivative(
     def to_inertial() -> jtp.Matrix:
 
         W_H_B = data.base_transform()
-        O_X_B = W_X_B = jaxsim.math.Adjoint.from_transform(transform=W_H_B)
+        O_X_B = W_X_B = Adjoint.from_transform(transform=W_H_B)
 
         with data.switch_velocity_representation(VelRepr.Body):
             B_v_WB = data.base_velocity()
@@ -515,11 +528,11 @@ def jacobian_derivative(
 
     def to_body() -> jtp.Matrix:
 
-        O_X_B = L_X_B = jaxsim.math.Adjoint.from_transform(
+        O_X_B = L_X_B = Adjoint.from_transform(
             transform=B_H_L[link_index, :, :], inverse=True
         )
 
-        B_X_L = jaxsim.math.Adjoint.inverse(adjoint=L_X_B)
+        B_X_L = Adjoint.inverse(adjoint=L_X_B)
 
         with data.switch_velocity_representation(VelRepr.Body):
             B_v_WB = data.base_velocity()
@@ -535,11 +548,11 @@ def jacobian_derivative(
         W_H_B = data.base_transform()
         W_H_L = W_H_B @ B_H_L[link_index, :, :]
         LW_H_L = W_H_L.at[0:3, 3].set(jnp.zeros(3))
-        LW_H_B = LW_H_L @ jaxsim.math.Transform.inverse(B_H_L[link_index, :, :])
+        LW_H_B = LW_H_L @ Transform.inverse(B_H_L[link_index, :, :])
 
-        O_X_B = LW_X_B = jaxsim.math.Adjoint.from_transform(transform=LW_H_B)
+        O_X_B = LW_X_B = Adjoint.from_transform(transform=LW_H_B)
 
-        B_X_LW = jaxsim.math.Adjoint.inverse(adjoint=LW_X_B)
+        B_X_LW = Adjoint.inverse(adjoint=LW_X_B)
 
         with data.switch_velocity_representation(VelRepr.Body):
             B_v_WB = data.base_velocity()

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -11,6 +11,8 @@ import jaxsim.typing as jtp
 from jaxsim import exceptions
 from jaxsim.math import Adjoint, Transform
 
+from .common import VelRepr
+
 # =======================
 # Index-related functions
 # =======================

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -11,8 +11,6 @@ import jaxsim.typing as jtp
 from jaxsim import exceptions
 from jaxsim.math import Adjoint, Transform
 
-from .common import VelRepr
-
 # =======================
 # Index-related functions
 # =======================
@@ -241,7 +239,7 @@ def jacobian(
     data: js.data.JaxSimModelData,
     *,
     link_index: jtp.IntLike,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Matrix:
     r"""
     Compute the free-floating jacobian of the link.
@@ -354,7 +352,7 @@ def velocity(
     data: js.data.JaxSimModelData,
     *,
     link_index: jtp.IntLike,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Vector:
     """
     Compute the 6D velocity of the link.

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -235,7 +235,7 @@ def com_position(
     )
 
 
-@functools.partial(jax.jit, static_argnames=["output_vel_repr"])
+@jax.jit
 def jacobian(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
@@ -335,7 +335,7 @@ def jacobian(
     return O_J_WL_I
 
 
-@functools.partial(jax.jit, static_argnames=["output_vel_repr"])
+@jax.jit
 def velocity(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
@@ -385,13 +385,13 @@ def velocity(
     return O_J_WL_I @ I_ν
 
 
-@functools.partial(jax.jit, static_argnames=["output_vel_repr"])
+@jax.jit
 def jacobian_derivative(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
     link_index: jtp.IntLike,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Matrix:
     r"""
     Compute the derivative of the free-floating jacobian of the link.
@@ -442,116 +442,128 @@ def jacobian_derivative(
     In = jnp.eye(model.dofs())
     On = jnp.zeros(shape=(model.dofs(), model.dofs()))
 
-    match data.velocity_representation:
+    def from_inertial() -> jtp.Matrix:
 
-        case VelRepr.Inertial:
+        W_H_B = data.base_transform()
+        B_X_W = jaxsim.math.Adjoint.from_transform(transform=W_H_B, inverse=True)
 
-            W_H_B = data.base_transform()
-            B_X_W = jaxsim.math.Adjoint.from_transform(transform=W_H_B, inverse=True)
+        with data.switch_velocity_representation(VelRepr.Inertial):
+            W_v_WB = data.base_velocity()
+            B_Ẋ_W = -B_X_W @ jaxsim.math.Cross.vx(W_v_WB)
 
-            with data.switch_velocity_representation(VelRepr.Inertial):
-                W_v_WB = data.base_velocity()
-                B_Ẋ_W = -B_X_W @ jaxsim.math.Cross.vx(W_v_WB)
+        # Compute the operator to change the representation of ν, and its
+        # time derivative.
+        T = jax.scipy.linalg.block_diag(B_X_W, In)
+        Ṫ = jax.scipy.linalg.block_diag(B_Ẋ_W, On)
+        return T, Ṫ
 
-            # Compute the operator to change the representation of ν, and its
-            # time derivative.
-            T = jax.scipy.linalg.block_diag(B_X_W, In)
-            Ṫ = jax.scipy.linalg.block_diag(B_Ẋ_W, On)
+    def from_body() -> jtp.Matrix:
 
-        case VelRepr.Body:
+        B_X_B = jaxsim.math.Adjoint.from_rotation_and_translation(
+            translation=jnp.zeros(3), rotation=jnp.eye(3)
+        )
 
-            B_X_B = jaxsim.math.Adjoint.from_rotation_and_translation(
-                translation=jnp.zeros(3), rotation=jnp.eye(3)
-            )
+        B_Ẋ_B = jnp.zeros(shape=(6, 6))
 
-            B_Ẋ_B = jnp.zeros(shape=(6, 6))
+        # Compute the operator to change the representation of ν, and its
+        # time derivative.
+        T = jax.scipy.linalg.block_diag(B_X_B, In)
+        Ṫ = jax.scipy.linalg.block_diag(B_Ẋ_B, On)
+        return T, Ṫ
 
-            # Compute the operator to change the representation of ν, and its
-            # time derivative.
-            T = jax.scipy.linalg.block_diag(B_X_B, In)
-            Ṫ = jax.scipy.linalg.block_diag(B_Ẋ_B, On)
+    def from_mixed() -> jtp.Matrix:
 
-        case VelRepr.Mixed:
+        BW_H_B = data.base_transform().at[0:3, 3].set(jnp.zeros(3))
+        B_X_BW = jaxsim.math.Adjoint.from_transform(transform=BW_H_B, inverse=True)
 
-            BW_H_B = data.base_transform().at[0:3, 3].set(jnp.zeros(3))
-            B_X_BW = jaxsim.math.Adjoint.from_transform(transform=BW_H_B, inverse=True)
+        with data.switch_velocity_representation(VelRepr.Mixed):
+            BW_v_WB = data.base_velocity()
+            BW_v_W_BW = BW_v_WB.at[3:6].set(jnp.zeros(3))
 
-            with data.switch_velocity_representation(VelRepr.Mixed):
-                BW_v_WB = data.base_velocity()
-                BW_v_W_BW = BW_v_WB.at[3:6].set(jnp.zeros(3))
+        BW_v_BW_B = BW_v_WB - BW_v_W_BW
+        B_Ẋ_BW = -B_X_BW @ jaxsim.math.Cross.vx(BW_v_BW_B)
 
-            BW_v_BW_B = BW_v_WB - BW_v_W_BW
-            B_Ẋ_BW = -B_X_BW @ jaxsim.math.Cross.vx(BW_v_BW_B)
+        # Compute the operator to change the representation of ν, and its
+        # time derivative.
+        T = jax.scipy.linalg.block_diag(B_X_BW, In)
+        Ṫ = jax.scipy.linalg.block_diag(B_Ẋ_BW, On)
+        return T, Ṫ
 
-            # Compute the operator to change the representation of ν, and its
-            # time derivative.
-            T = jax.scipy.linalg.block_diag(B_X_BW, In)
-            Ṫ = jax.scipy.linalg.block_diag(B_Ẋ_BW, On)
-
-        case _:
-            raise ValueError(data.velocity_representation)
+    T, Ṫ = jax.lax.switch(
+        index=data.velocity_representation,
+        branches=(
+            from_body,  # VelRepr.Body
+            from_mixed,  # VelRepr.Mixed
+            from_inertial,  # VelRepr.Inertial
+        ),
+    )
 
     # ======================================================
     # Compute quantities to adjust the output representation
     # ======================================================
 
-    match output_vel_repr:
+    def to_inertial() -> jtp.Matrix:
 
-        case VelRepr.Inertial:
+        W_H_B = data.base_transform()
+        O_X_B = W_X_B = jaxsim.math.Adjoint.from_transform(transform=W_H_B)
 
-            W_H_B = data.base_transform()
-            O_X_B = W_X_B = jaxsim.math.Adjoint.from_transform(transform=W_H_B)
+        with data.switch_velocity_representation(VelRepr.Body):
+            B_v_WB = data.base_velocity()
 
-            with data.switch_velocity_representation(VelRepr.Body):
-                B_v_WB = data.base_velocity()
+        O_Ẋ_B = W_Ẋ_B = W_X_B @ jaxsim.math.Cross.vx(B_v_WB)  # noqa: F841
+        return O_X_B, O_Ẋ_B
 
-            O_Ẋ_B = W_Ẋ_B = W_X_B @ jaxsim.math.Cross.vx(B_v_WB)  # noqa: F841
+    def to_body() -> jtp.Matrix:
 
-        case VelRepr.Body:
+        O_X_B = L_X_B = jaxsim.math.Adjoint.from_transform(
+            transform=B_H_L[link_index, :, :], inverse=True
+        )
 
-            O_X_B = L_X_B = jaxsim.math.Adjoint.from_transform(
-                transform=B_H_L[link_index, :, :], inverse=True
-            )
+        B_X_L = jaxsim.math.Adjoint.inverse(adjoint=L_X_B)
 
-            B_X_L = jaxsim.math.Adjoint.inverse(adjoint=L_X_B)
+        with data.switch_velocity_representation(VelRepr.Body):
+            B_v_WB = data.base_velocity()
+            L_v_WL = js.link.velocity(model=model, data=data, link_index=link_index)
 
-            with data.switch_velocity_representation(VelRepr.Body):
-                B_v_WB = data.base_velocity()
-                L_v_WL = js.link.velocity(model=model, data=data, link_index=link_index)
+        O_Ẋ_B = L_Ẋ_B = -L_X_B @ jaxsim.math.Cross.vx(  # noqa: F841
+            B_X_L @ L_v_WL - B_v_WB
+        )
+        return O_X_B, O_Ẋ_B
 
-            O_Ẋ_B = L_Ẋ_B = -L_X_B @ jaxsim.math.Cross.vx(  # noqa: F841
-                B_X_L @ L_v_WL - B_v_WB
-            )
+    def to_mixed() -> jtp.Matrix:
 
-        case VelRepr.Mixed:
+        W_H_B = data.base_transform()
+        W_H_L = W_H_B @ B_H_L[link_index, :, :]
+        LW_H_L = W_H_L.at[0:3, 3].set(jnp.zeros(3))
+        LW_H_B = LW_H_L @ jaxsim.math.Transform.inverse(B_H_L[link_index, :, :])
 
-            W_H_B = data.base_transform()
-            W_H_L = W_H_B @ B_H_L[link_index, :, :]
-            LW_H_L = W_H_L.at[0:3, 3].set(jnp.zeros(3))
-            LW_H_B = LW_H_L @ jaxsim.math.Transform.inverse(B_H_L[link_index, :, :])
+        O_X_B = LW_X_B = jaxsim.math.Adjoint.from_transform(transform=LW_H_B)
 
-            O_X_B = LW_X_B = jaxsim.math.Adjoint.from_transform(transform=LW_H_B)
+        B_X_LW = jaxsim.math.Adjoint.inverse(adjoint=LW_X_B)
 
-            B_X_LW = jaxsim.math.Adjoint.inverse(adjoint=LW_X_B)
+        with data.switch_velocity_representation(VelRepr.Body):
+            B_v_WB = data.base_velocity()
 
-            with data.switch_velocity_representation(VelRepr.Body):
-                B_v_WB = data.base_velocity()
+        with data.switch_velocity_representation(VelRepr.Mixed):
+            LW_v_WL = js.link.velocity(model=model, data=data, link_index=link_index)
+            LW_v_W_LW = LW_v_WL.at[3:6].set(jnp.zeros(3))
 
-            with data.switch_velocity_representation(VelRepr.Mixed):
-                LW_v_WL = js.link.velocity(
-                    model=model, data=data, link_index=link_index
-                )
-                LW_v_W_LW = LW_v_WL.at[3:6].set(jnp.zeros(3))
+        LW_v_LW_L = LW_v_WL - LW_v_W_LW
+        LW_v_B_LW = LW_v_WL - LW_X_B @ B_v_WB - LW_v_LW_L
 
-            LW_v_LW_L = LW_v_WL - LW_v_W_LW
-            LW_v_B_LW = LW_v_WL - LW_X_B @ B_v_WB - LW_v_LW_L
+        O_Ẋ_B = LW_Ẋ_B = -LW_X_B @ jaxsim.math.Cross.vx(  # noqa: F841
+            B_X_LW @ LW_v_B_LW
+        )
+        return O_X_B, O_Ẋ_B
 
-            O_Ẋ_B = LW_Ẋ_B = -LW_X_B @ jaxsim.math.Cross.vx(  # noqa: F841
-                B_X_LW @ LW_v_B_LW
-            )
-        case _:
-            raise ValueError(output_vel_repr)
-
+    O_X_B, O_Ẋ_B = jax.lax.switch(
+        index=output_vel_repr,
+        branches=(
+            to_body,  # VelRepr.Body
+            to_mixed,  # VelRepr.Mixed
+            to_inertial,  # VelRepr.Inertial
+        ),
+    )
     # =============================================================
     # Express the Jacobian derivative in the target representations
     # =============================================================

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -453,7 +453,7 @@ def generalized_free_floating_jacobian(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Matrix:
     """
     Compute the free-floating jacobians of all links.
@@ -1422,7 +1422,7 @@ def total_momentum_jacobian(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Matrix:
     """
     Compute the jacobian of the total momentum.
@@ -1519,7 +1519,7 @@ def average_velocity_jacobian(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: int | None = None,
+    output_vel_repr: jtp.VelRepr | None = None,
 ) -> jtp.Matrix:
     """
     Compute the Jacobian of the average velocity of the model.
@@ -1778,9 +1778,9 @@ def link_bias_accelerations(
         return C_H_L, L_v_CL
 
     def to_inertial() -> jtp.Matrix:
-        C_H_L = W_H_L = js.model.forward_kinematics(
+        C_H_L = W_H_L = js.model.forward_kinematics(  # noqa: F841
             model=model, data=data
-        )  # noqa: F841
+        )
         L_v_CL = L_v_WL
         return C_H_L, L_v_CL
 
@@ -1788,9 +1788,9 @@ def link_bias_accelerations(
         W_H_L = js.model.forward_kinematics(model=model, data=data)
         LW_H_L = jax.vmap(lambda W_H_L: W_H_L.at[0:3, 3].set(jnp.zeros(3)))(W_H_L)
         C_H_L = LW_H_L
-        L_v_CL = L_v_LW_L = jax.vmap(lambda v: v.at[0:3].set(jnp.zeros(3)))(
-            L_v_WL
-        )  # noqa: F841
+        L_v_CL = L_v_LW_L = jax.vmap(  # noqa: F841
+            lambda v: v.at[0:3].set(jnp.zeros(3))
+        )(L_v_WL)
         return C_H_L, L_v_CL
 
     C_H_L, L_v_CL = jax.lax.switch(

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -453,7 +453,7 @@ def generalized_free_floating_jacobian(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Matrix:
     """
     Compute the free-floating jacobians of all links.
@@ -1422,7 +1422,7 @@ def total_momentum_jacobian(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Matrix:
     """
     Compute the jacobian of the total momentum.
@@ -1519,7 +1519,7 @@ def average_velocity_jacobian(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    output_vel_repr: VelRepr | None = None,
+    output_vel_repr: int | None = None,
 ) -> jtp.Matrix:
     """
     Compute the Jacobian of the average velocity of the model.

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -568,9 +568,9 @@ def generalized_free_floating_jacobian(
         W_H_B = data.base_transform()
         W_X_B = jaxsim.math.Adjoint.from_transform(W_H_B)
 
-        O_J_WL_I = W_J_WL_I = jax.vmap(  # noqa: F841
-            lambda B_J_WL_I: W_X_B @ B_J_WL_I
-        )(B_J_WL_I)
+        O_J_WL_I = W_J_WL_I = jax.vmap(lambda B_J_WL_I: W_X_B @ B_J_WL_I)(  # noqa: F841
+            B_J_WL_I
+        )
         return O_J_WL_I
 
     def to_body() -> jtp.Matrix:
@@ -784,7 +784,7 @@ def forward_dynamics_aba(
         # In Mixed representation, we need to include a cross product in ℝ⁶.
         # In Inertial and Body representations, the cross product is always zero.
         C_X_W = Adjoint.from_transform(transform=W_H_C, inverse=True)
-        return C_X_W @ (W_v̇_WB - Cross.vx(W_v_WC) @ W_v_WB)
+        return C_X_W @ W_v̇_WB - Cross.vx(W_v_WC) @ W_v_WB
 
     def to_inertial():
         # In this case C=W
@@ -1778,7 +1778,9 @@ def link_bias_accelerations(
         return C_H_L, L_v_CL
 
     def to_inertial() -> jtp.Matrix:
-        C_H_L = W_H_L = js.model.forward_kinematics(model=model, data=data)  # noqa: F841
+        C_H_L = W_H_L = js.model.forward_kinematics(
+            model=model, data=data
+        )  # noqa: F841
         L_v_CL = L_v_WL
         return C_H_L, L_v_CL
 
@@ -1786,7 +1788,9 @@ def link_bias_accelerations(
         W_H_L = js.model.forward_kinematics(model=model, data=data)
         LW_H_L = jax.vmap(lambda W_H_L: W_H_L.at[0:3, 3].set(jnp.zeros(3)))(W_H_L)
         C_H_L = LW_H_L
-        L_v_CL = L_v_LW_L = jax.vmap(lambda v: v.at[0:3].set(jnp.zeros(3)))(L_v_WL)  # noqa: F841
+        L_v_CL = L_v_LW_L = jax.vmap(lambda v: v.at[0:3].set(jnp.zeros(3)))(
+            L_v_WL
+        )  # noqa: F841
         return C_H_L, L_v_CL
 
     C_H_L, L_v_CL = jax.lax.switch(

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -183,7 +183,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         # Return all link forces in inertial-fixed representation using the implicit
         # serialization.
         if model is None:
-            if self.velocity_representation is not VelRepr.Inertial:
+            if (self.velocity_representation != VelRepr.Inertial) is True:
                 raise ValueError(
                     "Missing model to use a representation different from `VelRepr.Inertial`"
                 )
@@ -198,7 +198,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         link_idxs = js.link.names_to_idxs(link_names=link_names, model=model)
 
         # In inertial-fixed representation, we already have the link forces.
-        if self.velocity_representation is VelRepr.Inertial:
+        if (self.velocity_representation == VelRepr.Inertial) is True:
             return W_f_L[link_idxs, :]
 
         if data is None:
@@ -373,7 +373,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         # In this case, we allow only to set the inertial 6D forces to all links
         # using the implicit link serialization.
         if model is None:
-            if self.velocity_representation is not VelRepr.Inertial:
+            if (self.velocity_representation != VelRepr.Inertial) is True:
                 raise ValueError(
                     "Missing model to use a representation different from `VelRepr.Inertial`"
                 )
@@ -412,7 +412,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         )
 
         # If inertial-fixed representation, we can directly store the link forces.
-        if self.velocity_representation is VelRepr.Inertial:
+        if (self.velocity_representation == VelRepr.Inertial) is True:
             W_f_L = f_L
             return replace(
                 forces=self.input.physics_model.f_ext.at[link_idxs, :].set(

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -34,7 +34,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
     def zero(
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData | None = None,
-        velocity_representation: int = VelRepr.Inertial,
+        velocity_representation: jtp.VelRepr = VelRepr.Inertial,
     ) -> JaxSimModelReferences:
         """
         Create a `JaxSimModelReferences` object with zero references.
@@ -60,7 +60,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         joint_force_references: jtp.Vector | None = None,
         link_forces: jtp.Matrix | None = None,
         data: js.data.JaxSimModelData | None = None,
-        velocity_representation: int | None = None,
+        velocity_representation: jtp.VelRepr | None = None,
     ) -> JaxSimModelReferences:
         """
         Create a `JaxSimModelReferences` object with the given references.
@@ -230,7 +230,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
             false_fun=lambda: None,
         )
 
-        def not_inertial(velocity_representation: int) -> jtp.Matrix:
+        def not_inertial(velocity_representation: jtp.VelRepr) -> jtp.Matrix:
             # Helper function to convert a single 6D force to the active representation
             # considering as body the link (i.e. L_f_L and LW_f_L).
             def convert(W_f_L: jtp.MatrixLike, W_H_L: jtp.ArrayLike) -> jtp.Matrix:
@@ -473,7 +473,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         )
 
         # If inertial-fixed representation, we can directly store the link forces.
-        def inertial(velocity_representation: int) -> JaxSimModelReferences:
+        def inertial(velocity_representation: jtp.VelRepr) -> JaxSimModelReferences:
             W_f_L = f_L
             return replace(
                 forces=self.input.physics_model.f_ext.at[link_idxs, :].set(
@@ -481,7 +481,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
                 )
             )
 
-        def not_inertial(velocity_representation: int) -> JaxSimModelReferences:
+        def not_inertial(velocity_representation: jtp.VelRepr) -> JaxSimModelReferences:
             # Helper function to convert a single 6D force to the inertial representation
             # considering as body the link (i.e. L_f_L and LW_f_L).
             def convert_using_link_frame(

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -32,7 +32,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
     def zero(
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData | None = None,
-        velocity_representation: VelRepr = VelRepr.Inertial,
+        velocity_representation: int = VelRepr.Inertial,
     ) -> JaxSimModelReferences:
         """
         Create a `JaxSimModelReferences` object with zero references.
@@ -58,7 +58,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         joint_force_references: jtp.Vector | None = None,
         link_forces: jtp.Matrix | None = None,
         data: js.data.JaxSimModelData | None = None,
-        velocity_representation: VelRepr | None = None,
+        velocity_representation: int | None = None,
     ) -> JaxSimModelReferences:
         """
         Create a `JaxSimModelReferences` object with the given references.

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -253,7 +253,9 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
                             "Missing model data to use a representation different from `VelRepr.Inertial`"
                         )
                     ),
-                    result_shape_dtypes=jnp.empty(shape=(1, 4, 4)),
+                    result_shape_dtypes=jnp.empty(
+                        shape=(model.number_of_links(), 4, 4)
+                    ),
                 ),
                 false_fun=lambda: js.model.forward_kinematics(
                     model=model, data=data or JaxSimModelData.zero(model=model)
@@ -498,7 +500,9 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
                             "Missing model data to use a representation different from `VelRepr.Inertial`"
                         )
                     ),
-                    result_shape_dtypes=jnp.empty(shape=(1, 4, 4)),
+                    result_shape_dtypes=jnp.empty(
+                        shape=(model.number_of_links(), 4, 4)
+                    ),
                 ),
                 false_fun=lambda: js.model.forward_kinematics(
                     model=model, data=data or JaxSimModelData.zero(model=model)

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -184,8 +184,9 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         # serialization.
         if model is None:
             if self.velocity_representation is not VelRepr.Inertial:
-                msg = "Missing model to use a representation different from {}"
-                raise ValueError(msg.format(VelRepr.Inertial.name))
+                raise ValueError(
+                    "Missing model to use a representation different from `VelRepr.Inertial`"
+                )
 
             if link_names is not None:
                 raise ValueError("Link names cannot be provided without a model")
@@ -201,8 +202,9 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
             return W_f_L[link_idxs, :]
 
         if data is None:
-            msg = "Missing model data to use a representation different from {}"
-            raise ValueError(msg.format(VelRepr.Inertial.name))
+            raise ValueError(
+                "Missing model data to use a representation different from `VelRepr.Inertial`"
+            )
 
         if not_tracing(self.input.physics_model.f_ext) and not data.valid(model=model):
             raise ValueError("The provided data is not valid for the model")
@@ -372,8 +374,9 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         # using the implicit link serialization.
         if model is None:
             if self.velocity_representation is not VelRepr.Inertial:
-                msg = "Missing model to use a representation different from {}"
-                raise ValueError(msg.format(VelRepr.Inertial.name))
+                raise ValueError(
+                    "Missing model to use a representation different from `VelRepr.Inertial`"
+                )
 
             if link_names is not None:
                 raise ValueError("Link names cannot be provided without a model")
@@ -418,8 +421,9 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
             )
 
         if data is None:
-            msg = "Missing model data to use a representation different from {}"
-            raise ValueError(msg.format(VelRepr.Inertial.name))
+            raise ValueError(
+                "Missing model data to use a representation different from `VelRepr.Inertial`"
+            )
 
         if not_tracing(forces) and not data.valid(model=model):
             raise ValueError("The provided data is not valid for the model")

--- a/src/jaxsim/typing.py
+++ b/src/jaxsim/typing.py
@@ -38,4 +38,4 @@ IntLike = int | Int | jax.typing.ArrayLike
 BoolLike = bool | Bool | jax.typing.ArrayLike
 FloatLike = float | Float | jax.typing.ArrayLike
 
-VelRepr = int
+VelRepr = Int

--- a/src/jaxsim/typing.py
+++ b/src/jaxsim/typing.py
@@ -37,3 +37,5 @@ MatrixLike = Matrix | ArrayLike
 IntLike = int | Int | jax.typing.ArrayLike
 BoolLike = bool | Bool | jax.typing.ArrayLike
 FloatLike = float | Float | jax.typing.ArrayLike
+
+VelRepr = int

--- a/tests/test_api_com.py
+++ b/tests/test_api_com.py
@@ -9,7 +9,7 @@ from . import utils_idyntree
 
 def test_com_properties(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_com.py
+++ b/tests/test_api_com.py
@@ -2,6 +2,7 @@ import jax
 import pytest
 
 import jaxsim.api as js
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 
 from . import utils_idyntree
@@ -9,7 +10,7 @@ from . import utils_idyntree
 
 def test_com_properties(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_com.py
+++ b/tests/test_api_com.py
@@ -53,7 +53,11 @@ def test_com_properties(
     assert pytest.approx(v_avg_com_idt) == v_avg_com_js
 
     # https://github.com/ami-iit/jaxsim/pull/117#discussion_r1535486123
-    if data.velocity_representation is not VelRepr.Body:
+    with data.switch_velocity_representation(
+        data.velocity_representation
+        if data.velocity_representation != VelRepr.Body
+        else VelRepr.Mixed
+    ):
         vl_com_idt = kin_dyn.com_velocity()
         vl_com_js = js.com.com_linear_velocity(model=model, data=data)
         assert pytest.approx(vl_com_idt) == vl_com_js
@@ -61,7 +65,7 @@ def test_com_properties(
     # iDynTree provides the bias acceleration in G[W] frame regardless of the velocity
     # representation. JaxSim, instead, returns the bias acceleration in G[B] when the
     # active representation is VelRepr.Body.
-    if data.velocity_representation is not VelRepr.Body:
+    if data.velocity_representation != VelRepr.Body:
         G_v̇_bias_WG_idt = kin_dyn.com_bias_acceleration()
         G_v̇_bias_WG_js = js.com.bias_acceleration(model=model, data=data)
         assert pytest.approx(G_v̇_bias_WG_idt) == G_v̇_bias_WG_js

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import pytest
 
 import jaxsim.api as js
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 from jaxsim.utils import Mutability
 
@@ -21,7 +22,7 @@ def test_data_valid(
 
 def test_data_joint_indexing(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -21,7 +21,7 @@ def test_data_valid(
 
 def test_data_joint_indexing(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_frame.py
+++ b/tests/test_api_frame.py
@@ -4,6 +4,7 @@ import jaxlib.xla_extension
 import pytest
 
 import jaxsim.api as js
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 from jaxsim.math.quaternion import Quaternion
 
@@ -124,7 +125,7 @@ def test_frame_transforms(
 
 def test_frame_jacobians(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_frame.py
+++ b/tests/test_api_frame.py
@@ -124,7 +124,7 @@ def test_frame_transforms(
 
 def test_frame_jacobians(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -5,6 +5,7 @@ import pytest
 
 import jaxsim.api as js
 import jaxsim.math
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 
 from . import utils_idyntree
@@ -128,7 +129,7 @@ def test_link_transforms(
 
 def test_link_jacobians(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 
@@ -197,7 +198,7 @@ def test_link_jacobians(
 
 def test_link_bias_acceleration(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 
@@ -298,7 +299,7 @@ def test_link_bias_acceleration(
 
 def test_link_jacobian_derivative(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -128,7 +128,7 @@ def test_link_transforms(
 
 def test_link_jacobians(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 
@@ -197,7 +197,7 @@ def test_link_jacobians(
 
 def test_link_bias_acceleration(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -8,6 +8,7 @@ import rod
 
 import jaxsim.api as js
 import jaxsim.math
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 
 from . import utils_idyntree
@@ -222,7 +223,7 @@ def test_model_creation_and_reduction(
 
 def test_model_properties(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 
@@ -269,7 +270,7 @@ def test_model_properties(
 def test_model_rbda(
     jaxsim_models_types: js.model.JaxSimModel,
     prng_key: jax.Array,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
 ):
 
     model = jaxsim_models_types
@@ -480,7 +481,7 @@ def test_coriolis_matrix(
 
 def test_model_fd_id_consistency(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -222,7 +222,7 @@ def test_model_creation_and_reduction(
 
 def test_model_properties(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 
@@ -269,7 +269,7 @@ def test_model_properties(
 def test_model_rbda(
     jaxsim_models_types: js.model.JaxSimModel,
     prng_key: jax.Array,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
 ):
 
     model = jaxsim_models_types
@@ -480,7 +480,7 @@ def test_coriolis_matrix(
 
 def test_model_fd_id_consistency(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_api_references.py
+++ b/tests/test_api_references.py
@@ -1,0 +1,150 @@
+import jax
+import jax.numpy as jnp
+import pytest
+from jaxlib.xla_extension import XlaRuntimeError
+
+import jaxsim.api as js
+import jaxsim.typing as jtp
+from jaxsim import VelRepr
+
+
+def get_random_references(
+    model: js.model.JaxSimModel | None = None,
+    data: js.data.JaxSimModelData | None = None,
+    *,
+    velocity_representation: jtp.VelRepr,
+    key: jax.Array,
+) -> tuple[js.data.JaxSimModelData, js.references.JaxSimModelReferences]:
+
+    _, subkey = jax.random.split(key, num=2)
+
+    _, subkey1, subkey2 = jax.random.split(subkey, num=3)
+
+    references = js.references.JaxSimModelReferences.build(
+        model=model,
+        joint_force_references=10 * jax.random.uniform(subkey1, shape=(model.dofs(),)),
+        link_forces=jax.random.uniform(subkey2, shape=(model.number_of_links(), 6)),
+        data=data,
+        velocity_representation=velocity_representation,
+    )
+
+    # Remove the force applied to the base link if the model is fixed-base.
+    if not model.floating_base():
+        references = references.apply_link_forces(
+            forces=jnp.atleast_2d(jnp.zeros(6)),
+            model=model,
+            data=data,
+            link_names=(model.base_link(),),
+            additive=False,
+        )
+
+    return references
+
+
+def test_raise_errors_link_forces(
+    jaxsim_model_box: js.model.JaxSimModel,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_model_box
+
+    _, subkey1, subkey2 = jax.random.split(prng_key, num=3)
+
+    data = js.data.random_model_data(model=model, key=subkey1)
+
+    # ================
+    # VelRepr.Inertial
+    # ================
+
+    references_inertial = get_random_references(
+        model=model, data=None, velocity_representation=VelRepr.Inertial, key=subkey2
+    )
+
+    # `model` is None and `link_names` is not None.
+    with pytest.raises(
+        ValueError, match="Link names cannot be provided without a model"
+    ):
+        references_inertial.link_forces(model=None, link_names=model.link_names())
+
+    # ============
+    # VelRepr.Body
+    # ============
+
+    references_body = get_random_references(
+        model=model, data=data, velocity_representation=VelRepr.Body, key=subkey2
+    )
+
+    # `model` is None and `link_names` is not None.
+    with pytest.raises(
+        ValueError, match="Link names cannot be provided without a model"
+    ):
+        references_body.link_forces(model=None, link_names=model.link_names())
+
+    # `model` is not None and `data` is None.
+    with pytest.raises(
+        XlaRuntimeError,
+        match="Missing model data to use a representation different from `VelRepr.Inertial`",
+    ):
+        references_body.link_forces(model=model, data=None)
+
+
+def test_raise_errors_apply_link_forces(
+    jaxsim_model_box: js.model.JaxSimModel,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_model_box
+
+    _, subkey1, subkey2 = jax.random.split(prng_key, num=3)
+
+    data = js.data.random_model_data(model=model, key=subkey1)
+
+    # ================
+    # VelRepr.Inertial
+    # ================
+
+    references_inertial = get_random_references(
+        model=model, data=None, velocity_representation=VelRepr.Inertial, key=subkey2
+    )
+
+    # `model` is None
+    with pytest.raises(
+        ValueError,
+        match="Link names cannot be provided without a model",
+    ):
+        references_inertial.apply_link_forces(
+            forces=jnp.zeros(6), model=None, data=None, link_names=model.link_names()
+        )
+
+    # ============
+    # VelRepr.Body
+    # ============
+
+    references_body = get_random_references(
+        model=model, data=data, velocity_representation=VelRepr.Body, key=subkey2
+    )
+
+    # `model` is None
+    with pytest.raises(
+        ValueError,
+        match="Link names cannot be provided without a model",
+    ):
+        references_body.apply_link_forces(
+            forces=jnp.zeros(6), model=None, data=None, link_names=model.link_names()
+        )
+
+    # `model` is None
+    with pytest.raises(
+        XlaRuntimeError,
+        match="Missing model to use a representation different from `VelRepr.Inertial`",
+    ):
+        references_body.apply_link_forces(forces=jnp.zeros(6), model=None, data=None)
+
+    # `model` is not None and `data` is None.
+    with pytest.raises(
+        XlaRuntimeError,
+        match="Missing model data to use a representation different from `VelRepr.Inertial`",
+    ):
+        references_body.apply_link_forces(
+            forces=jnp.zeros(6), model=model, data=None, link_names=model.link_names()
+        )

--- a/tests/test_api_references.py
+++ b/tests/test_api_references.py
@@ -109,7 +109,7 @@ def test_raise_errors_apply_link_forces(
 
     # `model` is None
     with pytest.raises(
-        ValueError,
+        XlaRuntimeError,
         match="Link names cannot be provided without a model",
     ):
         references_inertial.apply_link_forces(
@@ -123,15 +123,6 @@ def test_raise_errors_apply_link_forces(
     references_body = get_random_references(
         model=model, data=data, velocity_representation=VelRepr.Body, key=subkey2
     )
-
-    # `model` is None
-    with pytest.raises(
-        ValueError,
-        match="Link names cannot be provided without a model",
-    ):
-        references_body.apply_link_forces(
-            forces=jnp.zeros(6), model=None, data=None, link_names=model.link_names()
-        )
 
     # `model` is None
     with pytest.raises(

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -26,7 +26,7 @@ AD_ORDER = os.environ.get("JAXSIM_TEST_AD_ORDER", 1)
 
 def get_random_data_and_references(
     model: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     key: jax.Array,
 ) -> tuple[js.data.JaxSimModelData, js.references.JaxSimModelReferences]:
 

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -26,7 +26,7 @@ AD_ORDER = os.environ.get("JAXSIM_TEST_AD_ORDER", 1)
 
 def get_random_data_and_references(
     model: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     key: jax.Array,
 ) -> tuple[js.data.JaxSimModelData, js.references.JaxSimModelReferences]:
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -2,12 +2,13 @@ import jax
 import pytest
 
 import jaxsim.api as js
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 
 
 def test_collidable_point_jacobians(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -7,7 +7,7 @@ from jaxsim import VelRepr
 
 def test_collidable_point_jacobians(
     jaxsim_models_types: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
     prng_key: jax.Array,
 ):
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -5,13 +5,14 @@ import pytest
 import jaxsim.api as js
 import jaxsim.integrators
 import jaxsim.rbda
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 from jaxsim.utils import Mutability
 
 
 def test_box_with_external_forces(
     jaxsim_model_box: js.model.JaxSimModel,
-    velocity_representation: int,
+    velocity_representation: jtp.VelRepr,
 ):
     """
     This test simulates a box falling due to gravity.
@@ -96,7 +97,7 @@ def test_box_with_external_forces(
 
 def test_box_with_zero_gravity(
     jaxsim_model_box: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: jtp.VelRepr,
     prng_key: jnp.ndarray,
 ):
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -11,7 +11,7 @@ from jaxsim.utils import Mutability
 
 def test_box_with_external_forces(
     jaxsim_model_box: js.model.JaxSimModel,
-    velocity_representation: VelRepr,
+    velocity_representation: int,
 ):
     """
     This test simulates a box falling due to gravity.

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.typing as npt
 
 import jaxsim.api as js
+import jaxsim.typing as jtp
 from jaxsim import VelRepr
 
 
@@ -118,7 +119,7 @@ def store_jaxsim_data_in_kindyncomputations(
 class KinDynComputations:
     """High-level wrapper of the iDynTree KinDynComputations class."""
 
-    vel_repr: int
+    vel_repr: jtp.VelRepr
     gravity: npt.NDArray
     kin_dyn: idt.KinDynComputations
 
@@ -126,7 +127,7 @@ class KinDynComputations:
     def build(
         urdf: pathlib.Path | str,
         considered_joints: list[str] | None = None,
-        vel_repr: int = VelRepr.Inertial,
+        vel_repr: jtp.VelRepr = VelRepr.Inertial,
         gravity: npt.NDArray = np.array([0, 0, -10.0]),
         removed_joint_positions: dict[str, npt.NDArray | float | int] | None = None,
     ) -> KinDynComputations:

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -118,7 +118,7 @@ def store_jaxsim_data_in_kindyncomputations(
 class KinDynComputations:
     """High-level wrapper of the iDynTree KinDynComputations class."""
 
-    vel_repr: VelRepr
+    vel_repr: int
     gravity: npt.NDArray
     kin_dyn: idt.KinDynComputations
 
@@ -126,7 +126,7 @@ class KinDynComputations:
     def build(
         urdf: pathlib.Path | str,
         considered_joints: list[str] | None = None,
-        vel_repr: VelRepr = VelRepr.Inertial,
+        vel_repr: int = VelRepr.Inertial,
         gravity: npt.NDArray = np.array([0, 0, -10.0]),
         removed_joint_positions: dict[str, npt.NDArray | float | int] | None = None,
     ) -> KinDynComputations:


### PR DESCRIPTION
This pull request refactors the velocity representation in the JaxSim API. The changes include avoiding the use of `enum` in `VelRepr` and making `velocity_representation` a non-static argument in some methods of `jaxsim.api.JaxSimModelData`. These changes improve the compatibility with JAX while avoiding breaking changes in the API, making it possible to potentially using `jax.vmap` on different velocity representations

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--160.org.readthedocs.build//160/

<!-- readthedocs-preview jaxsim end -->