### PR TITLE
Simplify SO3 instantiation and quaternion handling

### DIFF
--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -12,7 +12,6 @@ import jaxlie
 import jaxsim.api as js
 import jaxsim.rbda
 import jaxsim.typing as jtp
-from jaxsim.math import Quaternion
 from jaxsim.rbda.contacts.soft import SoftContacts
 from jaxsim.utils import Mutability
 from jaxsim.utils.tracing import not_tracing
@@ -191,9 +190,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
 
         W_H_B = jaxlie.SE3.from_rotation_and_translation(
             translation=base_position,
-            rotation=jaxlie.SO3.from_quaternion_xyzw(
-                base_quaternion[jnp.array([1, 2, 3, 0])]
-            ),
+            rotation=jaxlie.SO3(wxyz=base_quaternion),
         ).as_matrix()
 
         v_WB = JaxSimModelData.other_representation_to_inertial(
@@ -380,13 +377,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             on_false=W_Q_B / jnp.linalg.norm(W_Q_B),
         )
 
-        return (
-            W_Q_B
-            if not dcm
-            else jaxlie.SO3.from_quaternion_xyzw(
-                Quaternion.to_xyzw(wxyz=W_Q_B)
-            ).as_matrix()
-        ).astype(float)
+        return (W_Q_B if not dcm else jaxlie.SO3(wxyz=W_Q_B).as_matrix()).astype(float)
 
     @jax.jit
     def base_transform(self) -> jtp.Matrix:

--- a/src/jaxsim/math/adjoint.py
+++ b/src/jaxsim/math/adjoint.py
@@ -3,7 +3,6 @@ import jaxlie
 
 import jaxsim.typing as jtp
 
-from .quaternion import Quaternion
 from .skew import Skew
 
 
@@ -31,7 +30,7 @@ class Adjoint:
         assert quaternion.size == 4
         assert translation.size == 3
 
