### PR TITLE
Use explicit integration of quaternions also in schemes on SO(3)

### DIFF
--- a/src/jaxsim/rbda/utils.py
+++ b/src/jaxsim/rbda/utils.py
@@ -2,6 +2,7 @@ import jax.numpy as jnp
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
+from jaxsim import exceptions
 from jaxsim.math import StandardGravity
 
 
@@ -130,6 +131,13 @@ def process_inputs(
 
     if W_Q_B.shape != (4,):
         raise ValueError(W_Q_B.shape, (4,))
+
+    # Check that the quaternion is unary since our RBDAs make this assumption in order
+    # to prevent introducing additional normalizations that would affect AD.
+    exceptions.raise_value_error_if(
+        condition=jnp.logical_not(jnp.allclose(W_Q_B.dot(W_Q_B), 1.0)),
+        msg="A RBDA received a quaternion that is not normalized.",
+    )
 
     # Pack the 6D base velocity and acceleration.
     W_v_WB = jnp.hstack([W_vl_WB, W_ω_WB])

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -93,7 +93,7 @@ def test_ad_aba(
     aba = lambda W_p_B, W_Q_B, s, W_v_WB, ṡ, τ, W_f_L, g: jaxsim.rbda.aba(
         model=model,
         base_position=W_p_B,
-        base_quaternion=W_Q_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
         joint_positions=s,
         base_linear_velocity=W_v_WB[0:3],
         base_angular_velocity=W_v_WB[3:6],
@@ -150,7 +150,7 @@ def test_ad_rnea(
     rnea = lambda W_p_B, W_Q_B, s, W_v_WB, ṡ, W_v̇_WB, s̈, W_f_L, g: jaxsim.rbda.rnea(
         model=model,
         base_position=W_p_B,
-        base_quaternion=W_Q_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
         joint_positions=s,
         base_linear_velocity=W_v_WB[0:3],
         base_angular_velocity=W_v_WB[3:6],
@@ -229,7 +229,7 @@ def test_ad_fk(
     fk = lambda W_p_B, W_Q_B, s: jaxsim.rbda.forward_kinematics_model(
         model=model,
         base_position=W_p_B,
-        base_quaternion=W_Q_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
         joint_positions=s,
     )
 


### PR DESCRIPTION
After the fix performed in https://github.com/ami-iit/jaxsim/pull/192, I had a deeper look to the $\text{SO}(3)$ integrators and how RBDAs and user code interface with the simulated data. This PR:

- Raises an exception if:
  - Any RBDA receives a quaternion that is not unary.
  - Any $\text{SO}(3)$ integrator receives at $t_0$ a quaternion that is not unary.
- Removes the custom implementation of the RK stage of $\text{SO}(3)$ integrators. This is no longer necessary since the quaternion is always normalized before being passed to RBDAs (and the raise, otherwise).
- Removing these normalizations should be safe also on the user side since they never should never directly read the buffer `JaxSimModelData.state.physics_state.base_quaternion` (that may be not unary on schemes not on $\text{SO}(3)$ ).

Beyond enhancin the robustness and fixing the explicitness of the integrators, another aim of this PR is to minimize the division by the norm, since it may affect AD performance. It should now be safe enough to remove the normalizations used here and there since all RBDA receive a quaternion from `JaxSimModelData.base_orientation()`, that already normalizes the quaternion if needed.

cc @traversaro @xela-95 @DanielePucci @flferretti 

---

Note that I found this problem by simulating one of the upcoming examples, in particular one simulating the [tennis racket theorem](https://www.wikiwand.com/en/Tennis_racket_theorem) (Dzhanibekov effect). In such system, one of the axis should always be constant. With the removed semi-implicit integration of the quaternion on the manifold, I was observing a kind of precession of such axis. This PR fixes the wrong outcome.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--205.org.readthedocs.build//205/

<!-- readthedocs-preview jaxsim end -->