### PR TITLE
Add algorithm to compute the Jacobian derivative of a link

### DIFF
--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -511,7 +511,7 @@ def jacobian_derivative(
 
     # Sum all the components that form the Jacobian derivative in the target
     # input/output velocity representations.
-    O_J̇_WL_I = 0.0
+    O_J̇_WL_I = jnp.zeros(shape=(6, 6 + model.dofs()))
     O_J̇_WL_I += O_Ẋ_B @ B_J_WL_B @ T
     O_J̇_WL_I += O_X_B @ B_J̇_WL_B @ T
     O_J̇_WL_I += O_X_B @ B_J_WL_B @ Ṫ

--- a/src/jaxsim/rbda/__init__.py
+++ b/src/jaxsim/rbda/__init__.py
@@ -2,6 +2,10 @@ from .aba import aba
 from .collidable_points import collidable_points_pos_vel
 from .crba import crba
 from .forward_kinematics import forward_kinematics, forward_kinematics_model
-from .jacobian import jacobian, jacobian_full_doubly_left
+from .jacobian import (
+    jacobian,
+    jacobian_derivative_full_doubly_left,
+    jacobian_full_doubly_left,
+)
 from .rnea import rnea
 from .soft_contacts import SoftContacts, SoftContactsParams

--- a/src/jaxsim/rbda/jacobian.py
+++ b/src/jaxsim/rbda/jacobian.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.math import Adjoint
+from jaxsim.math import Adjoint, Cross
 
 from . import utils
 
@@ -199,3 +199,120 @@ def jacobian_full_doubly_left(
     B_J_full_WL_B = J.squeeze().astype(float)
 
     return B_J_full_WL_B, B_H_L
+
+
+def jacobian_derivative_full_doubly_left(
+    model: js.model.JaxSimModel,
+    *,
+    joint_positions: jtp.VectorLike,
+    joint_velocities: jtp.VectorLike,
+) -> tuple[jtp.Matrix, jtp.Array]:
+    r"""
+    Compute the derivative of the doubly-left full free-floating Jacobian of a model.
+
+    The derivative of the full Jacobian is a 6x(6+n) matrix with all the columns filled.
+    It is useful to run the algorithm once, and then extract the link Jacobian
+    derivative by filtering the columns of the full Jacobian using the support
+    parent array :math:`\kappa(i)` of the link.
+
+    Args:
+        model: The model to consider.
+        joint_positions: The positions of the joints.
+        joint_velocities: The velocities of the joints.
+
+    Returns:
+        The derivative of the doubly-left full free-floating Jacobian of a model.
+    """
+
+    _, _, s, _, ṡ, _, _, _, _, _ = utils.process_inputs(
+        model=model, joint_positions=joint_positions, joint_velocities=joint_velocities
+    )
+
+    # Get the parent array λ(i).
+    # Note: λ(0) must not be used, it's initialized to -1.
+    λ = model.kin_dyn_parameters.parent_array
+
+    # Compute the parent-to-child adjoints and the motion subspaces of the joints.
+    # These transforms define the relative kinematics of the entire model, including
+    # the base transform for both floating-base and fixed-base models.
+    i_X_λi, S = model.kin_dyn_parameters.joint_transforms_and_motion_subspaces(
+        joint_positions=s, base_transform=jnp.eye(4)
+    )
+
+    # Allocate the buffer of 6D transform base -> link.
+    B_X_i = jnp.zeros(shape=(model.number_of_links(), 6, 6))
+    B_X_i = B_X_i.at[0].set(jnp.eye(6))
+
+    # Allocate the buffer of 6D transform derivatives base -> link.
+    B_Ẋ_i = jnp.zeros(shape=(model.number_of_links(), 6, 6))
+
+    # Allocate the buffer of the 6D link velocity in body-fixed representation.
+    B_v_Bi = jnp.zeros(shape=(model.number_of_links(), 6))
+
+    # Helper to compute the time derivative of the adjoint matrix.
+    def A_Ẋ_B(A_X_B: jtp.Matrix, B_v_AB: jtp.Vector) -> jtp.Matrix:
+        return A_X_B @ Cross.vx(B_v_AB).squeeze()
+
+    # ============================================
+    # Compute doubly-left full Jacobian derivative
+    # ============================================
+
+    # Allocate the Jacobian matrix.
+    J̇ = jnp.zeros(shape=(6, 6 + model.dofs()))
+
+    ComputeFullJacobianDerivativeCarry = tuple[
+        jtp.MatrixJax, jtp.MatrixJax, jtp.MatrixJax, jtp.MatrixJax
+    ]
+
+    compute_full_jacobian_derivative_carry: ComputeFullJacobianDerivativeCarry = (
+        B_v_Bi,
+        B_X_i,
+        B_Ẋ_i,
+        J̇,
+    )
+
+    def compute_full_jacobian_derivative(
+        carry: ComputeFullJacobianDerivativeCarry, i: jtp.Int
+    ) -> tuple[ComputeFullJacobianDerivativeCarry, None]:
+
+        ii = i - 1
+        B_v_Bi, B_X_i, B_Ẋ_i, J̇ = carry
+
+        # Compute the base (0) to link (i) adjoint matrix.
+        B_Xi_i = B_X_i[λ[i]] @ Adjoint.inverse(i_X_λi[i])
+        B_X_i = B_X_i.at[i].set(B_Xi_i)
+
+        # Compute the body-fixed velocity of the link.
+        B_vi_Bi = B_v_Bi[λ[i]] + B_X_i[i] @ S[i].squeeze() * ṡ[ii]
+        B_v_Bi = B_v_Bi.at[i].set(B_vi_Bi)
+
+        # Compute the base (0) to link (i) adjoint matrix derivative.
+        i_Xi_B = Adjoint.inverse(B_Xi_i)
+        B_Ẋi_i = A_Ẋ_B(A_X_B=B_Xi_i, B_v_AB=i_Xi_B @ B_vi_Bi)
+        B_Ẋ_i = B_Ẋ_i.at[i].set(B_Ẋi_i)
+
+        # Compute the ii-th column of the B_Ṡ_BL(s) matrix.
+        B_Ṡii_BL = B_Ẋ_i[i] @ S[i]
+        J̇ = J̇.at[0:6, 6 + ii].set(B_Ṡii_BL.squeeze())
+
+        return (B_v_Bi, B_X_i, B_Ẋ_i, J̇), None
+
+    (_, B_X_i, B_Ẋ_i, J̇), _ = (
+        jax.lax.scan(
+            f=compute_full_jacobian_derivative,
+            init=compute_full_jacobian_derivative_carry,
+            xs=np.arange(start=1, stop=model.number_of_links()),
+        )
+        if model.number_of_links() > 1
+        else [(_, B_X_i, B_Ẋ_i, J̇), None]
+    )
+
+    # Convert adjoints to SE(3) transforms.
+    # Returning them here prevents calling FK in case the output representation
+    # of the Jacobian needs to be changed.
+    B_H_L = jax.vmap(lambda B_X_L: Adjoint.to_transform(B_X_L))(B_X_i)
+
+    # Adjust shape of doubly-left free-floating full Jacobian derivative.
+    B_J̇_full_WL_B = J̇.squeeze().astype(float)
+
+    return B_J̇_full_WL_B, B_H_L

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -221,7 +221,7 @@ def test_link_jacobian_derivative(
 
     model = jaxsim_models_types
 
-    key, subkey = jax.random.split(prng_key, num=2)
+    _, subkey = jax.random.split(prng_key, num=2)
     data = js.data.random_model_data(
         model=model,
         key=subkey,

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -211,3 +211,43 @@ def test_link_bias_acceleration(
         Jν_idt = kin_dyn.frame_bias_acc(frame_name=name)
         Jν_js = js.link.bias_acceleration(model=model, data=data, link_index=index)
         assert pytest.approx(Jν_idt) == Jν_js
+
+
+def test_link_jacobian_derivative(
+    jaxsim_models_types: js.model.JaxSimModel,
+    velocity_representation: VelRepr,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_models_types
+
+    key, subkey = jax.random.split(prng_key, num=2)
+    data = js.data.random_model_data(
+        model=model,
+        key=subkey,
+        velocity_representation=velocity_representation,
+    )
+
+    # =====
+    # Tests
+    # =====
+
+    # Test only the last link of the model.
+    link_name = model.link_names()[-1]
+    link_index = js.link.name_to_idx(model=model, link_name=link_name)
+
+    # Get the generalized velocity.
+    I_ν = data.generalized_velocity()
+
+    # Compute J̇.
+    O_J̇_WL_I = js.link.jacobian_derivative(
+        model=model, data=data, link_index=link_index
+    )
+
+    # Compute the product J̇ν.
+    O_a_bias_WL = js.link.bias_acceleration(
+        model=model, data=data, link_index=link_index
+    )
+
+    # Compare the two computations.
+    assert O_J̇_WL_I @ I_ν == pytest.approx(O_a_bias_WL)


### PR DESCRIPTION
This PR adds a new RBDA to compute the derivative of the free-floating Jacobian $\dot{J}_{W,L}$. If:

- $L$ is the frame of the link,
- $I$ is the frame of the input velocity representation used by the generalized velocity ${}^I \boldsymbol{\nu}$,
- $O$ is frame of the output velocity representation corresponding to the result of the product ${}^O \dot{J}_{W,L/I} \\; {}^I \boldsymbol{\nu}$,

we first compute the following full Jacobian derivative (with all columns filled, similarly to what was done in #121):

```math
{}^B \dot{J}_{W,\_/B} \in \mathbb{R}^{6\times(6+n)}
```

and then mask the joint-related columns using the support parent array $\kappa(i)$ of the i-th link associated to the frame $L$:

```math
{}^B \dot{J}_{W,L/B} = M(\kappa(i)) \; {}^B \dot{J}_{W,\_/B}
```

The mask in practice sets to zero all the joint-related columns corresponding to the chains not supporting the link $L$, i.e. not in the path $\pi_B(L)$.

All of this is computed with the new `jaxsim.rbda.jacobian.jacobian_derivative_full_doubly_left` function.

This is not enough, since we are interested to compute quantities like $\dot{J} \boldsymbol{\nu}$. Note that in this specific case, we already have this product computed by #127, it's only an use-case example. Though, we also need to change the output and input velocity representations to something else in order to support body-fixed, mixed, and inertial-fixed variants. Therefore, we need to properly convert ${}^B \dot{J}\_{W,L/B}$ to a generic ${}^O \dot{J}\_{W,L/I}$.

The most generic formulation of the change of representations of the free-floating Jacobian is the following[^1]:

```math
{}^O J_{W,L/I} = {}^O \mathbf{X}_B \; {}^B J_{W,L/B} \; \text{diag}({}^B \mathbf{X}_I,\: \mathbf{I}_n)
```

Therefore, if we want the derivative ${}^O \dot{J}\_{W,L/I}$, we need to also consider the derivatives of the different $\mathbf{X}$ matrices. The `jaxsim.api.link.jacobian_derivative` accounts for them. For this, we can use the following relation:

```math
{}^A \dot{\mathbf{X}}_B = {}^A \mathbf{X}_B \; {}^B \mathbf{v}_{A,B} \times
```

Finally:

```math
\begin{align}
{}^O \dot{J}_{W,L/I} =& {}^O \dot{\mathbf{X}}_B \; {}^B J_{W,L/B} \; \text{diag}({}^B \mathbf{X}_I,\: \mathbf{I}_n) \\
+& {}^O \mathbf{X}_B \; {}^B \dot{J}_{W,L/B} \; \text{diag}({}^B \mathbf{X}_I,\: \mathbf{I}_n) \\
+& {}^O \mathbf{X}_B \; {}^B J_{W,L/B} \; \text{diag}({}^B \dot{\mathbf{X}}_I,\: \mathbf{0}_n)
\end{align}
```

where $I \in \\{W, \\, B,\\, B[W]\\}$ and $O \in \\{W, \\, L,\\, L[W] \\}$.

[^1]: Diego Ferigo, Eq (2.28) pag. 67, _Simulation Architectures for Reinforcement Learning applied to Robotics_, Ph.D. thesis, [URL](https://github.com/diegoferigo/phd-thesis).


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--169.org.readthedocs.build//169/

<!-- readthedocs-preview jaxsim end -->