### PR TITLE
Speed up passing different `JaxSimModel` with same pytree structure to JIT-compiled functions

### DIFF
--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -45,12 +45,14 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
 
     def __hash__(self) -> int:
 
+        from jaxsim.utils.wrappers import HashedNumpyArray
+
         return hash(
             (
                 hash(self.state),
-                hash(tuple(self.gravity.flatten().tolist())),
+                HashedNumpyArray.hash_of_array(self.gravity),
                 hash(self.soft_contacts_params),
-                hash(jnp.atleast_1d(self.time_ns).flatten().tolist()),
+                hash(tuple(self.time_ns.flatten().tolist())),
             )
         )
 

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -52,7 +52,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
                 hash(self.state),
                 HashedNumpyArray.hash_of_array(self.gravity),
                 hash(self.soft_contacts_params),
-                hash(tuple(self.time_ns.flatten().tolist())),
+                HashedNumpyArray.hash_of_array(self.time_ns),
             )
         )
 

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -748,7 +748,7 @@ class ContactParameters(JaxsimDataclass):
             A tuple of integers representing, for each collidable point, the index of
             the body (link) to which it is rigidly attached to.
         point:
-            The translation between the link frame and the collidable point, expressed
+            The translations between the link frame and the collidable point, expressed
             in the coordinates of the parent link frame.
 
     Note:
@@ -791,11 +791,11 @@ class ContactParameters(JaxsimDataclass):
             links_dict[cp.parent_link.name].index for cp in collidable_points
         )
 
-        # Build the GroundContact object.
+        # Build the ContactParameters object.
         cp = ContactParameters(point=points, body=link_index_of_points)  # noqa
 
-        assert cp.point.shape[1] == 3
-        assert cp.point.shape[0] == len(cp.body)
+        assert cp.point.shape[1] == 3, cp.point.shape[1]
+        assert cp.point.shape[0] == len(cp.body), cp.point.shape[0]
 
         return cp
 

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -6,7 +6,6 @@ import jax.lax
 import jax.numpy as jnp
 import jax_dataclasses
 import jaxlie
-import numpy as np
 from jax_dataclasses import Static
 
 import jaxsim.typing as jtp
@@ -15,7 +14,7 @@ from jaxsim.parsers.descriptions import JointDescription, ModelDescription
 from jaxsim.utils import HashedNumpyArray, JaxsimDataclass
 
 
-@jax_dataclasses.pytree_dataclass
+@jax_dataclasses.pytree_dataclass(eq=False, unsafe_hash=False)
 class KynDynParameters(JaxsimDataclass):
     r"""
     Class storing the kinematic and dynamic parameters of a model.
@@ -221,7 +220,6 @@ class KynDynParameters(JaxsimDataclass):
             (
                 hash(self.number_of_links()),
                 hash(self.number_of_joints()),
-                hash(tuple(np.atleast_1d(self.parent_array).flatten().tolist())),
                 hash(self._parent_array),
                 hash(self._support_body_array_bool),
             )

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -51,15 +51,26 @@ class JaxSimModel(JaxsimDataclass):
         if not isinstance(other, JaxSimModel):
             return False
 
-        return hash(self) == hash(other)
+        if self.model_name != other.model_name:
+            return False
+
+        if self.kin_dyn_parameters != other.kin_dyn_parameters:
+            return False
+
+        # Here we compare only the static quantities of ModelDescription
+        # that are actually used by our APIs.
+        if self.description.frames != other.description.frames:
+            return False
+
+        return True
 
     def __hash__(self) -> int:
 
         return hash(
             (
                 hash(self.model_name),
-                hash(self.description),
                 hash(self.kin_dyn_parameters),
+                hash(self.description),
             )
         )
 

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -22,7 +22,7 @@ from jaxsim.utils import JaxsimDataclass, Mutability
 from .common import VelRepr
 
 
-@jax_dataclasses.pytree_dataclass
+@jax_dataclasses.pytree_dataclass(eq=False, unsafe_hash=False)
 class JaxSimModel(JaxsimDataclass):
     """
     The JaxSim model defining the kinematics and dynamics of a robot.
