### PR TITLE
Improve support of visualizing heightmaps/hfield in the Mujoco passive viewer

### DIFF
--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -160,6 +160,7 @@ class RodModelToMjcf:
         considered_joints: list[str] | None = None,
         plane_normal: tuple[float, float, float] = (0, 0, 1),
         heightmap: bool | None = None,
+        heightmap_samples_xy: tuple[int, int] = (101, 101),
         cameras: list[dict[str, str]] | dict[str, str] | None = None,
     ) -> tuple[str, dict[str, Any]]:
         """
@@ -170,10 +171,11 @@ class RodModelToMjcf:
             considered_joints: The list of joint names to consider in the conversion.
             plane_normal: The normal vector of the plane.
             heightmap: Whether to generate a heightmap.
+            heightmap_samples_xy: The number of points in the heightmap grid.
             cameras: The list of cameras to add to the scene.
 
         Returns:
-            tuple: A tuple containing the MJCF string and the assets dictionary.
+            tuple: A tuple containing the MJCF string and the dictionary of assets.
         """
 
         # -------------------------------------
@@ -404,9 +406,11 @@ class RodModelToMjcf:
                 asset_element,
                 "hfield",
                 name="terrain",
-                nrow="100",
-                ncol="100",
-                size="5 5 1 1",
+                nrow=f"{int(heightmap_samples_xy[0])}",
+                ncol=f"{int(heightmap_samples_xy[1])}",
+                # The following 'size' is a placeholder, it is updated dynamically
+                # when a hfield/heightmap is stored into MjData.
+                size="1 1 1 1",
             )
             if heightmap
             else None


### PR DESCRIPTION
I couldn't make the previous logic work correctly. This PR makes sure of the following:

- The converted `MjModel` is initialized with a hfield grid whose number of rows and columns can be customized.
- The area over which the heightmap is sampled can now be defined.
- The MJCF model is dynamically updated with the wideness and elevation of the sampled heightmap data.

Here below the result.

Note that if the heightmap would be rendered incorrectly, the sphere would not lay over the surface as it would mean that the simulated data and the visualized terrain differ. The image shows that the two match as expected.

![image](https://github.com/ami-iit/jaxsim/assets/469199/095fef4b-69ac-400f-9ffd-b2b1c0e06b84)

<details>
<summary>MWE</summary>

```python
import time

import jax.numpy as jnp
import jax_dataclasses
import jaxsim
import jaxsim.api as js
import numpy as np
import rod.builder.primitives
from jaxsim import typing as jtp


# Define a custom terrain:
# https://it.mathworks.com/help/matlab/ref/peaks.html
@jax_dataclasses.pytree_dataclass
class PeaksTerrain(jaxsim.terrain.Terrain):

    def height(self, x: jtp.FloatLike, y: jtp.FloatLike) -> jtp.Float:

        z = (
            3 * (1 - x) ** 2 * jnp.exp(-(x**2) - (y + 1) ** 2)
            - 10 * (x / 5 - x**3 - y**5) * jnp.exp(-(x**2) - y**2)
            - 1 / 3 * jnp.exp(-((x + 1) ** 2) - y**2)
        )

        return jnp.array(0.25 * z, dtype=float)


# Build the ROD model of a sphere.
sphere = (
    rod.builder.primitives.SphereBuilder(name="sphere", mass=1.0, radius=0.1)
    .build_model()
    .add_link(name="link")
    .add_inertial()
    .add_visual()
    .add_collision()
    .build()
)


# Build the JaxSim model.
model = js.model.JaxSimModel.build_from_model_description(
    model_description=sphere,
    terrain=PeaksTerrain(),
)

# Initialize the sphere with the origin be located over the terrain at a
# given (x, y) coordinates.
x, y = -0.42, -0.62
data = js.data.JaxSimModelData.build(
    model=model,
    base_position=jnp.array([x, y, model.terrain.height(x=x, y=y)]),
)


# ================
# 3D visualization
# ================

import jaxsim.mujoco

mjcf_string, assets = jaxsim.mujoco.RodModelToMjcf().convert(
    rod_model=model.built_from,
    heightmap=True,
    heightmap_samples_xy=(256, 256),
)

mj_model_helper = jaxsim.mujoco.MujocoModelHelper.build_from_xml(
    mjcf_description=mjcf_string,
    assets=assets,
    heightmap=lambda x, y: model.terrain.height(x=x, y=y).tolist(),
    heightmap_radius_xy=(5.0, 5.0),
)

viz = jaxsim.mujoco.MujocoVisualizer(
    model=mj_model_helper.model, data=mj_model_helper.data
)


with viz.open() as viewer:

    with viewer.lock():
        mj_model_helper.set_base_position(position=np.array(data.base_position()))
        mj_model_helper.set_base_orientation(
            orientation=np.array(data.base_orientation(dcm=False))
        )

    viz.sync(viewer=viewer)

    while viewer.is_running():
        time.sleep(0.500)
```

</details>

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--202.org.readthedocs.build//202/

<!-- readthedocs-preview jaxsim end -->