### PR TITLE
Always forward to the integrator the `model` and `data` passed to `jaxsim.api.model.step`

### DIFF
--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -422,7 +422,9 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
 
         # Update the FSAL property for the next iteration.
         if self.has_fsal:
-            self.params["dxdt0"] = jax.tree_map(lambda l: l[self.index_of_fsal], K)
+            self.params["dxdt0"] = jax.tree_util.tree_map(
+                lambda l: l[self.index_of_fsal], K
+            )
 
         # Compute the output state.
         # Note that z contains as many new states as the rows of `b.T`.


### PR DESCRIPTION
This modification is necessary to re-use the same jit-compiled `jaxsim.api.model.step` function and the same integrator (closed over an initial model) on a modified model having the same structure of the initial model.

It enables running simulations with parametric models having constant pytree structure without incurring in jit recompilations.

For more details, refer to the following logic:

- [`jaxsim.api.model.step`](https://github.com/ami-iit/jaxsim/blob/5e4adaa269eff4f28d4820f573de088765d55ae2/src/jaxsim/api/model.py#L1812-L1870).
- [`jaxsim.integrators.common.Integrator.step`](https://github.com/ami-iit/jaxsim/blob/5e4adaa269eff4f28d4820f573de088765d55ae2/src/jaxsim/integrators/common.py#L85-L116) calling [`jaxsim.integrators.common.Integrator.__call__`](https://github.com/ami-iit/jaxsim/blob/5e4adaa269eff4f28d4820f573de088765d55ae2/src/jaxsim/integrators/common.py#L118-L120). For example, our fixed-step integrators pass the `kwargs` to the system dynamics [here](https://github.com/ami-iit/jaxsim/blob/5e4adaa269eff4f28d4820f573de088765d55ae2/src/jaxsim/integrators/common.py#L364-L365).
- The system dynamic function considered by the integrator is created in [`jaxsim.api.ode.wrap_system_dynamics_for_integration`](https://github.com/ami-iit/jaxsim/blob/5e4adaa269eff4f28d4820f573de088765d55ae2/src/jaxsim/api/ode.py#L56-L73). By default the integrator operating on this dynamics considers the `model` and `data` (mainly, the parameters stored in data that are not `data.state`) that are passed during the initialization of the integrator. This PR always overrides `model` and `data` with those passed to `jaxsim.api.model.step`.

Note: furthermore, if, for any reason, the user wants to pass to the integrator a different `model` or `data`, they can do it as follows:

```python
_ = js.model.step(
    model=model,
    data=data,
    dt=dt,
    integrator=integrator,
    integrator_state=integrator_state,
    # Override model and data:
    integrator_kwargs=dict(model=other_model, data=other_data),
)
```

Related to #101 and #120.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--183.org.readthedocs.build//183/

<!-- readthedocs-preview jaxsim end -->