@@ -31,19 +31,19 @@ class JaxSimModel(JaxsimDataclass):
     model_name: Static[str]
 
     terrain: Static[jaxsim.terrain.Terrain] = dataclasses.field(
-        default=jaxsim.terrain.FlatTerrain(), repr=False, compare=False, hash=False
+        default=jaxsim.terrain.FlatTerrain(), repr=False
     )
 
     kin_dyn_parameters: js.kin_dyn_parameters.KynDynParameters | None = (
-        dataclasses.field(default=None, repr=False, compare=False, hash=False)
+        dataclasses.field(default=None, repr=False)
     )
 
     built_from: Static[str | pathlib.Path | rod.Model | None] = dataclasses.field(
-        default=None, repr=False, compare=False, hash=False
+        default=None, repr=False
     )
 
     description: Static[jaxsim.parsers.descriptions.ModelDescription | None] = (
-        dataclasses.field(default=None, repr=False, compare=False, hash=False)
+        dataclasses.field(default=None, repr=False)
     )
 
     def __eq__(self, other: JaxSimModel) -> bool:

--- a/src/jaxsim/api/ode_data.py
+++ b/src/jaxsim/api/ode_data.py
@@ -283,12 +283,16 @@ class PhysicsModelState(JaxsimDataclass):
 
     def __hash__(self) -> int:
 
+        from jaxsim.utils.wrappers import HashedNumpyArray
+
         return hash(
             (
-                hash(tuple(jnp.atleast_1d(self.joint_positions.flatten().tolist()))),
-                hash(tuple(jnp.atleast_1d(self.joint_velocities.flatten().tolist()))),
-                hash(tuple(self.base_position.flatten().tolist())),
-                hash(tuple(self.base_quaternion.flatten().tolist())),
+                HashedNumpyArray.hash_of_array(self.joint_positions),
+                HashedNumpyArray.hash_of_array(self.joint_velocities),
+                HashedNumpyArray.hash_of_array(self.base_position),
+                HashedNumpyArray.hash_of_array(self.base_quaternion),
+                HashedNumpyArray.hash_of_array(self.base_linear_velocity),
+                HashedNumpyArray.hash_of_array(self.base_angular_velocity),
             )
         )
 
@@ -613,9 +617,9 @@ class SoftContactsState(JaxsimDataclass):
 
     def __hash__(self) -> int:
 
-        return hash(
-            tuple(jnp.atleast_1d(self.tangential_deformation.flatten()).tolist())
-        )
+        from jaxsim.utils.wrappers import HashedNumpyArray
+
+        return HashedNumpyArray.hash_of_array(self.tangential_deformation)
 
     def __eq__(self, other: SoftContactsState) -> bool:
 

--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -95,6 +95,61 @@ class JointDescription(JaxsimDataclass):
                 norm_of_axis = np.linalg.norm(self.axis)
                 self.axis = self.axis / norm_of_axis
 
+    def __eq__(self, other: JointDescription) -> bool:
+
+        if not isinstance(other, JointDescription):
+            return False
+
+        if self.name != other.name:
+            return False
+
+        if not np.allclose(self.axis, other.axis):
+            return False
+
+        if not np.allclose(self.pose, other.pose):
+            return False
+
+        if self.jtype != other.jtype:
+            return False
+
+        if self.child != other.child:
+            return False
+
+        if self.parent != other.parent:
+            return False
+
+        if self.index != other.index:
+            return False
+
+        if not np.allclose(self.friction_static, other.friction_static):
+            return False
+
+        if not np.allclose(self.friction_viscous, other.friction_viscous):
+            return False
+
+        if not np.allclose(self.position_limit_damper, other.position_limit_damper):
+            return False
+
+        if not np.allclose(self.position_limit_spring, other.position_limit_spring):
+            return False
+
+        if not np.allclose(self.position_limit, other.position_limit):
+            return False
+
+        if not np.allclose(self.initial_position, other.initial_position):
+            return False
+
+        if not np.allclose(self.motor_inertia, other.motor_inertia):
+            return False
+
+        if not np.allclose(self.motor_viscous_friction, other.motor_viscous_friction):
+            return False
+
+        if not np.allclose(self.motor_gear_ratio, other.motor_gear_ratio):
+            return False
+
+        return True
+
     def __hash__(self) -> int:
 
         from jaxsim.utils.wrappers import HashedNumpyArray

--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -100,52 +100,29 @@ class JointDescription(JaxsimDataclass):
         if not isinstance(other, JointDescription):
             return False
 
