### PR TITLE
Check `plane_normal` type when instantiating a `PlaneTerrain`

### DIFF
--- a/src/jaxsim/terrain/terrain.py
+++ b/src/jaxsim/terrain/terrain.py
@@ -59,6 +59,10 @@ class PlaneTerrain(Terrain):
         Returns:
             PlaneTerrain: A PlaneTerrain instance.
         """
+        if not isinstance(plane_normal, list):
+            raise TypeError(
+                f"Expected a list for the plane normal vector, got: {type(plane_normal)}."
+            )
 
         return PlaneTerrain(plane_normal=plane_normal)
 


### PR DESCRIPTION
This PR adds a type check on the plane normal when instantiating a `PlaneTerrain` class. 

Solves https://github.com/ami-iit/jaxsim/issues/176

C.C. @lorycontixd 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--177.org.readthedocs.build//177/

<!-- readthedocs-preview jaxsim end -->