### PR TITLE
Allow building a MJCF without user-defined cameras

### DIFF
--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -532,7 +532,12 @@ class UrdfToMjcf:
         model_name: str | None = None,
         plane_normal: tuple[float, float, float] = (0, 0, 1),
         heightmap: bool | None = None,
-        cameras: list[dict[str, str]] | dict[str, str] | None = None,
+        cameras: (
+            MujocoCamera
+            | Sequence[MujocoCamera]
+            | dict[str, str]
+            | Sequence[dict[str, str]]
+        ) = (),
     ) -> tuple[str, dict[str, Any]]:
         """
         Converts a URDF file to a Mujoco MJCF string.
@@ -574,7 +579,12 @@ class SdfToMjcf:
         model_name: str | None = None,
         plane_normal: tuple[float, float, float] = (0, 0, 1),
         heightmap: bool | None = None,
-        cameras: list[dict[str, str]] | dict[str, str] | None = None,
+        cameras: (
+            MujocoCamera
+            | Sequence[MujocoCamera]
+            | dict[str, str]
+            | Sequence[dict[str, str]]
+        ) = (),
     ) -> tuple[str, dict[str, Any]]:
         """
         Converts a SDF file to a Mujoco MJCF string.


### PR DESCRIPTION
This PR fixes a bug for which the MJCF could not be built without passing a user-defined camera.

<details><summary>Testing Script</summary>
<p>

```python
import rod
from rod.builder.primitives import SphereBuilder

from jaxsim.mujoco import UrdfToMjcf

model_sdf_string = rod.Sdf(
    version="1.7",
    model=SphereBuilder(radius=0.10, mass=1.0, name="sphere")
    .build_model()
    .add_link()
    .add_inertial()
    .add_visual()
    .add_collision()
    .build(),
).serialize(pretty=True)

mjcf_string, assets = UrdfToMjcf.convert(
    urdf=model_sdf_string,
)
```

</p>
</details> 

<details><summary>Error Log</summary>
<p>

```python
File ~/jaxsim/src/jaxsim/mujoco/loaders.py:496, in RodModelToMjcf.convert(rod_model, considered_joints, plane_normal, heightmap, heightmap_samples_xy, cameras)
    490 # Add user-defined camera.
    491 for camera in cameras if isinstance(cameras, Sequence) else [cameras]:
    493     mj_camera = (
    494         camera
    495         if isinstance(camera, MujocoCamera)
--> 496         else MujocoCamera.build(**camera)
    497     )
    499     _ = ET.SubElement(worldbody_element, "camera", mj_camera.asdict())
    501 # ------------------------------------------------
    502 # Add a light following the  CoM of the first link
    503 # ------------------------------------------------

TypeError: jaxsim.mujoco.loaders.MujocoCamera.build() argument after ** must be a mapping, not NoneType
```

</p>
</details> 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--216.org.readthedocs.build//216/

<!-- readthedocs-preview jaxsim end -->