### PR TITLE
Add the possibility to set forces to frames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,6 @@ ignore = [
     "E501", # Line too long
     "E731", # Do not assign a `lambda` expression, use a `def`
     "E741", # Ambiguous variable name
-    "F841", # Local variable is assigned to but never used
     "I001", # Import block is unsorted or unformatted
     "RUF003", # Ambigous unicode character in comment
 ]

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -137,9 +137,9 @@ def centroidal_momentum_jacobian(
 
     match data.velocity_representation:
         case VelRepr.Inertial | VelRepr.Mixed:
-            W_H_G = W_H_GW = jnp.eye(4).at[0:3, 3].set(W_p_CoM)
+            W_H_G = W_H_GW = jnp.eye(4).at[0:3, 3].set(W_p_CoM)  # noqa: F841
         case VelRepr.Body:
-            W_H_G = W_H_GB = W_H_B.at[0:3, 3].set(W_p_CoM)
+            W_H_G = W_H_GB = W_H_B.at[0:3, 3].set(W_p_CoM)  # noqa: F841
         case _:
             raise ValueError(data.velocity_representation)
 
@@ -172,9 +172,9 @@ def locked_centroidal_spatial_inertia(
 
     match data.velocity_representation:
         case VelRepr.Inertial | VelRepr.Mixed:
-            W_H_G = W_H_GW = jnp.eye(4).at[0:3, 3].set(W_p_CoM)
+            W_H_G = W_H_GW = jnp.eye(4).at[0:3, 3].set(W_p_CoM)  # noqa: F841
         case VelRepr.Body:
-            W_H_G = W_H_GB = W_H_B.at[0:3, 3].set(W_p_CoM)
+            W_H_G = W_H_GB = W_H_B.at[0:3, 3].set(W_p_CoM)  # noqa: F841
         case _:
             raise ValueError(data.velocity_representation)
 
@@ -290,14 +290,14 @@ def bias_acceleration(
 
         case VelRepr.Inertial:
 
-            C_v̇_WL = W_v̇_bias_WL = v̇_bias_WL
-            C_v_WC = W_v_WW = jnp.zeros(6)
+            C_v̇_WL = W_v̇_bias_WL = v̇_bias_WL  # noqa: F841
+            C_v_WC = W_v_WW = jnp.zeros(6)  # noqa: F841
 
-            L_H_C = L_H_W = jax.vmap(
+            L_H_C = L_H_W = jax.vmap(  # noqa: F841
                 lambda W_H_L: jaxsim.math.Transform.inverse(W_H_L)
             )(W_H_L)
 
-            L_v_LC = L_v_LW = jax.vmap(
+            L_v_LC = L_v_LW = jax.vmap(  # noqa: F841
                 lambda i: -js.link.velocity(
                     model=model, data=data, link_index=i, output_vel_repr=VelRepr.Body
                 )
@@ -314,9 +314,9 @@ def bias_acceleration(
 
         case VelRepr.Mixed:
 
-            C_v̇_WL = LW_v̇_bias_WL = v̇_bias_WL
+            C_v̇_WL = LW_v̇_bias_WL = v̇_bias_WL  # noqa: F841
 
-            C_v_WC = LW_v_W_LW = jax.vmap(
+            C_v_WC = LW_v_W_LW = jax.vmap(  # noqa: F841
                 lambda i: js.link.velocity(
                     model=model, data=data, link_index=i, output_vel_repr=VelRepr.Mixed
                 )
@@ -324,13 +324,13 @@ def bias_acceleration(
                 .set(jnp.zeros(3))
             )(jnp.arange(model.number_of_links()))
 
-            L_H_C = L_H_LW = jax.vmap(
+            L_H_C = L_H_LW = jax.vmap(  # noqa: F841
                 lambda W_H_L: jaxsim.math.Transform.inverse(
                     W_H_L.at[0:3, 3].set(jnp.zeros(3))
                 )
             )(W_H_L)
 
-            L_v_LC = L_v_L_LW = jax.vmap(
+            L_v_LC = L_v_L_LW = jax.vmap(  # noqa: F841
                 lambda i: -js.link.velocity(
                     model=model, data=data, link_index=i, output_vel_repr=VelRepr.Body
                 )

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -537,8 +537,10 @@ def jacobian_derivative(
 
         match output_vel_repr:
             case VelRepr.Inertial:
-                O_X_W = W_X_W = Adjoint.from_transform(transform=jnp.eye(4))
-                O_Ẋ_W = W_Ẋ_W = jnp.zeros((6, 6))
+                O_X_W = W_X_W = Adjoint.from_transform(  # noqa: F841
+                    transform=jnp.eye(4)
+                )
+                O_Ẋ_W = W_Ẋ_W = jnp.zeros((6, 6))  # noqa: F841
 
             case VelRepr.Body:
                 L_H_C = Transform.from_rotation_and_translation(translation=L_p_C)
@@ -548,7 +550,7 @@ def jacobian_derivative(
                     W_nu = data.generalized_velocity()
                 W_v_WC = W_J_WL_W[parent_link_idx] @ W_nu
                 W_vx_WC = Cross.vx(W_v_WC)
-                O_Ẋ_W = C_Ẋ_W = -C_X_W @ W_vx_WC
+                O_Ẋ_W = C_Ẋ_W = -C_X_W @ W_vx_WC  # noqa: F841
 
             case VelRepr.Mixed:
                 L_H_C = Transform.from_rotation_and_translation(translation=L_p_C)
@@ -560,7 +562,7 @@ def jacobian_derivative(
                     CW_v_WC = CW_J_WC_BW @ data.generalized_velocity()
                 W_v_W_CW = jnp.zeros(6).at[0:3].set(CW_v_WC[0:3])
                 W_vx_W_CW = Cross.vx(W_v_W_CW)
-                O_Ẋ_W = CW_Ẋ_W = -CW_X_W @ W_vx_W_CW
+                O_Ẋ_W = CW_Ẋ_W = -CW_X_W @ W_vx_W_CW  # noqa: F841
 
             case _:
                 raise ValueError(output_vel_repr)

--- a/src/jaxsim/api/frame.py
+++ b/src/jaxsim/api/frame.py
@@ -384,7 +384,7 @@ def jacobian_derivative(
                 W_nu = data.generalized_velocity()
             W_v_WF = W_J_WL_W @ W_nu
             W_vx_WF = Cross.vx(W_v_WF)
-            O_Ẋ_W = F_Ẋ_W = -F_X_W @ W_vx_WF
+            O_Ẋ_W = F_Ẋ_W = -F_X_W @ W_vx_WF  # noqa: F841
 
         case VelRepr.Mixed:
             W_H_F = transform(model=model, data=data, frame_index=frame_index)
@@ -401,7 +401,7 @@ def jacobian_derivative(
                 FW_v_WF = FW_J_WF_FW @ data.generalized_velocity()
             W_v_W_FW = jnp.zeros(6).at[0:3].set(FW_v_WF[0:3])
             W_vx_W_FW = Cross.vx(W_v_W_FW)
-            O_Ẋ_W = FW_Ẋ_W = -FW_X_W @ W_vx_W_FW
+            O_Ẋ_W = FW_Ẋ_W = -FW_X_W @ W_vx_W_FW  # noqa: F841
 
         case _:
             raise ValueError(output_vel_repr)

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -288,7 +288,7 @@ def jacobian(
         case VelRepr.Inertial:
             W_H_B = data.base_transform()
             B_X_W = Adjoint.from_transform(transform=W_H_B, inverse=True)
-            B_J_WL_I = B_J_WL_W = B_J_WL_B @ jax.scipy.linalg.block_diag(
+            B_J_WL_I = B_J_WL_W = B_J_WL_B @ jax.scipy.linalg.block_diag(  # noqa: F841
                 B_X_W, jnp.eye(model.dofs())
             )
 
@@ -299,7 +299,7 @@ def jacobian(
             W_R_B = data.base_orientation(dcm=True)
             BW_H_B = jnp.eye(4).at[0:3, 0:3].set(W_R_B)
             B_X_BW = Adjoint.from_transform(transform=BW_H_B, inverse=True)
-            B_J_WL_I = B_J_WL_BW = B_J_WL_B @ jax.scipy.linalg.block_diag(
+            B_J_WL_I = B_J_WL_BW = B_J_WL_B @ jax.scipy.linalg.block_diag(  # noqa: F841
                 B_X_BW, jnp.eye(model.dofs())
             )
 
@@ -313,7 +313,7 @@ def jacobian(
         case VelRepr.Inertial:
             W_H_B = data.base_transform()
             W_X_B = Adjoint.from_transform(transform=W_H_B)
-            O_J_WL_I = W_J_WL_I = W_X_B @ B_J_WL_I
+            O_J_WL_I = W_J_WL_I = W_X_B @ B_J_WL_I  # noqa: F841
 
         case VelRepr.Body:
             L_X_B = Adjoint.from_transform(transform=B_H_L, inverse=True)
@@ -505,7 +505,7 @@ def jacobian_derivative(
             with data.switch_velocity_representation(VelRepr.Body):
                 B_v_WB = data.base_velocity()
 
-            O_Ẋ_B = W_Ẋ_B = W_X_B @ jaxsim.math.Cross.vx(B_v_WB)
+            O_Ẋ_B = W_Ẋ_B = W_X_B @ jaxsim.math.Cross.vx(B_v_WB)  # noqa: F841
 
         case VelRepr.Body:
 
@@ -519,7 +519,9 @@ def jacobian_derivative(
                 B_v_WB = data.base_velocity()
                 L_v_WL = js.link.velocity(model=model, data=data, link_index=link_index)
 
-            O_Ẋ_B = L_Ẋ_B = -L_X_B @ jaxsim.math.Cross.vx(B_X_L @ L_v_WL - B_v_WB)
+            O_Ẋ_B = L_Ẋ_B = -L_X_B @ jaxsim.math.Cross.vx(  # noqa: F841
+                B_X_L @ L_v_WL - B_v_WB
+            )
 
         case VelRepr.Mixed:
 
@@ -544,8 +546,9 @@ def jacobian_derivative(
             LW_v_LW_L = LW_v_WL - LW_v_W_LW
             LW_v_B_LW = LW_v_WL - LW_X_B @ B_v_WB - LW_v_LW_L
 
-            O_Ẋ_B = LW_Ẋ_B = -LW_X_B @ jaxsim.math.Cross.vx(B_X_LW @ LW_v_B_LW)
-
+            O_Ẋ_B = LW_Ẋ_B = -LW_X_B @ jaxsim.math.Cross.vx(  # noqa: F841
+                B_X_LW @ LW_v_B_LW
+            )
         case _:
             raise ValueError(output_vel_repr)
 

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -495,8 +495,9 @@ def generalized_free_floating_jacobian(
             W_H_B = data.base_transform()
             B_X_W = Adjoint.from_transform(transform=W_H_B, inverse=True)
 
-            B_J_full_WX_I = B_J_full_WX_W = B_J_full_WX_B @ jax.scipy.linalg.block_diag(
-                B_X_W, jnp.eye(model.dofs())
+            B_J_full_WX_I = B_J_full_WX_W = (  # noqa: F841
+                B_J_full_WX_B
+                @ jax.scipy.linalg.block_diag(B_X_W, jnp.eye(model.dofs()))
             )
 
         case VelRepr.Body:
@@ -509,7 +510,7 @@ def generalized_free_floating_jacobian(
             BW_H_B = jnp.eye(4).at[0:3, 0:3].set(W_R_B)
             B_X_BW = Adjoint.from_transform(transform=BW_H_B, inverse=True)
 
-            B_J_full_WX_I = B_J_full_WX_BW = (
+            B_J_full_WX_I = B_J_full_WX_BW = (  # noqa: F841
                 B_J_full_WX_B
                 @ jax.scipy.linalg.block_diag(B_X_BW, jnp.eye(model.dofs()))
             )
@@ -542,11 +543,13 @@ def generalized_free_floating_jacobian(
             W_H_B = data.base_transform()
             W_X_B = jaxsim.math.Adjoint.from_transform(W_H_B)
 
-            O_J_WL_I = W_J_WL_I = jax.vmap(lambda B_J_WL_I: W_X_B @ B_J_WL_I)(B_J_WL_I)
+            O_J_WL_I = W_J_WL_I = jax.vmap(  # noqa: F841
+                lambda B_J_WL_I: W_X_B @ B_J_WL_I
+            )(B_J_WL_I)
 
         case VelRepr.Body:
 
-            O_J_WL_I = L_J_WL_I = jax.vmap(
+            O_J_WL_I = L_J_WL_I = jax.vmap(  # noqa: F841
                 lambda B_H_L, B_J_WL_I: jaxsim.math.Adjoint.from_transform(
                     B_H_L, inverse=True
                 )
@@ -565,7 +568,7 @@ def generalized_free_floating_jacobian(
                 lambda LW_H_L, B_H_L: LW_H_L @ jaxsim.math.Transform.inverse(B_H_L)
             )(LW_H_L, B_H_L)
 
-            O_J_WL_I = LW_J_WL_I = jax.vmap(
+            O_J_WL_I = LW_J_WL_I = jax.vmap(  # noqa: F841
                 lambda LW_H_B, B_J_WL_I: jaxsim.math.Adjoint.from_transform(LW_H_B)
                 @ B_J_WL_I
             )(LW_H_B, B_J_WL_I)
@@ -756,8 +759,8 @@ def forward_dynamics_aba(
     match data.velocity_representation:
         case VelRepr.Inertial:
             # In this case C=W
-            W_H_C = W_H_W = jnp.eye(4)
-            W_v_WC = W_v_WW = jnp.zeros(6)
+            W_H_C = W_H_W = jnp.eye(4)  # noqa: F841
+            W_v_WC = W_v_WW = jnp.zeros(6)  # noqa: F841
 
         case VelRepr.Body:
             # In this case C=B
@@ -767,9 +770,9 @@ def forward_dynamics_aba(
         case VelRepr.Mixed:
             # In this case C=B[W]
             W_H_B = data.base_transform()
-            W_H_C = W_H_BW = W_H_B.at[0:3, 0:3].set(jnp.eye(3))
+            W_H_C = W_H_BW = W_H_B.at[0:3, 0:3].set(jnp.eye(3))  # noqa: F841
             W_ṗ_B = data.base_velocity()[0:3]
-            W_v_WC = W_v_W_BW = jnp.zeros(6).at[0:3].set(W_ṗ_B)
+            W_v_WC = W_v_W_BW = jnp.zeros(6).at[0:3].set(W_ṗ_B)  # noqa: F841
 
         case _:
             raise ValueError(data.velocity_representation)
@@ -1124,8 +1127,8 @@ def inverse_dynamics(
 
     match data.velocity_representation:
         case VelRepr.Inertial:
-            W_H_C = W_H_W = jnp.eye(4)
-            W_v_WC = W_v_WW = jnp.zeros(6)
+            W_H_C = W_H_W = jnp.eye(4)  # noqa: F841
+            W_v_WC = W_v_WW = jnp.zeros(6)  # noqa: F841
 
         case VelRepr.Body:
             W_H_C = W_H_B = data.base_transform()
@@ -1134,9 +1137,9 @@ def inverse_dynamics(
 
         case VelRepr.Mixed:
             W_H_B = data.base_transform()
-            W_H_C = W_H_BW = W_H_B.at[0:3, 0:3].set(jnp.eye(3))
+            W_H_C = W_H_BW = W_H_B.at[0:3, 0:3].set(jnp.eye(3))  # noqa: F841
             W_ṗ_B = data.base_velocity()[0:3]
-            W_v_WC = W_v_W_BW = jnp.zeros(6).at[0:3].set(W_ṗ_B)
+            W_v_WC = W_v_W_BW = jnp.zeros(6).at[0:3].set(W_ṗ_B)  # noqa: F841
 
         case _:
             raise ValueError(data.velocity_representation)
@@ -1571,15 +1574,15 @@ def link_bias_accelerations(
     # a simple C_X_W 6D transform.
     match data.velocity_representation:
         case VelRepr.Inertial:
-            W_H_C = W_H_W = jnp.eye(4)
-            W_v_WC = W_v_WW = jnp.zeros(6)
+            W_H_C = W_H_W = jnp.eye(4)  # noqa: F841
+            W_v_WC = W_v_WW = jnp.zeros(6)  # noqa: F841
             with data.switch_velocity_representation(VelRepr.Inertial):
                 C_v_WB = W_v_WB = data.base_velocity()
 
         case VelRepr.Body:
             W_H_C = W_H_B
             with data.switch_velocity_representation(VelRepr.Inertial):
-                W_v_WC = W_v_WB = data.base_velocity()
+                W_v_WC = W_v_WB = data.base_velocity()  # noqa: F841
             with data.switch_velocity_representation(VelRepr.Body):
                 C_v_WB = B_v_WB = data.base_velocity()
 
@@ -1590,9 +1593,9 @@ def link_bias_accelerations(
                 W_ṗ_B = data.base_velocity()[0:3]
                 BW_v_W_BW = jnp.zeros(6).at[0:3].set(W_ṗ_B)
                 W_X_BW = jaxsim.math.Adjoint.from_transform(transform=W_H_BW)
-                W_v_WC = W_v_W_BW = W_X_BW @ BW_v_W_BW
+                W_v_WC = W_v_W_BW = W_X_BW @ BW_v_W_BW  # noqa: F841
             with data.switch_velocity_representation(VelRepr.Mixed):
-                C_v_WB = BW_v_WB = data.base_velocity()
+                C_v_WB = BW_v_WB = data.base_velocity()  # noqa: F841
 
         case _:
             raise ValueError(data.velocity_representation)
@@ -1700,8 +1703,12 @@ def link_bias_accelerations(
 
     match data.velocity_representation:
         case VelRepr.Body:
-            C_H_L = L_H_L = jnp.stack([jnp.eye(4)] * model.number_of_links())
-            L_v_CL = L_v_LL = jnp.zeros(shape=(model.number_of_links(), 6))
+            C_H_L = L_H_L = jnp.stack(  # noqa: F841
+                [jnp.eye(4)] * model.number_of_links()
+            )
+            L_v_CL = L_v_LL = jnp.zeros(  # noqa: F841
+                shape=(model.number_of_links(), 6)
+            )
 
         case VelRepr.Inertial:
             C_H_L = W_H_L = js.model.forward_kinematics(model=model, data=data)
@@ -1711,7 +1718,9 @@ def link_bias_accelerations(
             W_H_L = js.model.forward_kinematics(model=model, data=data)
             LW_H_L = jax.vmap(lambda W_H_L: W_H_L.at[0:3, 3].set(jnp.zeros(3)))(W_H_L)
             C_H_L = LW_H_L
-            L_v_CL = L_v_LW_L = jax.vmap(lambda v: v.at[0:3].set(jnp.zeros(3)))(L_v_WL)
+            L_v_CL = L_v_LW_L = jax.vmap(  # noqa: F841
+                lambda v: v.at[0:3].set(jnp.zeros(3))
+            )(L_v_WL)
 
         case _:
             raise ValueError(data.velocity_representation)

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -8,6 +8,7 @@ import jax_dataclasses
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
+from jaxsim.math import Adjoint
 from jaxsim.utils.tracing import not_tracing
 
 from .common import VelRepr
@@ -444,4 +445,108 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
 
         return replace(
             forces=self.input.physics_model.f_ext.at[link_idxs, :].set(W_f0_L + W_f_L)
+        )
+
+    def apply_frame_forces(
+        self,
+        forces: jtp.MatrixLike,
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
+        frame_names: tuple[str, ...] | str | None = None,
+        additive: bool = False,
+    ) -> Self:
+        """
+        Apply the frame forces.
+
+        Args:
+            forces: The frame 6D forces in the active representation.
+            model:
+                The model to consider, only needed if a frame serialization different
+                from the implicit one is used.
+            data:
+                The data of the considered model, only needed if the velocity
+                representation is not inertial-fixed.
+            frame_names: The names of the frames corresponding to the forces.
+            additive:
+                Whether to add the forces to the existing ones instead of replacing them.
+
+        Returns:
+            A new `JaxSimModelReferences` object with the given frame forces.
+
+        Note:
+            The frame forces must be expressed in the active representation.
+            Then, we always convert and store forces in inertial-fixed representation.
+        """
+
+        f_F = jnp.atleast_2d(forces).astype(float)
+
+        # If we have the model, we can extract the frame names if not provided.
+        frame_names = frame_names if frame_names is not None else model.frame_names()
+
+        # Make sure that the frame names are a tuple if they are provided by the user.
+        frame_names = (frame_names,) if isinstance(frame_names, str) else frame_names
+
+        if len(frame_names) != f_F.shape[0]:
+            msg = "The number of frame names ({}) must match the number of forces ({})"
+            raise ValueError(msg.format(len(frame_names), f_F.shape[0]))
+
+        # Extract the frame indices.
+        frame_idxs = js.frame.names_to_idxs(frame_names=frame_names, model=model)
+        parent_link_idxs = js.frame.idx_of_parent_link(
+            model=model, frame_idxs=frame_idxs
+        )
+
+        if not_tracing(forces) and not data.valid(model=model):
+            raise ValueError("The provided data is not valid for the model")
+
+        W_H_Fi = jax.vmap(
+            lambda frame_idx: js.frame.transform(
+                model=model, data=data, frame_index=frame_idx
+            )
+        )(frame_idxs)
+
+        # Helper function to convert a single 6D force to the inertial representation
+        # considering as body the frame (i.e. L_f_F and LW_f_F).
+        def to_inertial(
+            f_F: jtp.MatrixLike, W_H_F: jtp.MatrixLike, frame_idx: jtp.ArrayLike
+        ) -> jtp.Matrix:
+            return JaxSimModelReferences.other_representation_to_inertial(
+                array=f_F,
+                other_representation=self.velocity_representation,
+                transform=W_H_F,
+                is_force=True,
+            )
+
+        match self.velocity_representation:
+            case VelRepr.Inertial:
+                W_f_F = f_F
+
+            case VelRepr.Body | VelRepr.Mixed:
+                W_f_F = jax.vmap(to_inertial)(f_F, W_H_Fi, frame_idxs)
+
+            case _:
+                raise ValueError("Invalid velocity representation.")
+
+        def convert_to_link_force(
+            W_f_F: jtp.MatrixLike, W_H_F: jtp.MatrixLike, parent_link_idx: jtp.ArrayLike
+        ) -> jtp.Matrix:
+            W_H_L = js.link.transform(
+                model=model, data=data, link_index=parent_link_idx
+            )
+
+            F_H_L = js.transform.inverse(W_H_F) @ W_H_L
+            F_X_L = Adjoint.from_transform(transform=F_H_L, inverse=True)
+
+            return F_X_L @ W_f_F
+
+        W_f_L = jax.vmap(convert_to_link_force)(W_f_F, W_H_Fi, parent_link_idxs)
+
+        return self.apply_link_forces(
+            model=model,
+            data=data,
+            link_names=js.link.idxs_to_names(
+                model=model, link_indices=parent_link_idxs
+            ),
+            forces=W_f_L,
+            additive=additive,
         )

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -539,7 +539,11 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
 
             return F_X_L @ W_f_F
 
-        W_f_L = jax.vmap(convert_to_link_force)(W_f_F, W_H_Fi, parent_link_idxs)
+        W_f_L_i = jax.vmap(convert_to_link_force)(W_f_F, W_H_Fi, parent_link_idxs)
+
+        # Sum the forces on the parent links.
+        mask = parent_link_idxs[:, jnp.newaxis] == jnp.arange(model.number_of_links())
+        W_f_L = mask.T @ W_f_L_i
 
         return self.apply_link_forces(
             model=model,

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -498,7 +498,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         )
 
         exceptions.raise_value_error_if(
-            condition=not_tracing(forces) and not data.valid(model=model),
+            condition=jnp.logical_not(data.valid(model=model)),
             msg="The provided data is not valid for the model",
         )
         W_H_Fi = jax.vmap(

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -261,8 +261,10 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
         # Check if the Butcher tableau supports FSAL (first-same-as-last).
         # If it does, store the index of the intermediate derivative to be used as the
         # first derivative of the next iteration.
-        has_fsal, index_of_fsal = ExplicitRungeKutta.butcher_tableau_supports_fsal(
-            A=cls.A, b=cls.b, c=cls.c, index_of_solution=cls.row_index_of_solution
+        has_fsal, index_of_fsal = (  # noqa: F841
+            ExplicitRungeKutta.butcher_tableau_supports_fsal(
+                A=cls.A, b=cls.b, c=cls.c, index_of_solution=cls.row_index_of_solution
+            )
         )
 
         # Build the integrator object.

--- a/src/jaxsim/math/adjoint.py
+++ b/src/jaxsim/math/adjoint.py
@@ -83,14 +83,14 @@ class Adjoint:
         A_o_B = translation.squeeze()
 
         if not inverse:
-            X = A_X_B = jnp.vstack(
+            X = A_X_B = jnp.vstack(  # noqa: F841
                 [
                     jnp.block([A_R_B, Skew.wedge(A_o_B) @ A_R_B]),
                     jnp.block([jnp.zeros(shape=(3, 3)), A_R_B]),
                 ]
             )
         else:
-            X = B_X_A = jnp.vstack(
+            X = B_X_A = jnp.vstack(  # noqa: F841
                 [
                     jnp.block([A_R_B.T, -A_R_B.T @ Skew.wedge(A_o_B)]),
                     jnp.block([jnp.zeros(shape=(3, 3)), A_R_B.T]),

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -192,7 +192,7 @@ class SoftContacts(ContactModel):
 
         # Unpack the position of the collidable point.
         px, py, pz = W_p_C = position.squeeze()
-        vx, vy, vz = W_ṗ_C = velocity.squeeze()
+        W_ṗ_C = velocity.squeeze()
 
         # Compute the terrain normal and the contact depth.
         n̂ = self.terrain.normal(x=px, y=py).squeeze()


### PR DESCRIPTION
The implementation extends `JaxSimModelReferences` with a `apply_frame_forces` method that first converts the forces to inertial representation, then converts them to the parent link forces and finally calls `apply_link_forces` to return the object with the updated link forces. 
The conversion logic can be found at https://github.com/ami-iit/jaxsim/issues/159#issuecomment-2233371413.

Closes #159 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--209.org.readthedocs.build//209/

<!-- readthedocs-preview jaxsim end -->