### PR TITLE
Compute the pose and the jacobian of the implicit frames associated to collidable points

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -369,8 +369,8 @@ def jacobian(
                 C_X_W = jaxsim.math.Adjoint.from_transform(
                     transform=W_H_C, inverse=True
                 )
-                C_J_WCi = C_X_W @ W_J_WC
-                return C_J_WCi
+                C_J_WC = C_X_W @ W_J_WC
+                return C_J_WC
 
             O_J_WC = jax.vmap(jacobian)(W_H_C, W_J_WC)
 

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -32,6 +32,7 @@ def collidable_point_kinematics(
 
     from jaxsim.rbda import collidable_points
 
+    # Switch to inertial-fixed since the RBDAs expect velocities in this representation.
     with data.switch_velocity_representation(VelRepr.Inertial):
         W_p_Ci, W_ṗ_Ci = collidable_points.collidable_points_pos_vel(
             model=model,
@@ -61,7 +62,9 @@ def collidable_point_positions(
         The position of the collidable points in the world frame.
     """
 
-    return collidable_point_kinematics(model=model, data=data)[0]
+    W_p_Ci, _ = collidable_point_kinematics(model=model, data=data)
+
+    return W_p_Ci
 
 
 @jax.jit
@@ -79,7 +82,9 @@ def collidable_point_velocities(
         The 3D velocity of the collidable points.
     """
 
-    return collidable_point_kinematics(model=model, data=data)[1]
+    _, W_ṗ_Ci = collidable_point_kinematics(model=model, data=data)
+
+    return W_ṗ_Ci
 
 
 @jax.jit

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -1,0 +1,37 @@
+import jax
+import pytest
+
+import jaxsim.api as js
+from jaxsim import VelRepr
+
+
+def test_collidable_point_jacobians(
+    jaxsim_models_types: js.model.JaxSimModel,
+    velocity_representation: VelRepr,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_models_types
+
+    key, subkey = jax.random.split(prng_key, num=2)
+    data = js.data.random_model_data(
+        model=model, key=subkey, velocity_representation=velocity_representation
+    )
+
+    # =====
+    # Tests
+    # =====
+
+    # Compute the velocity of the collidable points with a RBDA.
+    # This function always returns the linear part of the mixed velocity of the
+    # implicit frame C corresponding to the collidable point.
+    W_ṗ_C = js.contact.collidable_point_velocities(model=model, data=data)
+
+    # Compute the generalized velocity and the free-floating Jacobian of the frame C.
+    ν = data.generalized_velocity()
+    CL_J_WC = js.contact.jacobian(model=model, data=data, output_vel_repr=VelRepr.Mixed)
+
+    # Compute the velocity of the collidable points using the Jacobians.
+    v_WC_from_jax = jax.vmap(lambda J, ν: J @ ν, in_axes=(0, None))(CL_J_WC, ν)
+
+    assert W_ṗ_C == pytest.approx(v_WC_from_jax[:, 0:3])

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -29,9 +29,9 @@ def test_collidable_point_jacobians(
 
     # Compute the generalized velocity and the free-floating Jacobian of the frame C.
     ν = data.generalized_velocity()
-    CL_J_WC = js.contact.jacobian(model=model, data=data, output_vel_repr=VelRepr.Mixed)
+    CW_J_WC = js.contact.jacobian(model=model, data=data, output_vel_repr=VelRepr.Mixed)
 
     # Compute the velocity of the collidable points using the Jacobians.
-    v_WC_from_jax = jax.vmap(lambda J, ν: J @ ν, in_axes=(0, None))(CL_J_WC, ν)
+    v_WC_from_jax = jax.vmap(lambda J, ν: J @ ν, in_axes=(0, None))(CW_J_WC, ν)
 
     assert W_ṗ_C == pytest.approx(v_WC_from_jax[:, 0:3])


### PR DESCRIPTION
We consider the following implicit frame associated to each collidable point:

```math
C := \left({}^W \mathbf{p}_C, [L]\right)
```

where:

- ${}^W \mathbf{p}_C \in \mathbb{R}^3$ is the position of the collidable point in world coordinates.
- $[L]$ is the orientation frame of the parent link of the collidable point (i.e. the link it is rigidly attached to).

This PR implements the following:

- The world-to-contact-frame transform ${}^W \mathbf{H}_C \in \text{SE}(3)$.
- The free-floating jacobian ${}^O J_{W,C/I}$ of the contact frame, where $I$ is the input representation that should match the representation of $\boldsymbol{\nu} \in \mathbb{R}^{6+n}$, and $O$ the desired output representation.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--163.org.readthedocs.build//163/

<!-- readthedocs-preview jaxsim end -->