### PR TITLE
Add `data` parameter to `jaxsim.api.references.JaxSimModelReferences.zero`

### DIFF
--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -38,7 +38,8 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
 
         Args:
             model: The model for which to create the zero references.
-            data: The data of the model, only needed if the velocity representation is
+            data:
+                The data of the model, only needed if the velocity representation is
                 not inertial-fixed.
             velocity_representation: The velocity representation to use.
 

--- a/src/jaxsim/api/references.py
+++ b/src/jaxsim/api/references.py
@@ -30,6 +30,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
     @staticmethod
     def zero(
         model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData | None = None,
         velocity_representation: VelRepr = VelRepr.Inertial,
     ) -> JaxSimModelReferences:
         """
@@ -37,6 +38,8 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
 
         Args:
             model: The model for which to create the zero references.
+            data: The data of the model, only needed if the velocity representation is
+                not inertial-fixed.
             velocity_representation: The velocity representation to use.
 
         Returns:
@@ -44,7 +47,7 @@ class JaxSimModelReferences(js.common.ModelDataWithVelocityRepresentation):
         """
 
         return JaxSimModelReferences.build(
-            model=model, velocity_representation=velocity_representation
+            model=model, data=data, velocity_representation=velocity_representation
         )
 
     @staticmethod


### PR DESCRIPTION
Without the `data` parameter it is not possible to create a reference object with a velocity representation different from inertial.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--215.org.readthedocs.build//215/

<!-- readthedocs-preview jaxsim end -->