### PR TITLE
Speed up computation of contact jacobians

### DIFF
--- a/tests/test_api_contact.py
+++ b/tests/test_api_contact.py
@@ -1,0 +1,58 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import jaxsim.api as js
+from jaxsim import VelRepr
+
+
+def test_contact_kinematics(
+    jaxsim_models_types: js.model.JaxSimModel,
+    velocity_representation: VelRepr,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_models_types
+
+    _, subkey = jax.random.split(prng_key, num=2)
+    data = js.data.random_model_data(
+        model=model,
+        key=subkey,
+        velocity_representation=velocity_representation,
+    )
+
+    # =====
+    # Tests
+    # =====
+
+    # Compute the pose of the implicit contact frame associated to the collidable points
+    # and the transforms of all links.
+    W_H_C = js.contact.transforms(model=model, data=data)
+    W_H_L = js.model.forward_kinematics(model=model, data=data)
+
+    # Check that the orientation of the implicit contact frame matches with the
+    # orientation of the link to which the contact point is attached.
+    for contact_idx, index_of_parent_link in enumerate(
+        model.kin_dyn_parameters.contact_parameters.body
+    ):
+        assert W_H_C[contact_idx, 0:3, 0:3] == pytest.approx(
+            W_H_L[index_of_parent_link][0:3, 0:3]
+        )
+
+    # Check that the origin of the implicit contact frame is located over the
+    # collidable point.
+    W_p_C = js.contact.collidable_point_positions(model=model, data=data)
+    assert W_p_C == pytest.approx(W_H_C[:, 0:3, 3])
+
+    # Compute the velocity of the collidable point.
+    # This quantity always matches with the linear component of the mixed 6D velocity
+    # of the implicit frame associated to the collidable point.
+    W_ṗ_C = js.contact.collidable_point_velocities(model=model, data=data)
+
+    # Compute the velocity of the collidable point using the contact Jacobian.
+    ν = data.generalized_velocity()
+    CW_J_WC = js.contact.jacobian(model=model, data=data, output_vel_repr=VelRepr.Mixed)
+    CW_vl_WC = jnp.einsum("c6g,g->c6", CW_J_WC, ν)[:, 0:3]
+
+    # Compare the two velocities.
+    assert W_ṗ_C == pytest.approx(CW_vl_WC)


### PR DESCRIPTION
The computation of the Jacobians corresponding to the implicit frames associated to the collidable points was introduced in #163. At that time, there was a difference in the body frame considered in the Jacobians computed with `jaxsim.api.model.generalized_free_floating_jacobian`, that was fixed in #167.

For this reason, originally the code to compute the contact Jacobian was calling `jaxsim.link.jacobian` inside a `jax.vmap` transformation. This PR modifies this logic to compute the Jacobians of all links only once, and then with `jax.vmap` extract the one corresponding to the link to which the collidable point is attached.

On the ErgoCub model, that has 32 collidable points, the speedup is significant:

```python
# Before
8.46 ms ± 574 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# After
262 µs ± 6.87 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--188.org.readthedocs.build//188/

<!-- readthedocs-preview jaxsim end -->