### PR TITLE
Preserve the original terrain in reduced models

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -338,6 +338,7 @@ def reduce(
     reduced_model = JaxSimModel.build(
         model_description=reduced_intermediate_description,
         model_name=model.name(),
+        terrain=model.terrain,
     )
 
     # Store the origin of the model, in case downstream logic needs it

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -93,6 +93,9 @@ def test_model_creation_and_reduction(
     # Check that all non-fixed joints are in the reduced model.
     assert set(reduced_joints) == set(model_reduced.joint_names())
 
+    # Check that the reduce model maintain the same terrain of the full model.
+    assert model_full.terrain == model_reduced.terrain
+
     # Build the data of the reduced model.
     data_reduced = js.data.JaxSimModelData.build(
         model=model_reduced,


### PR DESCRIPTION
This PR fixes the bug occurring when reducing a model with `jaxsim.api.model.reduce`, in which the terrain specification was not preserved.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--168.org.readthedocs.build//168/

<!-- readthedocs-preview jaxsim end -->