-        if self.name != other.name:
-            return False
-
-        if not np.allclose(self.axis, other.axis):
-            return False
-
-        if not np.allclose(self.pose, other.pose):
-            return False
-
-        if self.jtype != other.jtype:
-            return False
-
-        if self.child != other.child:
-            return False
-
-        if self.parent != other.parent:
-            return False
-
-        if self.index != other.index:
-            return False
-
-        if not np.allclose(self.friction_static, other.friction_static):
-            return False
-
-        if not np.allclose(self.friction_viscous, other.friction_viscous):
-            return False
-
-        if not np.allclose(self.position_limit_damper, other.position_limit_damper):
-            return False
-
-        if not np.allclose(self.position_limit_spring, other.position_limit_spring):
-            return False
-
-        if not np.allclose(self.position_limit, other.position_limit):
-            return False
-
-        if not np.allclose(self.initial_position, other.initial_position):
-            return False
-
-        if not np.allclose(self.motor_inertia, other.motor_inertia):
-            return False
-
-        if not np.allclose(self.motor_viscous_friction, other.motor_viscous_friction):
-            return False
-
-        if not np.allclose(self.motor_gear_ratio, other.motor_gear_ratio):
+        if not (
+            self.name == other.name
+            and self.jtype == other.jtype
+            and self.child == other.child
+            and self.parent == other.parent
+            and self.index == other.index
+            and all(
+                np.allclose(getattr(self, attr), getattr(other, attr))
+                for attr in [
+                    "axis",
+                    "pose",
+                    "friction_static",
+                    "friction_viscous",
+                    "position_limit_damper",
+                    "position_limit_spring",
+                    "position_limit",
+                    "initial_position",
+                    "motor_inertia",
+                    "motor_viscous_friction",
+                    "motor_gear_ratio",
+                ]
+            ),
+        ):
             return False
 
         return True
@@ -163,14 +140,14 @@ class JointDescription(JaxsimDataclass):
                 hash(self.child),
                 hash(self.parent),
                 hash(int(self.index)) if self.index is not None else 0,
-                HashedNumpyArray.hash_of_array(np.array(self.friction_static)),
-                HashedNumpyArray.hash_of_array(np.array(self.friction_viscous)),
-                HashedNumpyArray.hash_of_array(np.array(self.position_limit_damper)),
-                HashedNumpyArray.hash_of_array(np.array(self.position_limit_spring)),
-                HashedNumpyArray.hash_of_array(np.array(self.position_limit)),
+                HashedNumpyArray.hash_of_array(self.friction_static),
+                HashedNumpyArray.hash_of_array(self.friction_viscous),
+                HashedNumpyArray.hash_of_array(self.position_limit_damper),
+                HashedNumpyArray.hash_of_array(self.position_limit_spring),
+                HashedNumpyArray.hash_of_array(self.position_limit),
                 HashedNumpyArray.hash_of_array(self.initial_position),
-                HashedNumpyArray.hash_of_array(np.array(self.motor_inertia)),
-                HashedNumpyArray.hash_of_array(np.array(self.motor_viscous_friction)),
-                HashedNumpyArray.hash_of_array(np.array(self.motor_gear_ratio)),
+                HashedNumpyArray.hash_of_array(self.motor_inertia),
+                HashedNumpyArray.hash_of_array(self.motor_viscous_friction),
+                HashedNumpyArray.hash_of_array(self.motor_gear_ratio),
             ),
         )

--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -41,7 +41,7 @@ class JointGenericAxis:
         return hash(self) == hash(other)
 
 
