### PR TITLE
Validate link, frame, and joint indices in our jit-compiled APIs

### DIFF
--- a/src/jaxsim/api/frame.py
+++ b/src/jaxsim/api/frame.py
@@ -4,7 +4,6 @@ from typing import Sequence
 import jax
 import jax.numpy as jnp
 import jaxlie
-import numpy as np
 
 import jaxsim.api as js
 import jaxsim.math
@@ -65,13 +64,12 @@ def name_to_idx(model: js.model.JaxSimModel, *, frame_name: str) -> jtp.Int:
 
     return (
         jnp.array(
-            np.argwhere(
-                np.array(model.kin_dyn_parameters.frame_parameters.name) == frame_name
-            )
+            model.number_of_links()
+            + model.kin_dyn_parameters.frame_parameters.name.index(frame_name)
         )
         .astype(int)
         .squeeze()
-    ) + model.number_of_links()
+    )
 
 
 def idx_to_name(model: js.model.JaxSimModel, *, frame_index: jtp.IntLike) -> str:

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -10,6 +10,7 @@ import numpy as np
 import jaxsim.api as js
 import jaxsim.rbda
 import jaxsim.typing as jtp
+from jaxsim import exceptions
 
 from .common import VelRepr
 
@@ -31,15 +32,16 @@ def name_to_idx(model: js.model.JaxSimModel, *, link_name: str) -> jtp.Int:
         The index of the link.
     """
 
-    if link_name in model.kin_dyn_parameters.link_names:
-        return (
-            jnp.array(
-                np.argwhere(np.array(model.kin_dyn_parameters.link_names) == link_name)
-            )
-            .squeeze()
-            .astype(int)
+    if link_name not in model.link_names():
+        raise ValueError(f"Link '{link_name}' not found in the model.")
+
+    return (
+        jnp.array(
+            np.argwhere(np.array(model.kin_dyn_parameters.link_names) == link_name)
         )
-    return jnp.array(-1).astype(int)
+        .astype(int)
+        .squeeze()
+    )
 
 
 def idx_to_name(model: js.model.JaxSimModel, *, link_index: jtp.IntLike) -> str:
@@ -53,6 +55,14 @@ def idx_to_name(model: js.model.JaxSimModel, *, link_index: jtp.IntLike) -> str:
     Returns:
         The name of the link.
     """
+
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
 
     return model.kin_dyn_parameters.link_names[link_index]
 
@@ -112,6 +122,14 @@ def mass(model: js.model.JaxSimModel, *, link_index: jtp.IntLike) -> jtp.Float:
         The mass of the link.
     """
 
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
+
     return model.kin_dyn_parameters.link_parameters.mass[link_index].astype(float)
 
 
@@ -130,6 +148,14 @@ def spatial_inertia(
         The 6×6 matrix representing the spatial inertia of the link expressed in
         the link frame (body-fixed representation).
     """
+
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
 
     link_parameters = jax.tree_util.tree_map(
         lambda l: l[link_index], model.kin_dyn_parameters.link_parameters
@@ -156,6 +182,14 @@ def transform(
     Returns:
         The 4x4 matrix representing the transform.
     """
+
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
 
     return js.model.forward_kinematics(model=model, data=data)[link_index]
 
@@ -229,6 +263,14 @@ def jacobian(
         The input representation of the free-floating jacobian is the active
         velocity representation.
     """
+
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
 
     output_vel_repr = (
         output_vel_repr if output_vel_repr is not None else data.velocity_representation
@@ -318,6 +360,14 @@ def velocity(
         The 6D velocity of the link in the specified velocity representation.
     """
 
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
+
     output_vel_repr = (
         output_vel_repr if output_vel_repr is not None else data.velocity_representation
     )
@@ -363,6 +413,14 @@ def jacobian_derivative(
         The input representation of the free-floating jacobian derivative is the active
         velocity representation.
     """
+
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
 
     output_vel_repr = (
         output_vel_repr if output_vel_repr is not None else data.velocity_representation
@@ -537,6 +595,14 @@ def bias_acceleration(
     Returns:
         The 6D bias acceleration of the link.
     """
+
+    exceptions.raise_value_error_if(
+        condition=jnp.array(
+            [link_index < 0, link_index >= model.number_of_links()]
+        ).any(),
+        msg="Invalid link index '{idx}'",
+        idx=link_index,
+    )
 
     # Compute the bias acceleration of all links in the active representation.
     O_v̇_WL = js.model.link_bias_accelerations(model=model, data=data)[link_index]

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -5,7 +5,6 @@ import jax
 import jax.numpy as jnp
 import jax.scipy.linalg
 import jaxlie
-import numpy as np
 
 import jaxsim.api as js
 import jaxsim.rbda
@@ -36,9 +35,7 @@ def name_to_idx(model: js.model.JaxSimModel, *, link_name: str) -> jtp.Int:
         raise ValueError(f"Link '{link_name}' not found in the model.")
 
     return (
-        jnp.array(
-            np.argwhere(np.array(model.kin_dyn_parameters.link_names) == link_name)
-        )
+        jnp.array(model.kin_dyn_parameters.link_names.index(link_name))
         .astype(int)
         .squeeze()
     )

--- a/tests/test_api_joint.py
+++ b/tests/test_api_joint.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import jaxlib.xla_extension
 import pytest
 
 import jaxsim.api as js
@@ -33,3 +34,12 @@ def test_joint_index(
         )
         == model.joint_names()
     )
+
+    with pytest.raises(ValueError):
+        _ = js.joint.name_to_idx(model=model, joint_name="non_existent_joint")
+
+    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+        _ = js.joint.idx_to_name(model=model, joint_index=-1)
+
+    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+        _ = js.joint.idx_to_name(model=model, joint_index=model.number_of_joints())

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import jaxlib.xla_extension
 import pytest
 
 import jaxsim.api as js
@@ -38,6 +39,15 @@ def test_link_index(
         )
         == model.link_names()
     )
+
+    with pytest.raises(ValueError):
+        _ = js.link.name_to_idx(model=model, link_name="non_existent_link")
+
+    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+        _ = js.link.idx_to_name(model=model, link_index=-1)
+
+    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+        _ = js.link.idx_to_name(model=model, link_index=model.number_of_links())
 
 
 def test_link_inertial_properties(


### PR DESCRIPTION
Implements the jit-compatible exceptions of #181 to stop the execution of jit-compiled methods when the integer indices of links, frames, and joints are not valid.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--182.org.readthedocs.build//182/

<!-- readthedocs-preview jaxsim end -->