### PR TITLE
Update CI/CD workflow to interface with PyPI as Trusted Publisher

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,6 +144,8 @@ jobs:
     name: Publish to PyPI
     needs: test
     runs-on: ubuntu-22.04
+    permissions:
+        id-token: write
 
     steps:
 
@@ -163,6 +165,4 @@ jobs:
            (github.event_name == 'release'))
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
           skip-existing: true


### PR DESCRIPTION
More info about Trusted Publishers in PyPI: https://docs.pypi.org/trusted-publishers/.

I've enabled the `ci_cd.yml` workflow in PyPI as follows:

![image](https://github.com/ami-iit/jaxsim/assets/469199/bc920ec9-6570-4777-bc59-2d615a65bf66)


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--174.org.readthedocs.build//174/

<!-- readthedocs-preview jaxsim end -->