### PR TITLE
Fix prismatic joints transform in `math.joint_model.supported_joint_motion`

### DIFF
--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -267,7 +267,10 @@ def supported_joint_motion(
         # This is a metadata required by only some joint types.
         axis = jnp.array(joint_axis).astype(float).squeeze()
 
-        pre_H_suc = jaxlie.SE3.from_translation(translation=jnp.array(s * axis))
+        pre_H_suc = jaxlie.SE3.from_rotation_and_translation(
+            rotation=jaxlie.SO3.identity(),
+            translation=jnp.array(s * axis),
+        )
 
         S = jnp.vstack(jnp.hstack([axis, jnp.zeros(3)]))
 


### PR DESCRIPTION
The method `jaxlie.SE3.from_translation` used to calculate the parent-child transform for prismatic joints doesn't actually exists

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--170.org.readthedocs.build//170/

<!-- readthedocs-preview jaxsim end -->