-@jax_dataclasses.pytree_dataclass
+@jax_dataclasses.pytree_dataclass(eq=False, unsafe_hash=False)
 class JointDescription(JaxsimDataclass):
     """
     In-memory description of a robot link.
@@ -97,23 +97,25 @@ class JointDescription(JaxsimDataclass):
 
     def __hash__(self) -> int:
 
+        from jaxsim.utils.wrappers import HashedNumpyArray
+
         return hash(
             (
                 hash(self.name),
-                hash(tuple(self.axis.tolist())),
-                hash(tuple(self.pose.flatten().tolist())),
+                HashedNumpyArray.hash_of_array(self.axis),
+                HashedNumpyArray.hash_of_array(self.pose),
                 hash(int(self.jtype)),
                 hash(self.child),
                 hash(self.parent),
                 hash(int(self.index)) if self.index is not None else 0,
-                hash(float(self.friction_static)),
-                hash(float(self.friction_viscous)),
-                hash(float(self.position_limit_damper)),
-                hash(float(self.position_limit_spring)),
-                hash((float(el) for el in self.position_limit)),
-                hash(tuple(np.atleast_1d(self.initial_position).tolist())),
-                hash(float(self.motor_inertia)),
-                hash(float(self.motor_viscous_friction)),
-                hash(float(self.motor_gear_ratio)),
+                HashedNumpyArray.hash_of_array(np.array(self.friction_static)),
+                HashedNumpyArray.hash_of_array(np.array(self.friction_viscous)),
+                HashedNumpyArray.hash_of_array(np.array(self.position_limit_damper)),
+                HashedNumpyArray.hash_of_array(np.array(self.position_limit_spring)),
+                HashedNumpyArray.hash_of_array(np.array(self.position_limit)),
+                HashedNumpyArray.hash_of_array(self.initial_position),
+                HashedNumpyArray.hash_of_array(np.array(self.motor_inertia)),
+                HashedNumpyArray.hash_of_array(np.array(self.motor_viscous_friction)),
+                HashedNumpyArray.hash_of_array(np.array(self.motor_gear_ratio)),
             ),
         )

--- a/src/jaxsim/parsers/descriptions/link.py
+++ b/src/jaxsim/parsers/descriptions/link.py
@@ -12,7 +12,7 @@ import jaxsim.typing as jtp
 from jaxsim.utils import JaxsimDataclass
 
 
-@jax_dataclasses.pytree_dataclass
+@jax_dataclasses.pytree_dataclass(eq=False, unsafe_hash=False)
 class LinkDescription(JaxsimDataclass):
     """
     In-memory description of a robot link.
@@ -40,13 +40,15 @@ class LinkDescription(JaxsimDataclass):
 
     def __hash__(self) -> int:
 