-        Q_sixd = jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(quaternion))
+        Q_sixd = jaxlie.SO3(wxyz=quaternion)
         Q_sixd = Q_sixd if not normalize_quaternion else Q_sixd.normalize()
 
         return Adjoint.from_rotation_and_translation(

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -255,7 +255,7 @@ def supported_joint_motion(
         axis = jnp.array(joint_axis).astype(float).squeeze()
 
         pre_H_suc = jaxlie.SE3.from_rotation(
-            rotation=jaxlie.SO3.from_matrix(Rotation.from_axis_angle(vector=s * axis))
+            rotation=Rotation.from_axis_angle(vector=s * axis)
         )
 
         S = jnp.vstack(jnp.hstack([jnp.zeros(3), axis]))

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -254,8 +254,8 @@ def supported_joint_motion(
         # This is a metadata required by only some joint types.
         axis = jnp.array(joint_axis).astype(float).squeeze()
 
-        pre_H_suc = jaxlie.SE3.from_rotation(
-            rotation=Rotation.from_axis_angle(vector=s * axis)
+        pre_H_suc = jaxlie.SE3.from_matrix(
+            matrix=jnp.eye(4).at[:3, :3].set(Rotation.from_axis_angle(vector=s * axis))
         )
 
         S = jnp.vstack(jnp.hstack([jnp.zeros(3), axis]))

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -43,9 +43,7 @@ class Quaternion:
         Returns:
             jtp.Matrix: Direction cosine matrix (DCM).
         """
-        return jaxlie.SO3.from_quaternion_xyzw(
-            xyzw=Quaternion.to_xyzw(quaternion)
-        ).as_matrix()
+        return jaxlie.SO3(wxyz=quaternion).as_matrix()
 
     @staticmethod
     def from_dcm(dcm: jtp.Matrix) -> jtp.Vector:
@@ -158,7 +156,7 @@ class Quaternion:
         A_Q_B = jnp.array(quaternion).squeeze().astype(float)
 
         # Build the initial SO(3) quaternion.
-        W_Q_B_t0 = jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(wxyz=A_Q_B))
+        W_Q_B_t0 = jaxlie.SO3(wxyz=A_Q_B)
 
         # Integrate the quaternion on the manifold.
         W_Q_B_tf = jax.lax.select(

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -79,11 +79,9 @@ class Rotation:
 
             return R.transpose()
 
-        return jaxlie.SO3.from_matrix(
-            jax.lax.cond(
-                pred=(theta == 0.0),
-                true_fun=lambda operand: jnp.eye(3),
-                false_fun=theta_is_not_zero,
-                operand=(theta, vector),
-            )
+        return jax.lax.cond(
+            pred=(theta == 0.0),
+            true_fun=lambda operand: jnp.eye(3),
+            false_fun=theta_is_not_zero,
+            operand=(theta, vector),
         )

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -79,9 +79,11 @@ class Rotation:
 
             return R.transpose()
 
-        return jax.lax.cond(
-            pred=(theta == 0.0),
-            true_fun=lambda operand: jnp.eye(3),
-            false_fun=theta_is_not_zero,
-            operand=(theta, vector),
+        return jaxlie.SO3.from_matrix(
+            jax.lax.cond(
+                pred=(theta == 0.0),
+                true_fun=lambda operand: jnp.eye(3),
+                false_fun=theta_is_not_zero,
+                operand=(theta, vector),
+            )
         )

--- a/src/jaxsim/math/transform.py
+++ b/src/jaxsim/math/transform.py
@@ -3,8 +3,6 @@ import jaxlie
 
 import jaxsim.typing as jtp
 
-from .quaternion import Quaternion
-
 
 class Transform:
 
@@ -35,7 +33,7 @@ class Transform:
         assert W_p_B.size == 3
         assert W_Q_B.size == 4
 
-        A_R_B = jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(W_Q_B))
+        A_R_B = jaxlie.SO3(wxyz=W_Q_B)
         A_R_B = A_R_B if not normalize_quaternion else A_R_B.normalize()
 
         A_H_B = jaxlie.SE3.from_rotation_and_translation(

--- a/src/jaxsim/mujoco/model.py
+++ b/src/jaxsim/mujoco/model.py
@@ -238,9 +238,9 @@ class MujocoModelHelper:
             raise ValueError("The orientation is not a valid element of SO(3)")
 
         W_Q_B = (
-            Rotation.from_matrix(orientation).as_quat(canonical=True)[
-                np.array([3, 0, 1, 2])
-            ]
+            Rotation.from_matrix(orientation).as_quat(
+                canonical=True, scalar_first=False
+            )
             if dcm
             else orientation
         )
@@ -394,8 +394,8 @@ class MujocoModelHelper:
         if dcm:
             return R
 
-        q_xyzw = Rotation.from_matrix(R).as_quat(canonical=True)
-        return q_xyzw[[3, 0, 1, 2]]
+        q_xyzw = Rotation.from_matrix(R).as_quat(canonical=True, scalar_first=False)
+        return q_xyzw
 
     # ===============
     # Private methods

--- a/src/jaxsim/rbda/aba.py
+++ b/src/jaxsim/rbda/aba.py
@@ -4,7 +4,7 @@ import jaxlie
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.math import Adjoint, Cross, Quaternion, StandardGravity
+from jaxsim.math import Adjoint, Cross, StandardGravity
 
 from . import utils
 
@@ -77,7 +77,7 @@ def aba(
 
     # Compute the base transform.
     W_H_B = jaxlie.SE3.from_rotation_and_translation(
-        rotation=jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(wxyz=W_Q_B)),
+        rotation=jaxlie.SO3(wxyz=W_Q_B),
         translation=W_p_B,
     )
 

--- a/src/jaxsim/rbda/collidable_points.py
+++ b/src/jaxsim/rbda/collidable_points.py
@@ -4,7 +4,7 @@ import jaxlie
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.math import Adjoint, Quaternion, Skew
+from jaxsim.math import Adjoint, Skew
 
 from . import utils
 
@@ -57,7 +57,7 @@ def collidable_points_pos_vel(
 
     # Compute the base transform.
     W_H_B = jaxlie.SE3.from_rotation_and_translation(
-        rotation=jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(wxyz=W_Q_B)),
+        rotation=jaxlie.SO3(wxyz=W_Q_B),
         translation=W_p_B,
     )
 

--- a/src/jaxsim/rbda/forward_kinematics.py
+++ b/src/jaxsim/rbda/forward_kinematics.py
@@ -4,7 +4,7 @@ import jaxlie
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.math import Adjoint, Quaternion
+from jaxsim.math import Adjoint
 
 from . import utils
 
@@ -42,7 +42,7 @@ def forward_kinematics_model(
 
     # Compute the base transform.
     W_H_B = jaxlie.SE3.from_rotation_and_translation(
-        rotation=jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(wxyz=W_Q_B)),
+        rotation=jaxlie.SO3(wxyz=W_Q_B),
         translation=W_p_B,
     )
 

--- a/src/jaxsim/rbda/rnea.py
+++ b/src/jaxsim/rbda/rnea.py
@@ -6,7 +6,7 @@ import jaxlie
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.math import Adjoint, Cross, Quaternion, StandardGravity
+from jaxsim.math import Adjoint, Cross, StandardGravity
 
 from . import utils
 
@@ -82,7 +82,7 @@ def rnea(
 
     # Compute the base transform.
     W_H_B = jaxlie.SE3.from_rotation_and_translation(
-        rotation=jaxlie.SO3.from_quaternion_xyzw(xyzw=Quaternion.to_xyzw(wxyz=W_Q_B)),
+        rotation=jaxlie.SO3(wxyz=W_Q_B),
         translation=W_p_B,
     )
 


### PR DESCRIPTION
This pull request simplifies the instantiation of SO3 objects from quaternions in multiple files. It replaces the usage of `jaxlie.SO3.from_quaternion_xyzw` with the more concise `jaxlie.SO3(wxyz=quaternion)`. Additionally, it refactors the reordering of the quaternions from SciPy by using the `scalar_first` option. 