+        from jaxsim.utils.wrappers import HashedNumpyArray
+
         return hash(
             (
                 hash(self.name),
                 hash(float(self.mass)),
-                hash(tuple(np.atleast_1d(self.inertia).flatten().tolist())),
-                hash(int(self.index)) if self.index is not None else 0,
-                hash(tuple(np.atleast_1d(self.pose).flatten().tolist())),
+                HashedNumpyArray.hash_of_array(self.inertia),
+                hash(int(self.index)) if self.index is not None else self.index,
+                HashedNumpyArray.hash_of_array(self.pose),
                 hash(tuple(self.children)),
                 # Here only using the name to prevent circular recursion:
                 hash(self.parent.name) if self.parent is not None else 0,

--- a/src/jaxsim/parsers/descriptions/link.py
+++ b/src/jaxsim/parsers/descriptions/link.py
@@ -47,7 +47,7 @@ class LinkDescription(JaxsimDataclass):
                 hash(self.name),
                 hash(float(self.mass)),
                 HashedNumpyArray.hash_of_array(self.inertia),
-                hash(int(self.index)) if self.index is not None else self.index,
+                hash(int(self.index)) if self.index is not None else 0,
                 HashedNumpyArray.hash_of_array(self.pose),
                 hash(tuple(self.children)),
                 # Here only using the name to prevent circular recursion:
@@ -60,29 +60,19 @@ class LinkDescription(JaxsimDataclass):
         if not isinstance(other, LinkDescription):
             return False
 
-        if self.name != other.name:
-            return False
-
-        if not np.allclose(self.mass, other.mass):
-            return False
-
-        if not np.allclose(self.inertia, other.inertia):
-            return False
-
-        if self.index != other.index:
-            return False
-
-        if not np.allclose(self.pose, other.pose):
-            return False
-
-        if self.children != other.children:
-            return False
-
-        # Here only using the name to prevent circular recursion
-        if self.parent is not None and self.parent.name != other.parent.name:
-            return False
-
-        if self.parent is None and other.parent is not None:
+        if not (
+            self.name == other.name
+            and np.allclose(self.mass, other.mass)
+            and np.allclose(self.inertia, other.inertia)
+            and self.index == other.index
+            and np.allclose(self.pose, other.pose)
+            and self.children == other.children
+            and (
+                (self.parent is not None and self.parent.name == other.parent.name)
+                if self.parent is not None
+                else other.parent is None
+            ),
+        ):
             return False
 
         return True

--- a/src/jaxsim/parsers/descriptions/link.py
+++ b/src/jaxsim/parsers/descriptions/link.py
@@ -31,7 +31,7 @@ class LinkDescription(JaxsimDataclass):
     mass: float = dataclasses.field(repr=False)
     inertia: jtp.Matrix = dataclasses.field(repr=False)
     index: int | None = None
-    parent: LinkDescription = dataclasses.field(default=None, repr=False)
+    parent: LinkDescription | None = dataclasses.field(default=None, repr=False)
     pose: jtp.Matrix = dataclasses.field(default_factory=lambda: jnp.eye(4), repr=False)
 
     children: Static[tuple[LinkDescription]] = dataclasses.field(
@@ -60,7 +60,32 @@ class LinkDescription(JaxsimDataclass):
         if not isinstance(other, LinkDescription):
             return False
 
-        return hash(self) == hash(other)
+        if self.name != other.name:
+            return False
+
+        if not np.allclose(self.mass, other.mass):
+            return False
+
+        if not np.allclose(self.inertia, other.inertia):
+            return False
+
+        if self.index != other.index:
+            return False
+
+        if not np.allclose(self.pose, other.pose):
+            return False
+
+        if self.children != other.children:
+            return False
+
+        # Here only using the name to prevent circular recursion
+        if self.parent is not None and self.parent.name != other.parent.name:
+            return False
+
+        if self.parent is None and other.parent is not None:
+            return False
+
+        return True
 
     @property
     def name_and_index(self) -> str:

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -12,7 +12,7 @@ from .joint import JointDescription
 from .link import LinkDescription
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, eq=False, unsafe_hash=False)
 class ModelDescription(KinematicGraph):
     """
     Intermediate representation representing the kinematic graph of a robot model.
@@ -28,7 +28,7 @@ class ModelDescription(KinematicGraph):
     fixed_base: bool = True
 
     collision_shapes: tuple[CollisionShape, ...] = dataclasses.field(
-        default_factory=list, repr=False, hash=False
+        default_factory=list, repr=False
     )
 
     @staticmethod

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -249,7 +249,25 @@ class ModelDescription(KinematicGraph):
         if not isinstance(other, ModelDescription):
             return False
 
-        return hash(self) == hash(other)
+        if self.name != other.name:
+            return False
+
+        if self.fixed_base != other.fixed_base:
+            return False
+
+        if self.root != other.root:
+            return False
+
+        if self.joints != other.joints:
+            return False
+
+        if self.frames != other.frames:
+            return False
+
+        if self.root_pose != other.root_pose:
+            return False
+
+        return True
 
     def __hash__(self) -> int:
 

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -249,22 +249,14 @@ class ModelDescription(KinematicGraph):
         if not isinstance(other, ModelDescription):
             return False
 
-        if self.name != other.name:
-            return False
-
-        if self.fixed_base != other.fixed_base:
-            return False
-
-        if self.root != other.root:
-            return False
-
-        if self.joints != other.joints:
-            return False
-
-        if self.frames != other.frames:
-            return False
-
-        if self.root_pose != other.root_pose:
+        if not (
+            self.name == other.name
+            and self.fixed_base == other.fixed_base
+            and self.root == other.root
+            and self.joints == other.joints
+            and self.frames == other.frames
+            and self.root_pose == other.root_pose
+        ):
             return False
 
         return True

--- a/src/jaxsim/rbda/soft_contacts.py
+++ b/src/jaxsim/rbda/soft_contacts.py
@@ -31,11 +31,13 @@ class SoftContactsParams(JaxsimDataclass):
 
     def __hash__(self) -> int:
 
+        from jaxsim.utils.wrappers import HashedNumpyArray
+
         return hash(
             (
-                hash(tuple(jnp.atleast_1d(self.K).flatten().tolist())),
-                hash(tuple(jnp.atleast_1d(self.D).flatten().tolist())),
-                hash(tuple(jnp.atleast_1d(self.mu).flatten().tolist())),
+                HashedNumpyArray.hash_of_array(self.K),
+                HashedNumpyArray.hash_of_array(self.D),
+                HashedNumpyArray.hash_of_array(self.mu),
             )
         )
 

--- a/src/jaxsim/utils/wrappers.py
+++ b/src/jaxsim/utils/wrappers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Generic, TypeVar
+from typing import Callable, Generic, TypeVar
 
 import jax
 import jax_dataclasses
@@ -33,6 +33,33 @@ class HashlessObject(Generic[T]):
     def __eq__(self, other: HashlessObject[T]) -> bool:
 
         if not isinstance(other, HashlessObject) and isinstance(
+            other.get(), type(self.get())
+        ):
+            return False
+
+        return hash(self) == hash(other)
+
+
+@dataclasses.dataclass
+class CustomHashedObject(Generic[T]):
+    """
+    A class that wraps an object and computes its hash with a custom hash function.
+    """
+
+    obj: T
+
+    hash_function: Callable[[T], int] = dataclasses.field(default=lambda obj: hash(obj))
+
+    def get(self: CustomHashedObject[T]) -> T:
+        return self.obj
+
+    def __hash__(self) -> int:
+
+        return self.hash_function(self.obj)
+
+    def __eq__(self, other: CustomHashedObject[T]) -> bool:
+
+        if not isinstance(other, CustomHashedObject) and isinstance(
             other.get(), type(self.get())
         ):
             return False


### PR DESCRIPTION
PR #173 changed how `JaxSimModel` objects are hashed and compared. It was a necessary change since our frame-related data were read from `JaxSimModel.description` that is a `Static` attribute. Before that PR, the hash of the description was explicitly ignored, but that caused problems when different models were passed to the same JIT-compiled function because JAX was not taking into account possible differences in frame data. The outcome was that the frames test was not passing, and the solution was to make `JaxSimModel.description` properly hashable.

These days I played a bit around with different `JaxSimModels` (e.g. parameterized models), and I discovered that if there are two exact instances `model1` and `model2` created from the same URDF (therefore, not having the second model directly copied from the first one), calling a JIT-compiled function on `model` was extremely slow even if JIT-recompilation was not triggered. **The problem is that in these cases, JAX computes the hash of static attributes**, and right now the hash of `ModelDescription` takes hundreds of milliseconds. This is a problem because the processing of static attributes is orders of magnitude longer than the actual compiled computation.

Originally, I though ways to speed up the equality computation of `ModelDescription`, and this PR contains new `__eq__` methods that do not call `__hash__`.

However, then I realized that the best solution is to move also frame-related data in `KinDynParameters`, similarly to what we already do for links, joints, and contacts. In this way, `JaxSimModel.description` can be ignored again, and there's no longer the need to compute its hash. This speeds up significantly calling function that have been JIT-compiled on `model1` using `model2`.

There still is an overhead. I guess that JAX saves the id of `model1` and skips the check on static attributes, check that instead is done for `model2. The following is the runtime on CPU using two full ErgoCub models:

```python
import jaxsim.api as js
import resolve_robotics_uri_py
from jaxsim import VelRepr

urdf_path = resolve_robotics_uri_py.resolve_robotics_uri(
    uri="model://ergoCubSN001/model.urdf"
)

model1 = js.model.JaxSimModel.build_from_model_description(
    model_description=urdf_path,
    is_urdf=True,
)

model2 = js.model.JaxSimModel.build_from_model_description(
    model_description=urdf_path,
    is_urdf=True,
)

data = js.data.random_model_data(model=model1, velocity_representation=VelRepr.Mixed)

# First run for JIT compilation, second one for runtime.
%time _ = js.model.forward_dynamics_aba(model1, data)  # Wall time: 4.31 s
%timeit js.model.forward_dynamics_aba(model1, data)    # 296 µs ± 12.6 µs

# This should not get JIT compiled.
%time _ = js.model.forward_dynamics_aba(model2, data)  # Wall time: 1.56 ms

# This should go almost as fast as on model1.
# The overhead is due to the comparison of static attributes.
%timeit js.model.forward_dynamics_aba(model2, data)  # 883 µs ± 14.2 µs
```

---

Note: this PR goes also in the direction of exploting the on-disk JAX compilation cache supported by the GPU and TPU backends. In the past, I've never managed to make it work with JaxSim, probably due to factors related to this PR. Now things should be better since hash and equality are correct. What I suspect is still missing is wrapping static strings with a custom hash function since by default the hash of a string in Python is not the same among executions.  

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--179.org.readthedocs.build//179/

<!-- readthedocs-preview jaxsim end -->