### PR TITLE
Add alternative rigid contact model

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jaxlie >= 1.3.0
   - jax-dataclasses >= 1.4.0
   - pptree
+  - qpax
   - rod >= 0.3.0
   - typing_extensions # python<3.12
   # ====================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "jaxlie >= 1.3.0",
     "jax_dataclasses >= 1.4.0",
     "pptree",
+    "qpax",
     "rod >= 0.3.0",
     "typing_extensions ; python_version < '3.12'",
 ]
@@ -187,6 +188,7 @@ mediapy = "*"
 mujoco = "*"
 notebook = "*"
 pptree = "*"
+qpax = "*"
 rod = "*"
 sdformat14 = "*"
 typing_extensions = "*"

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -124,8 +124,9 @@ def collidable_point_dynamics(
     Args:
         model: The model to consider.
         data: The data of the considered model.
-        link_forces: The 6D external forces to apply to the links
-            expressed in the same representation of data.
+        link_forces:
+            The 6D external forces to apply to the links expressed in the same
+            representation of data.
 
     Returns:
         The 6D force applied to each collidable point and additional data based on the contact model configured:

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -115,18 +115,18 @@ def collidable_point_forces(
 @jax.jit
 def collidable_point_dynamics(
     model: js.model.JaxSimModel, data: js.data.JaxSimModelData
-) -> tuple[jtp.Matrix, jtp.Matrix]:
+) -> tuple[jtp.Matrix, tuple[jtp.Array]]:
     r"""
-    Compute the 6D force applied to each collidable point and the corresponding
-    material deformation rate.
+    Compute the 6D force applied to each collidable point.
 
     Args:
         model: The model to consider.
         data: The data of the considered model.
 
     Returns:
-        The 6D force applied to each collidable point and the corresponding
-        material deformation rate.
+        The 6D force applied to each collidable point and additional data based on the contact model configured:
+        - Soft: the material deformation rate.
+        - Rigid: the new system velocity after potential impacts.
 
     Note:
         The material deformation rate is always returned in the mixed frame
@@ -138,7 +138,8 @@ def collidable_point_dynamics(
     # all collidable points belonging to the robot.
     W_p_Ci, W_ṗ_Ci = js.contact.collidable_point_kinematics(model=model, data=data)
 
-    # Import privately the soft contacts classes.
+    # Import privately the contacts classes.
+    from jaxsim.rbda.contacts.rigid import RigidContacts, RigidContactsState
     from jaxsim.rbda.contacts.soft import SoftContacts, SoftContactsState
 
     # Build the soft contact model.
@@ -161,6 +162,23 @@ def collidable_point_dynamics(
             W_f_Ci, (CW_ṁ,) = jax.vmap(soft_contacts.compute_contact_forces)(
                 W_p_Ci, W_ṗ_Ci, data.state.contact.tangential_deformation
             )
+            aux_data = (CW_ṁ,)
+
+        case RigidContacts():
+            assert isinstance(model.contact_model, RigidContacts)
+            assert isinstance(data.state.contact, RigidContactsState)
+
+            # Build the contact model.
+            rigid_contacts = RigidContacts(
+                parameters=data.contacts_params, terrain=model.terrain
+            )
+
+            # Compute the 6D force expressed in the inertial frame and applied to each
+            # collidable point.
+            W_f_Ci, (nu,) = rigid_contacts.compute_contact_forces(
+                W_p_Ci, W_ṗ_Ci, model, data
+            )
+            aux_data = nu
 
         case _:
             raise ValueError(f"Invalid contact model {model.contact_model}")
@@ -175,7 +193,7 @@ def collidable_point_dynamics(
         )
     )(W_f_Ci)
 
-    return f_Ci, CW_ṁ
+    return f_Ci, aux_data
 
 
 @functools.partial(jax.jit, static_argnames=["link_names"])

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -115,7 +115,7 @@ def collidable_point_forces(
 @jax.jit
 def collidable_point_dynamics(
     model: js.model.JaxSimModel, data: js.data.JaxSimModelData
-) -> tuple[jtp.Matrix, tuple[jtp.Array]]:
+) -> tuple[jtp.Matrix, dict[str, jtp.Array]]:
     r"""
     Compute the 6D force applied to each collidable point.
 
@@ -162,7 +162,7 @@ def collidable_point_dynamics(
             W_f_Ci, (CW_ṁ,) = jax.vmap(soft_contacts.compute_contact_forces)(
                 W_p_Ci, W_ṗ_Ci, data.state.contact.tangential_deformation
             )
-            aux_data = (CW_ṁ,)
+            aux_data = dict(ṁ=CW_ṁ)
 
         case RigidContacts():
             assert isinstance(model.contact_model, RigidContacts)
@@ -178,7 +178,7 @@ def collidable_point_dynamics(
             W_f_Ci, (nu,) = rigid_contacts.compute_contact_forces(
                 W_p_Ci, W_ṗ_Ci, model, data
             )
-            aux_data = nu
+            aux_data = dict(nu_impact=nu)
 
         case _:
             raise ValueError(f"Invalid contact model {model.contact_model}")

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -162,7 +162,7 @@ def collidable_point_dynamics(
             W_f_Ci, (CW_ṁ,) = jax.vmap(soft_contacts.compute_contact_forces)(
                 W_p_Ci, W_ṗ_Ci, data.state.contact.tangential_deformation
             )
-            aux_data = dict(ṁ=CW_ṁ)
+            aux_data = dict(m_dot=CW_ṁ)
 
         case RigidContacts():
             assert isinstance(model.contact_model, RigidContacts)

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -114,7 +114,9 @@ def collidable_point_forces(
 
 @jax.jit
 def collidable_point_dynamics(
-    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+    model: js.model.JaxSimModel,
+    data: js.data.JaxSimModelData,
+    link_external_forces: js.references.JaxSimModelReferences | None = None,
 ) -> tuple[jtp.Matrix, dict[str, jtp.Array]]:
     r"""
     Compute the 6D force applied to each collidable point.
@@ -122,6 +124,7 @@ def collidable_point_dynamics(
     Args:
         model: The model to consider.
         data: The data of the considered model.
+        link_external_forces: References object containing the 6D external forces applied to links.
 
     Returns:
         The 6D force applied to each collidable point and additional data based on the contact model configured:
@@ -180,6 +183,7 @@ def collidable_point_dynamics(
                 velocity=W_ṗ_Ci,
                 model=model,
                 data=data,
+                link_external_forces=link_external_forces,
             )
 
             data_post_impact = data.reset_base_velocity(

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -116,7 +116,7 @@ def collidable_point_forces(
 def collidable_point_dynamics(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
-    link_external_forces: jtp.Matrix | None = None,
+    link_external_forces: jtp.MatrixLike | None = None,
 ) -> tuple[jtp.Matrix, dict[str, jtp.Array]]:
     r"""
     Compute the 6D force applied to each collidable point.

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -184,7 +184,7 @@ def collidable_point_dynamics(
                 velocity=W_ṗ_Ci,
                 model=model,
                 data=data,
-                link_external_forces=link_forces,
+                link_forces=link_forces,
             )
 
             aux_data = dict()

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -139,7 +139,11 @@ def collidable_point_dynamics(
     W_p_Ci, W_ṗ_Ci = js.contact.collidable_point_kinematics(model=model, data=data)
 
     # Import privately the contacts classes.
-    from jaxsim.rbda.contacts.rigid import RigidContacts, RigidContactsState
+    from jaxsim.rbda.contacts.rigid import (
+        RigidContactParams,
+        RigidContacts,
+        RigidContactsState,
+    )
     from jaxsim.rbda.contacts.soft import SoftContacts, SoftContactsState
 
     # Build the soft contact model.
@@ -175,11 +179,16 @@ def collidable_point_dynamics(
 
             # Compute the 6D force expressed in the inertial frame and applied to each
             # collidable point.
+            if isinstance(data.contacts_params, RigidContactParams):
+                inactive_points_previous = data.contacts_params.inactive_points_prev
+            else:
+                raise ValueError("Invalid contact parameters")
+
             W_f_Ci, (new_impacts, nu, inactive_collidable_points) = (
                 rigid_contacts.compute_contact_forces(
                     position=W_p_Ci,
                     velocity=W_ṗ_Ci,
-                    inactive_collidable_points_prev=data.state.contact.inactive_points_prev,
+                    inactive_collidable_points_prev=inactive_points_previous,
                     model=model,
                     data=data,
                 )

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -129,7 +129,7 @@ def collidable_point_dynamics(
     Returns:
         The 6D force applied to each collidable point and additional data based on the contact model configured:
         - Soft: the material deformation rate.
-        - Rigid: the new system velocity after potential impacts.
+        - Rigid: nothing.
 
     Note:
         The material deformation rate is always returned in the mixed frame
@@ -178,7 +178,7 @@ def collidable_point_dynamics(
 
             # Compute the 6D force expressed in the inertial frame and applied to each
             # collidable point.
-            W_f_Ci, (BW_nu_post_impact, _) = rigid_contacts.compute_contact_forces(
+            W_f_Ci, _ = rigid_contacts.compute_contact_forces(
                 position=W_p_Ci,
                 velocity=W_ṗ_Ci,
                 model=model,
@@ -186,14 +186,7 @@ def collidable_point_dynamics(
                 link_external_forces=link_external_forces,
             )
 
-            data_post_impact = data.reset_base_velocity(
-                BW_nu_post_impact[0:6], velocity_representation=VelRepr.Mixed
-            ).reset_joint_velocities(BW_nu_post_impact[6:])
-
-            aux_data = dict(data_post_impact=data_post_impact)
-
-            # Update the data object with the post-impact data
-            data = data_post_impact
+            aux_data = dict()
 
         case _:
             raise ValueError(f"Invalid contact model {model.contact_model}")

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -116,7 +116,7 @@ def collidable_point_forces(
 def collidable_point_dynamics(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
-    link_external_forces: js.references.JaxSimModelReferences | None = None,
+    link_external_forces: jtp.Matrix | None = None,
 ) -> tuple[jtp.Matrix, dict[str, jtp.Array]]:
     r"""
     Compute the 6D force applied to each collidable point.
@@ -124,7 +124,8 @@ def collidable_point_dynamics(
     Args:
         model: The model to consider.
         data: The data of the considered model.
-        link_external_forces: References object containing the 6D external forces applied to links.
+        link_external_forces: The 6D external forces to apply to the links
+            expressed in the same representation of data.
 
     Returns:
         The 6D force applied to each collidable point and additional data based on the contact model configured:

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -116,7 +116,7 @@ def collidable_point_forces(
 def collidable_point_dynamics(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
-    link_external_forces: jtp.MatrixLike | None = None,
+    link_forces: jtp.MatrixLike | None = None,
 ) -> tuple[jtp.Matrix, dict[str, jtp.Array]]:
     r"""
     Compute the 6D force applied to each collidable point.
@@ -124,7 +124,7 @@ def collidable_point_dynamics(
     Args:
         model: The model to consider.
         data: The data of the considered model.
-        link_external_forces: The 6D external forces to apply to the links
+        link_forces: The 6D external forces to apply to the links
             expressed in the same representation of data.
 
     Returns:
@@ -184,7 +184,7 @@ def collidable_point_dynamics(
                 velocity=W_ṗ_Ci,
                 model=model,
                 data=data,
-                link_external_forces=link_external_forces,
+                link_external_forces=link_forces,
             )
 
             aux_data = dict()

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -175,10 +175,20 @@ def collidable_point_dynamics(
 
             # Compute the 6D force expressed in the inertial frame and applied to each
             # collidable point.
-            W_f_Ci, (nu,) = rigid_contacts.compute_contact_forces(
-                W_p_Ci, W_ṗ_Ci, model, data
+            W_f_Ci, (new_impacts, nu, inactive_collidable_points) = (
+                rigid_contacts.compute_contact_forces(
+                    position=W_p_Ci,
+                    velocity=W_ṗ_Ci,
+                    inactive_collidable_points_prev=data.state.contact.inactive_points_prev,
+                    model=model,
+                    data=data,
+                )
             )
-            aux_data = dict(nu_impact=nu)
+            aux_data = dict(
+                nu_impact=nu,
+                inactive_collidable_points=inactive_collidable_points,
+                new_impacts=new_impacts,
+            )
 
         case _:
             raise ValueError(f"Invalid contact model {model.contact_model}")

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1951,9 +1951,12 @@ def step(
                 M = js.model.free_floating_mass_matrix(model, data)
                 J_WC = js.contact.jacobian(model, data)
                 px, py, _ = W_p_C.T
-                terrain = model.contact_model.terrain
-                terrain_height = jax.vmap(terrain.height)(px, py)
-                terrain_normal = jax.vmap(terrain.normal)(px, py)
+                terrain_height = jax.vmap(lambda x, y: model.terrain.height(x=x, y=y))(
+                    px, py
+                )
+                terrain_normal = jax.vmap(lambda x, y: model.terrain.normal(x=x, y=y))(
+                    px, py
+                )
                 inactive_collidable_points, _ = RigidContacts.detect_contacts(
                     W_p_C=W_p_C,
                     W_ṗ_C=W_ṗ_C,

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1951,13 +1951,13 @@ def step(
                 terrain_normal = jax.vmap(model.contact_model.terrain.normal)(
                     W_o_C[:, 0], W_o_C[:, 1]
                 )
-                inactive_collidable_points, _ = RigidContacts._detect_contacts(
+                inactive_collidable_points, _ = RigidContacts.detect_contacts(
                     W_o_C=W_o_C,
                     W_o_dot_C=W_o_dot_C,
                     terrain_height=terrain_height,
                     terrain_normal=terrain_normal,
                 )
-                BW_nu_post_impact = RigidContacts._compute_impact_velocity(
+                BW_nu_post_impact = RigidContacts.compute_impact_velocity(
                     data=data,
                     inactive_collidable_points=inactive_collidable_points,
                     M=M,

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1947,21 +1947,16 @@ def step(
         case RigidContacts():
             inputa_data_repr = data.velocity_representation
             with data.switch_velocity_representation(VelRepr.Mixed):
-                W_p_C, W_ṗ_C = js.contact.collidable_point_kinematics(model, data)
+                W_p_C = js.contact.collidable_point_positions(model, data)
                 M = js.model.free_floating_mass_matrix(model, data)
                 J_WC = js.contact.jacobian(model, data)
                 px, py, _ = W_p_C.T
                 terrain_height = jax.vmap(lambda x, y: model.terrain.height(x=x, y=y))(
                     px, py
                 )
-                terrain_normal = jax.vmap(lambda x, y: model.terrain.normal(x=x, y=y))(
-                    px, py
-                )
                 inactive_collidable_points, _ = RigidContacts.detect_contacts(
                     W_p_C=W_p_C,
-                    W_ṗ_C=W_ṗ_C,
                     terrain_height=terrain_height,
-                    terrain_normal=terrain_normal,
                 )
                 BW_nu_post_impact = RigidContacts.compute_impact_velocity(
                     data=data,

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1938,8 +1938,6 @@ def step(
         )
     )
 
-    jax.debug.print("before data base vel{base_vel}", base_vel=data.base_velocity())
-
     # In case of rigid contact model, update data
     match model.contact_model:
         case RigidContacts():
@@ -1968,7 +1966,6 @@ def step(
                 data = data.reset_base_velocity(BW_nu_post_impact[0:6])
                 data = data.reset_joint_velocities(BW_nu_post_impact[6:])
 
-    jax.debug.print("updated data base vel{base_vel}", base_vel=data.base_velocity())
     return (
         data,
         integrator_state_xf,

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1942,7 +1942,7 @@ def step(
     match model.contact_model:
         case RigidContacts():
             with data.switch_velocity_representation(VelRepr.Mixed):
-                W_o_C, W_o_dot_C = js.contact.collidable_point_kinematics(model, data)
+                W_o_C, W_ȯ_C = js.contact.collidable_point_kinematics(model, data)
                 M = js.model.free_floating_mass_matrix(model, data)
                 J_WC = js.contact.jacobian(model, data)
                 terrain_height = jax.vmap(model.contact_model.terrain.height)(
@@ -1953,7 +1953,7 @@ def step(
                 )
                 inactive_collidable_points, _ = RigidContacts.detect_contacts(
                     W_o_C=W_o_C,
-                    W_o_dot_C=W_o_dot_C,
+                    W_o_dot_C=W_ȯ_C,
                     terrain_height=terrain_height,
                     terrain_normal=terrain_normal,
                 )

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -107,9 +107,6 @@ def system_velocity_dynamics(
         the system dynamics evaluation.
     """
 
-    from jaxsim.rbda.contacts.rigid import RigidContacts
-    from jaxsim.rbda.contacts.soft import SoftContacts
-
     # Build link forces if not provided.
     # These forces are expressed in the frame corresponding to the velocity
     # representation of data.
@@ -144,21 +141,7 @@ def system_velocity_dynamics(
             W_f_Ci, aux_data = js.contact.collidable_point_dynamics(
                 model=model, data=data, link_external_forces=references
             )
-
-        match model.contact_model:
-            case SoftContacts():
-                pass
-            case RigidContacts():
-                data_post_impact: js.data.JaxSimModelData = aux_data.get(
-                    "data_post_impact"
-                )
-                # Update the data object with the post-impact data with the same velocity representation.
-                with data_post_impact.switch_velocity_representation(
-                    data.velocity_representation
-                ):
-                    data = data_post_impact
-            case _:
-                raise ValueError("Invalid contact model {}".format(model.contact_model))
+            # jax.debug.print("W_f_Ci={W_f_Ci}", W_f_Ci=W_f_Ci)
 
         # Construct the vector defining the parent link index of each collidable point.
         # We use this vector to sum the 6D forces of all collidable points rigidly
@@ -379,12 +362,7 @@ def system_dynamics(
             ode_state_kwargs["tangential_deformation"] = aux_dict["m_dot"]
 
         case RigidContacts():
-            data_post_impact: js.data.JaxSimModelData = aux_dict.get("data_post_impact")
-            # Update the data object with the post-impact data with the same velocity representation.
-            with data_post_impact.switch_velocity_representation(
-                data.velocity_representation
-            ):
-                data = data_post_impact
+            pass
 
         case _:
             raise ValueError("Unable to determine contact state class prefix.")

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -379,7 +379,7 @@ def system_dynamics(
             ode_state_kwargs["tangential_deformation"] = aux_dict["m_dot"]
 
         case RigidContacts():
-            data_post_impact: js.data.JaxSimModelData = aux_dict.pop("data_post_impact")
+            data_post_impact: js.data.JaxSimModelData = aux_dict.get("data_post_impact")
             # Update the data object with the post-impact data with the same velocity representation.
             with data_post_impact.switch_velocity_representation(
                 data.velocity_representation

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -192,9 +192,9 @@ def system_acceleration(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    joint_forces: jtp.Vector | None = None,
+    joint_forces: jtp.VectorLike | None = None,
     link_forces: jtp.MatrixLike | None = None,
-):
+) -> tuple[jtp.Vector, jtp.Vector]:
     """
     Compute the system acceleration in inertial-fixed representation.
 
@@ -206,8 +206,8 @@ def system_acceleration(
             The 6D forces to apply to the links expressed in the same representation of data.
 
     Returns:
-        A tuple containing the derivative of the base 6D velocity in inertial-fixed
-        representation and the derivative of the joint velocities.
+        A tuple containing the base 6D acceleration in inertial-fixed representation
+        and the joint accelerations.
     """
 
     # ====================

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -50,7 +50,7 @@ def wrap_system_dynamics_for_integration(
     # The wrapped dynamics will hold a reference of this object.
     model_closed = model.copy()
     data_closed = data.copy().replace(
-        state=js.ode_data.ODEState.zero(model=model_closed)
+        state=js.ode_data.ODEState.zero(model=model_closed, data=data)
     )
 
     def f(x: ODEState, t: Time, **kwargs_f) -> tuple[ODEState, dict[str, Any]]:

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -141,7 +141,6 @@ def system_velocity_dynamics(
             W_f_Ci, aux_data = js.contact.collidable_point_dynamics(
                 model=model, data=data, link_external_forces=references
             )
-            # jax.debug.print("W_f_Ci={W_f_Ci}", W_f_Ci=W_f_Ci)
 
         # Construct the vector defining the parent link index of each collidable point.
         # We use this vector to sum the 6D forces of all collidable points rigidly

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -356,7 +356,7 @@ def system_dynamics(
 
     match model.contact_model:
         case SoftContacts():
-            ṁ = aux_dict["ṁ"]
+            ṁ = aux_dict["m_dot"]
         case RigidContacts():
             nu_impact = aux_dict["nu_impact"]
             # Update system velocity with the impact velocity

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -141,7 +141,7 @@ def system_velocity_dynamics(
             W_f_Ci, aux_data = js.contact.collidable_point_dynamics(
                 model=model,
                 data=data,
-                link_external_forces=references.link_forces(model=model, data=data),
+                link_forces=references.link_forces(model=model, data=data),
             )
 
         # Construct the vector defining the parent link index of each collidable point.

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -119,6 +119,13 @@ def system_velocity_dynamics(
         else jnp.zeros((model.number_of_links(), 6))
     ).astype(float)
 
+    references = js.references.JaxSimModelReferences.build(
+        model=model,
+        link_forces=O_f_L,
+        data=data,
+        velocity_representation=data.velocity_representation,
+    )
+
     # ======================
     # Compute contact forces
     # ======================
@@ -135,7 +142,7 @@ def system_velocity_dynamics(
         #  and the corresponding material deformation rates.
         with data.switch_velocity_representation(VelRepr.Inertial):
             W_f_Ci, aux_data = js.contact.collidable_point_dynamics(
-                model=model, data=data
+                model=model, data=data, link_external_forces=references
             )
 
         match model.contact_model:
@@ -172,13 +179,6 @@ def system_velocity_dynamics(
     # ===========================
     # Compute system acceleration
     # ===========================
-
-    references = js.references.JaxSimModelReferences.build(
-        model=model,
-        link_forces=O_f_L,
-        data=data,
-        velocity_representation=data.velocity_representation,
-    )
 
     with references.switch_velocity_representation(VelRepr.Inertial):
         W_f_L = references.link_forces(model=model, data=data)

--- a/src/jaxsim/api/ode_data.py
+++ b/src/jaxsim/api/ode_data.py
@@ -172,7 +172,7 @@ class ODEState(JaxsimDataclass):
                     ),
                 )
             case RigidContacts():
-                contact = RigidContactsState.build_from_jaxsim_model(model=model)
+                contact = RigidContactsState.build()
             case _:
                 raise ValueError("Unable to determine contact state class prefix.")
 

--- a/src/jaxsim/api/ode_data.py
+++ b/src/jaxsim/api/ode_data.py
@@ -172,10 +172,7 @@ class ODEState(JaxsimDataclass):
                     ),
                 )
             case RigidContacts():
-                inactive_points_prev = kwargs.get("inactive_collidable_points", None)
-                contact = RigidContactsState.build_from_jaxsim_model(
-                    model=model, inactive_points_prev=inactive_points_prev
-                )
+                contact = RigidContactsState.build_from_jaxsim_model(model=model)
             case _:
                 raise ValueError("Unable to determine contact state class prefix.")
 

--- a/src/jaxsim/api/ode_data.py
+++ b/src/jaxsim/api/ode_data.py
@@ -6,6 +6,7 @@ import jax_dataclasses
 import jaxsim.api as js
 import jaxsim.typing as jtp
 from jaxsim.rbda import ContactsState
+from jaxsim.rbda.contacts.rigid import RigidContacts, RigidContactsState
 from jaxsim.rbda.contacts.soft import SoftContacts, SoftContactsState
 from jaxsim.utils import JaxsimDataclass
 
@@ -171,6 +172,8 @@ class ODEState(JaxsimDataclass):
                         else dict()
                     ),
                 )
+            case RigidContacts():
+                contact = RigidContactsState.build_from_jaxsim_model(model=model)
             case _:
                 raise ValueError("Unable to determine contact state class prefix.")
 
@@ -216,6 +219,8 @@ class ODEState(JaxsimDataclass):
         match contact:
             case SoftContactsState():
                 pass
+            case RigidContactsState():
+                pass
             case None:
                 contact = SoftContactsState.zero(model=model)
             case _:
@@ -224,7 +229,7 @@ class ODEState(JaxsimDataclass):
         return ODEState(physics_model=physics_model_state, contact=contact)
 
     @staticmethod
-    def zero(model: js.model.JaxSimModel) -> ODEState:
+    def zero(model: js.model.JaxSimModel, data: js.data.JaxSimModelData) -> ODEState:
         """
         Build a zero `ODEState` from a `JaxSimModel`.
 
@@ -235,7 +240,9 @@ class ODEState(JaxsimDataclass):
             A zero `ODEState` instance.
         """
 
-        model_state = ODEState.build(model=model)
+        model_state = ODEState.build(
+            model=model, contact=data.state.contact.zero(model=model)
+        )
 
         return model_state
 

--- a/src/jaxsim/api/ode_data.py
+++ b/src/jaxsim/api/ode_data.py
@@ -216,9 +216,7 @@ class ODEState(JaxsimDataclass):
 
         # Get the contact model from the `JaxSimModel`.
         match contact:
-            case SoftContactsState():
-                pass
-            case RigidContactsState():
+            case SoftContactsState() | RigidContactsState():
                 pass
             case None:
                 contact = SoftContactsState.zero(model=model)

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -109,11 +109,14 @@ class Integrator(JaxsimDataclass, abc.ABC, Generic[State, StateDerivative]):
             integrator.params = params
 
         with integrator.mutable_context(mutability=Mutability.MUTABLE):
-            xf = integrator(x0, t0, dt, **kwargs)
+            xf, aux_dict = integrator(x0, t0, dt, **kwargs)
 
-        return xf, integrator.params | {
-            Integrator.AfterInitKey: jnp.array(False).astype(bool)
-        }
+        return (
+            xf,
+            integrator.params
+            | {Integrator.AfterInitKey: jnp.array(False).astype(bool)}
+            | aux_dict,
+        )
 
     @abc.abstractmethod
     def __call__(self, x0: State, t0: Time, dt: TimeStep, **kwargs) -> NextState:
@@ -277,15 +280,19 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
 
         return integrator
 
-    def __call__(self, x0: State, t0: Time, dt: TimeStep, **kwargs) -> NextState:
+    def __call__(
+        self, x0: State, t0: Time, dt: TimeStep, **kwargs
+    ) -> tuple[NextState, dict[str, Any]]:
 
         # Here z is a batched state with as many batch elements as b.T rows.
         # Note that z has multiple batches only if b.T has more than one row,
         # e.g. in Butcher tableau of embedded schemes.
-        z = self._compute_next_state(x0=x0, t0=t0, dt=dt, **kwargs)
+        z, aux_dict = self._compute_next_state(x0=x0, t0=t0, dt=dt, **kwargs)
 
         # The next state is the batch element located at the configured index of solution.
-        return jax.tree_util.tree_map(lambda l: l[self.row_index_of_solution], z)
+        next_state = jax.tree_util.tree_map(lambda l: l[self.row_index_of_solution], z)
+
+        return next_state, aux_dict
 
     @classmethod
     def integrate_rk_stage(
@@ -343,7 +350,7 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
 
     def _compute_next_state(
         self, x0: State, t0: Time, dt: TimeStep, **kwargs
-    ) -> NextState:
+    ) -> tuple[NextState, dict[str, Any]]:
         """
         Compute the next state of the system, returning all the output states.
 
@@ -373,19 +380,21 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
         )
 
         # Apply FSAL property by passing ẋ0 = f(x0, t0) from the previous iteration.
-        get_ẋ0 = lambda: self.params.get("dxdt0", f(x0, t0)[0])
+        get_ẋ0 = lambda: self.params.get("dxdt0", f(x0, t0))
 
         # We use a `jax.lax.scan` to compile the `f` function only once.
         # Otherwise, if we compute e.g. for RK4 sequentially, the jit-compiled code
         # would include 4 repetitions of the `f` logic, making everything extremely slow.
-        def scan_body(carry: jax.Array, i: int | jax.Array) -> tuple[jax.Array, None]:
+        def scan_body(
+            carry: jax.Array, i: int | jax.Array
+        ) -> tuple[jax.Array, dict[str, Any]]:
             """"""
 
             # Unpack the carry, i.e. the stacked kᵢ vectors.
             K = carry
 
             # Define the computation of the Runge-Kutta stage.
-            def compute_ki() -> jax.Array:
+            def compute_ki() -> tuple[jax.Array, dict[str, Any]]:
 
                 # Compute ∑ⱼ aᵢⱼ kⱼ.
                 op_sum_ak = lambda k: jnp.einsum("s,s...->...", A[i], k)
@@ -398,11 +407,11 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
                 # Compute the next time for the kᵢ evaluation.
                 ti = t0 + c[i] * Δt
 
-                # This is kᵢ = f(xᵢ, tᵢ).
-                return f(xi, ti)[0]
+                # This is kᵢ, aux_dict = f(xᵢ, tᵢ).
+                return f(xi, ti)
 
             # This selector enables FSAL property in the first iteration (i=0).
-            ki = jax.lax.cond(
+            ki, aux_dict = jax.lax.cond(
                 pred=jnp.logical_and(i == 0, self.has_fsal),
                 true_fun=get_ẋ0,
                 false_fun=compute_ki,
@@ -413,10 +422,10 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
             K = jax.tree_util.tree_map(op, K, ki)
 
             carry = K
-            return carry, None
+            return carry, aux_dict
 
         # Compute the state derivatives kᵢ.
-        K, _ = jax.lax.scan(
+        K, aux_dict = jax.lax.scan(
             f=scan_body,
             init=carry0,
             xs=jnp.arange(c.size),
@@ -439,7 +448,7 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
             lambda xf: self.post_process_state(x0=x0, t0=t0, xf=xf, dt=dt)
         )(z)
 
-        return z_transformed
+        return z_transformed, aux_dict
 
     @staticmethod
     def butcher_tableau_is_valid(

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -380,7 +380,7 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
         )
 
         # Apply FSAL property by passing ẋ0 = f(x0, t0) from the previous iteration.
-        get_ẋ0 = lambda: self.params.get("dxdt0", f(x0, t0))
+        get_ẋ0_and_aux_dict = lambda: self.params.get("dxdt0", f(x0, t0))
 
         # We use a `jax.lax.scan` to compile the `f` function only once.
         # Otherwise, if we compute e.g. for RK4 sequentially, the jit-compiled code
@@ -413,7 +413,7 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
             # This selector enables FSAL property in the first iteration (i=0).
             ki, aux_dict = jax.lax.cond(
                 pred=jnp.logical_and(i == 0, self.has_fsal),
-                true_fun=get_ẋ0,
+                true_fun=get_ẋ0_and_aux_dict,
                 false_fun=compute_ki,
             )
 

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import jaxsim.terrain
 import jaxsim.typing as jtp
+from jaxsim.utils import JaxsimDataclass
 
 
 class ContactsState(abc.ABC):
@@ -42,7 +43,7 @@ class ContactsState(abc.ABC):
         pass
 
 
-class ContactsParams(abc.ABC):
+class ContactsParams(JaxsimDataclass):
     """
     Abstract class representing the parameters of a contact model.
     """
@@ -67,7 +68,7 @@ class ContactsParams(abc.ABC):
         pass
 
 
-class ContactModel(abc.ABC):
+class ContactModel(JaxsimDataclass):
     """
     Abstract class representing a contact model.
 

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import jax_dataclasses
+
+import jaxsim.typing as jtp
+from jaxsim.terrain.terrain import FlatTerrain, Terrain
+
+from .common import ContactModel, ContactsParams
+
+
+@jax_dataclasses.pytree_dataclass
+class RigidContactParams(ContactsParams):
+    """Parameters of the rigid contacts model."""
+
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+    def __eq__(self, value: object) -> bool:
+        return super().__eq__(value)
+
+
+@jax_dataclasses.pytree_dataclass
+class RigidContacts(ContactModel):
+    """Rigid contacts model."""
+
+    parameters: RigidContactParams = dataclasses.field(
+        default_factory=RigidContactParams
+    )
+
+    terrain: jax_dataclasses.Static[Terrain] = dataclasses.field(
+        default_factory=FlatTerrain
+    )
+
+    def compute_contact_forces(
+        self, position: jtp.Vector, velocity: jtp.Vector, **kwargs
+    ) -> tuple[jtp.Vector, tuple[Any, ...]]:
+        pass

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -3,23 +3,131 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+import jax
+import jax.numpy as jnp
 import jax_dataclasses
+import qpax
+from jax.numpy.linalg import pinv
+from jax.scipy.linalg import block_diag
 
+import jaxsim.api as js
 import jaxsim.typing as jtp
+from jaxsim import math
+from jaxsim.api.common import VelRepr
 from jaxsim.terrain.terrain import FlatTerrain, Terrain
 
-from .common import ContactModel, ContactsParams
+from .common import ContactModel, ContactsParams, ContactsState
 
 
 @jax_dataclasses.pytree_dataclass
 class RigidContactParams(ContactsParams):
     """Parameters of the rigid contacts model."""
 
-    def __hash__(self) -> int:
-        return super().__hash__()
+    # Static friction coefficient
+    mu: jtp.Float = dataclasses.field(
+        default_factory=lambda: jnp.array(0.5, dtype=float)
+    )
 
-    def __eq__(self, value: object) -> bool:
-        return super().__eq__(value)
+    # Baumgarte proportional term
+    K: jtp.Float = dataclasses.field(
+        default_factory=lambda: jnp.array(0.0, dtype=float)
+    )
+
+    # Baumgarte derivative term
+    D: jtp.Float = dataclasses.field(
+        default_factory=lambda: jnp.array(0.0, dtype=float)
+    )
+
+    # Inactive contact points at the previous time step
+    inactive_points_prev: jtp.Vector = dataclasses.field(
+        init=False, default_factory=lambda: jnp.zeros(0)
+    )
+
+    def __hash__(self) -> int:
+        from jaxsim.utils.wrappers import HashedNumpyArray
+
+        return hash(
+            (
+                HashedNumpyArray.hash_of_array(self.mu),
+                HashedNumpyArray.hash_of_array(self.K),
+                HashedNumpyArray.hash_of_array(self.D),
+                HashedNumpyArray.hash_of_array(self.inactive_points_prev),
+            )
+        )
+
+    def __eq__(self, other: RigidContactParams) -> bool:
+        return hash(self) == hash(other)
+
+    @staticmethod
+    def build(
+        inactive_points_prev: jtp.Vector,
+        mu: jtp.Float = 0.5,
+        K: jtp.Float = 0.0,
+        D: jtp.Float = 0.0,
+    ) -> RigidContactParams:
+        """Create a `RigidContactParams` instance"""
+        return RigidContactParams(
+            mu=mu, K=K, D=D, inactive_points_prev=inactive_points_prev
+        )
+
+    @staticmethod
+    def build_from_jaxsim_model(
+        model: js.model.JaxSimModel,
+        *,
+        static_friction_coefficient: jtp.Float = 0.5,
+        K: jtp.Float = 0.0,
+        D: jtp.Float = 0.0,
+    ) -> RigidContactParams:
+        """Build a `RigidContactParams` instance from a `JaxSimModel`."""
+
+        inactive_points_prev = jnp.zeros(
+            model.kin_dyn_parameters.contact_parameters.point.shape[0]
+        )
+
+        return RigidContactParams.build(
+            mu=static_friction_coefficient,
+            K=K,
+            D=D,
+            inactive_points_prev=inactive_points_prev,
+        )
+
+    def valid(self) -> bool:
+        return bool(
+            jnp.all(self.mu >= 0.0)
+            and jnp.all(self.K >= 0.0)
+            and jnp.all(self.D >= 0.0)
+        )
+
+
+@jax_dataclasses.pytree_dataclass
+class RigidContactsState(ContactsState):
+    """Class storing the state of the rigid contacts model."""
+
+    def __hash__(self) -> int:
+        return hash(tuple(jnp.atleast_1d(self.inactive_points_prev.flatten()).tolist()))
+
+    def __eq__(self, other: RigidContactsState) -> bool:
+        return hash(self) == hash(other)
+
+    @staticmethod
+    def build_from_jaxsim_model(
+        model: js.model.JaxSimModel | None = None,
+    ) -> RigidContactsState:
+        """Build a `RigidContactsState` instance from a `JaxSimModel`."""
+        return RigidContactsState.build()
+
+    @staticmethod
+    def build() -> RigidContactsState:
+        """Create a `RigidContactsState` instance"""
+        return RigidContactsState()
+
+    @staticmethod
+    def zero(model: js.model.JaxSimModel) -> RigidContactsState:
+        """Build a zero `RigidContactsState` instance from a `JaxSimModel`."""
+        return RigidContactsState.build()
+
+    def valid(self, model: js.model.JaxSimModel) -> bool:
+        return True
 
 
 @jax_dataclasses.pytree_dataclass
@@ -34,7 +142,419 @@ class RigidContacts(ContactModel):
         default_factory=FlatTerrain
     )
 
-    def compute_contact_forces(
-        self, position: jtp.Vector, velocity: jtp.Vector, **kwargs
+    @staticmethod
+    def _detect_contacts(
+        W_o_C: jtp.Array,
+        W_o_dot_C: jtp.Array,
+        terrain_height: jtp.Array,
+        terrain_normal: jtp.Array,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
-        pass
+        """
+        Detect contacts between the collidable points and the terrain.
+        """
+
+        # TODO: reduce code duplication with js.contact.in_contact
+        def detect_contact(
+            W_o_C: jtp.Array,
+            W_o_dot_C: jtp.Array,
+            terrain_height: jtp.Float,
+            terrain_normal: jtp.Vector,
+        ) -> tuple[jtp.Vector, tuple[Any, ...]]:
+            """
+            Detect contacts between the collidable points and the terrain."""
+
+            # Unpack the position of the collidable point.
+            _px, _py, pz = W_o_C.squeeze()
+            W_o_dot_C = W_o_dot_C.squeeze()
+
+            inactive = pz > terrain_height
+
+            # Compute the terrain normal and the contact depth
+            n̂ = terrain_normal.squeeze()
+            h = jnp.array([0, 0, terrain_height - pz])
+
+            # Compute the penetration depth normal to the terrain.
+            δ = jnp.maximum(0.0, jnp.dot(h, n̂))
+
+            # Compute the penetration normal velocity.
+            δ̇ = -jnp.dot(W_o_dot_C, n̂)
+            print(f"{δ=}, {δ̇=}")
+
+            return inactive, (δ, δ̇)
+
+        inactive_collidable_points, (delta, delta_dot) = jax.vmap(detect_contact)(
+            W_o_C, W_o_dot_C, terrain_height, terrain_normal
+        )
+
+        return inactive_collidable_points, (delta, delta_dot)
+
+    @staticmethod
+    def _delassus_matrix(
+        M: jtp.Matrix,
+        J_WC: jtp.Matrix,
+    ):
+        sl = jnp.s_[:, 0:3, :]
+        J_WC_lin = jnp.vstack(J_WC[sl])
+
+        delassus_matrix = J_WC_lin @ pinv(M) @ J_WC_lin.T
+        return delassus_matrix
+
+    @staticmethod
+    def _compute_ineq_constraint_matrix(
+        inactive_collidable_points: jtp.Vector, mu: jtp.Float
+    ) -> jtp.Matrix:
+        def compute_G_single_point(mu: float, c: float) -> jtp.Matrix:
+            """
+            Compute the inequality constraint matrix for a single collidable point
+            Rows 0-3: enforce the friction pyramid constraint,
+            Row 4: last one is for the non negativity of the vertical force
+            Row 5: contact complementarity condition
+            """
+            G_single_point = jnp.array(
+                [
+                    [1, 0, -mu],
+                    [0, 1, -mu],
+                    [-1, 0, -mu],
+                    [0, -1, -mu],
+                    [0, 0, -1],
+                    [0, 0, c],
+                ]
+            )
+            return G_single_point
+
+        G = jax.vmap(compute_G_single_point, in_axes=(None, 0))(
+            mu, inactive_collidable_points
+        )
+        G = block_diag(*G)
+        return G
+
+    @staticmethod
+    def _compute_ineq_bounds(n_collidable_points: jtp.Float) -> jtp.Vector:
+        n_constraints = 6 * len(n_collidable_points)
+        return jnp.zeros(shape=(n_constraints,))
+
+    @staticmethod
+    def _compute_mixed_nu_dot(
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
+        references: js.references.JaxSimModelReferences,
+    ) -> jtp.Array:
+        references = (
+            references
+            if references is not None
+            else js.references.JaxSimModelReferences.zero(
+                model=model, data=data, velocity_representation=VelRepr.Mixed
+            )
+        )
+
+        with (
+            data.switch_velocity_representation(VelRepr.Mixed),
+            references.switch_velocity_representation(VelRepr.Mixed),
+        ):
+            BW_v_WB = data.base_velocity()
+            W_o_dot_B = BW_v_WB[0:3]
+            W_omega_WB = BW_v_WB[3:6]
+            W_v̇_WB, s̈, _ = js.ode.system_velocity_dynamics(
+                model=model,
+                data=data,
+                joint_forces=references.joint_force_references(model=model),
+                link_forces=references.link_forces(model=model, data=data),
+            )
+
+        # Convert the inertial-fixed base acceleration to a body-fixed base acceleration.
+        W_H_B = data.base_transform()
+        W_H_BW = W_H_B.at[0:3, 0:3].set(jnp.eye(3))
+        BW_H_W = math.Transform.inverse(W_H_BW)
+        BW_X_W = math.Adjoint.from_transform(
+            BW_H_W,
+        )
+        term1 = BW_X_W @ W_v̇_WB
+        term2 = jnp.zeros(6).at[0:3].set(jnp.cross(W_o_dot_B, W_omega_WB))
+        BW_v̇_WB = term1 - term2
+
+        BW_ν̇ = jnp.hstack([BW_v̇_WB, s̈])
+
+        return BW_ν̇
+
+    @staticmethod
+    def _linear_acceleration_of_collidable_points(
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
+        nu_dot_mixed: jax.Array,
+    ) -> jax.Array:
+        with data.switch_velocity_representation(VelRepr.Mixed):
+            CW_J_WC_BW = js.contact.jacobian(
+                model=model,
+                data=data,
+                output_vel_repr=VelRepr.Mixed,
+            )
+            CW_J_dot_WC_BW = js.contact.jacobian_derivative(
+                model=model,
+                data=data,
+                output_vel_repr=VelRepr.Mixed,
+            )
+
+            BW_ν = data.generalized_velocity()
+
+        CW_a_WC = jax.vmap(
+            lambda J_dot, J, nu_dot, nu: J_dot @ nu + J @ nu_dot,
+            in_axes=(0, 0, None, None),
+        )(
+            CW_J_dot_WC_BW,
+            CW_J_WC_BW,
+            nu_dot_mixed,
+            BW_ν,
+        )
+        print(f"{CW_a_WC.shape=}")
+
+        return CW_a_WC[:, 0:3].squeeze()
+
+    @staticmethod
+    def _compute_baumgarte_stabilization_term(
+        inactive_collidable_points: jax.Array,
+        delta: jax.Array,
+        delta_dot: jax.Array,
+        K: jtp.Float,
+        D: jtp.Float,
+    ) -> jtp.Array:
+        def baumgarte_stabilization(
+            inactive: bool,
+            delta: jax.Array,
+            delta_dot: jax.Array,
+            k_baumgarte: float,
+            d_baumgarte: float,
+        ) -> jtp.Array:
+            baumgarte_term = jax.lax.cond(
+                inactive,
+                lambda in_arg: jnp.zeros(shape=(3)),
+                lambda in_arg: jnp.zeros(3)
+                .at[2]
+                .set(in_arg[2] * in_arg[0] + in_arg[3] * in_arg[1]),
+                (
+                    delta,
+                    delta_dot,
+                    k_baumgarte,
+                    d_baumgarte,
+                ),
+            )
+            return baumgarte_term
+
+        baumgarte_term = jax.vmap(
+            baumgarte_stabilization, in_axes=(0, 0, 0, None, None)
+        )(
+            inactive_collidable_points,
+            delta,
+            delta_dot,
+            K,
+            D,
+        )
+
+        return baumgarte_term
+
+    @staticmethod
+    def _compute_impact_velocity(
+        inactive_collidable_points: jtp.Array,
+        inactive_collidable_points_prev: jtp.Array,
+        M: jtp.Matrix,
+        J_WC: jtp.Matrix,
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
+    ):
+        """Returns the new velocity of the system after a potential impact."""
+
+        def impact_velocity(
+            inactive_collidable_points: jtp.Array,
+            nu_pre: jtp.Array,
+            M: jtp.Matrix,
+            J_WC: jtp.Matrix,
+            data: js.data.JaxSimModelData,
+        ):
+            # Compute system velocity after impact maintaining zero linear velocity of active points
+            with data.switch_velocity_representation(VelRepr.Mixed):
+                sl = jnp.s_[:, 0:3, :]
+                J_WC_lin = J_WC[sl]
+                # Zero out the jacobian rows of inactive points
+                J_WC_lin = jax.vmap(
+                    lambda J, inactive: jax.lax.cond(
+                        inactive, lambda _: jnp.zeros_like(J), lambda _: J, operand=None
+                    )
+                )(J_WC_lin, inactive_collidable_points)
+                J_WC_lin = jnp.vstack(J_WC_lin)
+
+                I = jnp.eye(M.shape[0])
+                nu_post = (
+                    I
+                    - pinv(M)
+                    @ J_WC_lin.T
+                    @ pinv(J_WC_lin @ pinv(M) @ J_WC_lin.T)
+                    @ J_WC_lin
+                ) @ nu_pre
+                return nu_post
+
+        new_impacts = jnp.any(
+            inactive_collidable_points_prev & ~inactive_collidable_points
+        )
+        jax.debug.print("new_impacts={new_impacts}", new_impacts=new_impacts)
+
+        nu_pre = data.generalized_velocity()
+
+        nu = jax.lax.cond(
+            new_impacts,
+            lambda operands: impact_velocity(
+                model=operands["model"],
+                data=operands["data"],
+                inactive_collidable_points=operands["inactive_collidable_points"],
+                nu_pre=operands["nu_pre"],
+                M=operands["M"],
+                J_WC=operands["J_WC"],
+            ),
+            lambda operands: operands["nu_pre"],
+            dict(
+                model=model,
+                data=data,
+                inactive_collidable_points=inactive_collidable_points,
+                nu_pre=nu_pre,
+                M=M,
+                J_WC=J_WC,
+            ),
+        )
+
+        return nu
+
+    @staticmethod
+    def _compute_link_forces_inertial_fixed(
+        CW_f_C: jtp.Matrix,
+        W_H_C: jtp.Matrix,
+    ):
+        def convert_wrench_mixed_to_inertial(
+            W_H_C: jax.Array, CW_f: jax.Array
+        ) -> jax.Array:
+            W_H_CW = W_H_C.at[0:3, 0:3].set(jnp.eye(3))
+            CW_H_W = math.Transform.inverse(W_H_CW)
+            CW_X_W = math.Adjoint.from_transform(
+                CW_H_W,
+            )
+            W_Xf_CW = CW_X_W.T
+            return W_Xf_CW @ CW_f
+
+        W_f_C = jax.vmap(convert_wrench_mixed_to_inertial)(W_H_C, CW_f_C)
+        return W_f_C
+
+    def compute_contact_forces(
+        self,
+        position: jtp.Vector,
+        velocity: jtp.Vector,
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
+    ) -> tuple[jtp.Vector, tuple[Any, ...]]:
+        # Compute kin-dyn quantities used in the contact model
+        with data.switch_velocity_representation(VelRepr.Mixed):
+            M = js.model.free_floating_mass_matrix(model=model, data=data)
+            J_WC = js.contact.jacobian(model=model, data=data)
+            W_H_C = js.contact.transforms(model=model, data=data)
+        inactive_collisable_points_prev = self.parameters.inactive_points_prev
+        terrain_height = jax.vmap(self.terrain.height)(position[:, 0], position[:, 1])
+        terrain_normal = jax.vmap(self.terrain.normal)(position[:, 0], position[:, 1])
+        n_collidable_points = model.kin_dyn_parameters.contact_parameters.point.shape[0]
+
+        # Compute the activation state of the collidable points
+        inactive_collidable_points, (delta, delta_dot) = RigidContacts._detect_contacts(
+            W_o_C=position,
+            W_o_dot_C=velocity,
+            terrain_height=terrain_height,
+            terrain_normal=terrain_normal,
+        )
+
+        delassus_matrix = RigidContacts._delassus_matrix(M=M, J_WC=J_WC)
+        # Make it symmetric if not
+        delassus_matrix = jax.lax.cond(
+            jnp.allclose(delassus_matrix, delassus_matrix.T),
+            lambda G: G,
+            lambda G: (G + G.T) / 2,
+            delassus_matrix,
+        )
+        # Add regularization for better numerical conditioning
+        delassus_matrix = delassus_matrix + 1e-6 * jnp.eye(delassus_matrix.shape[0])
+
+        nu_dot_free_mixed = RigidContacts._compute_mixed_nu_dot(
+            model, data, references=None
+        )
+
+        free_contact_acc = RigidContacts._linear_acceleration_of_collidable_points(
+            model,
+            data,
+            nu_dot_free_mixed,
+        )
+        # Compute stabilization term
+        baumgarte_term = RigidContacts._compute_baumgarte_stabilization_term(
+            inactive_collidable_points=inactive_collidable_points,
+            delta=delta,
+            delta_dot=delta_dot,
+            K=self.parameters.K,
+            D=self.parameters.D,
+        ).flatten()
+        free_contact_acc -= baumgarte_term
+
+        # Setup optimization problem
+        Q = delassus_matrix
+        q = free_contact_acc
+        G = RigidContacts._compute_ineq_constraint_matrix(
+            inactive_collidable_points=inactive_collidable_points, mu=self.parameters.mu
+        )
+        h = RigidContacts._compute_ineq_bounds(n_collidable_points=n_collidable_points)
+        A = jnp.zeros((0, 3 * n_collidable_points))
+        b = jnp.zeros((0,))
+
+        jax.debug.print(
+            "Shapes: Q={Q}, q={q}, A={A}, b={b}, G={G}, h={h}",
+            Q=Q.shape,
+            q=q.shape,
+            A=A.shape,
+            b=b.shape,
+            G=G.shape,
+            h=h.shape,
+        )
+
+        # Solve the optimization problem
+        solution, s, z, y, converged, iters = qpax.solve_qp(
+            Q=Q, q=q, A=A, b=b, G=G, h=h
+        )
+
+        jax.debug.print(
+            "x={x}, s={s}, z={z}, y={y}, converged={converged}, iters={iters}",
+            x=solution,
+            s=s,
+            z=z,
+            y=y,
+            converged=converged,
+            iters=iters,
+        )
+
+        f_C_lin = solution.reshape(-1, 3)
+
+        # Compute the impact velocity
+        nu = RigidContacts._compute_impact_velocity(
+            model=model,
+            data=data,
+            inactive_collidable_points=inactive_collidable_points,
+            inactive_collidable_points_prev=inactive_collisable_points_prev,
+            M=M,
+            J_WC=J_WC,
+        )
+
+        self.parameters.inactive_points_prev = inactive_collidable_points
+
+        # Transform linear contact forces to 6D
+        CW_f_C = jnp.hstack(
+            (
+                f_C_lin,
+                jnp.zeros((f_C_lin.shape[0], 3)),
+            )
+        )
+
+        # Transform the contact forces to inertial-fixed representation
+        W_f_C = RigidContacts._compute_link_forces_inertial_fixed(
+            CW_f_C=CW_f_C, W_H_C=W_H_C
+        )
+
+        return W_f_C, (nu)

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -6,7 +6,6 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
-import qpax
 from jax.numpy.linalg import pinv
 from jax.scipy.linalg import block_diag
 
@@ -451,6 +450,9 @@ class RigidContacts(ContactModel):
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
+        # Import qpax just in this method
+        import qpax
+
         # Compute kin-dyn quantities used in the contact model
         with data.switch_velocity_representation(VelRepr.Mixed):
             M = js.model.free_floating_mass_matrix(model=model, data=data)

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -51,14 +51,19 @@ class RigidContactParams(ContactsParams):
     def __eq__(self, other: RigidContactParams) -> bool:
         return hash(self) == hash(other)
 
-    @staticmethod
+    @classmethod
     def build(
-        mu: jtp.Float = 0.5,
-        K: jtp.Float = 0.0,
-        D: jtp.Float = 0.0,
+        cls,
+        mu: jtp.Float | None = None,
+        K: jtp.Float | None = None,
+        D: jtp.Float | None = None,
     ) -> RigidContactParams:
         """Create a `RigidContactParams` instance"""
-        return RigidContactParams(mu=mu, K=K, D=D)
+        return RigidContactParams(
+            mu=mu or cls.__dataclass_fields__["mu"].default,
+            K=K or cls.__dataclass_fields__["K"].default,
+            D=D or cls.__dataclass_fields__["D"].default,
+        )
 
     def valid(self) -> bool:
         return bool(

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -17,7 +17,7 @@ from .common import ContactModel, ContactsParams, ContactsState
 
 
 @jax_dataclasses.pytree_dataclass
-class RigidContactParams(ContactsParams):
+class RigidContactsParams(ContactsParams):
     """Parameters of the rigid contacts model."""
 
     # Static friction coefficient
@@ -46,7 +46,7 @@ class RigidContactParams(ContactsParams):
             )
         )
 
-    def __eq__(self, other: RigidContactParams) -> bool:
+    def __eq__(self, other: RigidContactsParams) -> bool:
         return hash(self) == hash(other)
 
     @classmethod
@@ -55,9 +55,9 @@ class RigidContactParams(ContactsParams):
         mu: jtp.FloatLike | None = None,
         K: jtp.FloatLike | None = None,
         D: jtp.FloatLike | None = None,
-    ) -> RigidContactParams:
+    ) -> RigidContactsParams:
         """Create a `RigidContactParams` instance"""
-        return RigidContactParams(
+        return RigidContactsParams(
             mu=mu or cls.__dataclass_fields__["mu"].default,
             K=K or cls.__dataclass_fields__["K"].default,
             D=D or cls.__dataclass_fields__["D"].default,
@@ -97,8 +97,8 @@ class RigidContactsState(ContactsState):
 class RigidContacts(ContactModel):
     """Rigid contacts model."""
 
-    parameters: RigidContactParams = dataclasses.field(
-        default_factory=RigidContactParams
+    parameters: RigidContactsParams = dataclasses.field(
+        default_factory=RigidContactsParams
     )
 
     terrain: jax_dataclasses.Static[Terrain] = dataclasses.field(

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -467,7 +467,7 @@ class RigidContacts(ContactModel):
             baumgarte_term = jax.lax.cond(
                 inactive,
                 lambda δ, δ̇, K, D: jnp.zeros(shape=(3,)),
-                lambda δ, δ̇, K, D: jnp.zeros(3).at[2].set(K * δ + D * δ̇),
+                lambda δ, δ̇, K, D: jnp.zeros(shape=(3,)).at[2].set(K * δ + D * δ̇),
                 *(
                     delta,
                     delta_dot,

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -226,7 +226,7 @@ class RigidContacts(ContactModel):
         velocity: jtp.Vector,
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData,
-        link_external_forces: jtp.MatrixLike | None = None,
+        link_forces: jtp.MatrixLike | None = None,
         regularization_term: jtp.FloatLike = 1e-6,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
         """
@@ -237,7 +237,7 @@ class RigidContacts(ContactModel):
             velocity: The linear velocity of the collidable point.
             model: The `JaxSimModel` instance.
             data: The `JaxSimModelData` instance.
-            link_external_forces: Optional `(n_links, 6)` matrix of external forces acting on the links,
+            link_forces: Optional `(n_links, 6)` matrix of external forces acting on the links,
                 expressed in the same representation of data.
             regularization_term: The regularization term to add to the diagonal of the Delassus
                 matrix for better numerical conditioning.
@@ -249,9 +249,9 @@ class RigidContacts(ContactModel):
         # Import qpax just in this method
         import qpax
 
-        link_external_forces = (
-            link_external_forces
-            if link_external_forces is not None
+        link_forces = (
+            link_forces
+            if link_forces is not None
             else jnp.zeros((model.number_of_links(), 6))
         )
 
@@ -283,7 +283,7 @@ class RigidContacts(ContactModel):
             model=model,
             data=data,
             velocity_representation=data.velocity_representation,
-            link_forces=link_external_forces,
+            link_forces=link_forces,
         )
 
         with references.switch_velocity_representation(VelRepr.Mixed):


### PR DESCRIPTION
This PR adds rigid-contacts as an alternative contact model along with the default soft-contacts model.

Major changes:
- Add `rigid.py` containing implementations of `ContactsState`, `ContactParams` and `ContactModel` for rigid contacts;
- Make `ContactsState`, `ContactParams` and `ContactModel` inherit from `JaxsimDataclass`;
- Add [qpax](https://github.com/kevin-tracy/qpax) solver as a new dependency;
- Generalize the use of different contact models each with different auxiliary parameters in `integrators.common.py`(e.g. now the tangential deformation rate $\dot m$ is an auxiliary parameter for soft contacts)
- Allow auxiliary contact state to be passed to `model.step` without being integrated;
- In `ode.py`, refactor the computation of system acceleration in a separate `system_acceleration` function (to not incur into circular references when computing the free acceleration in rigid contacts).


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--218.org.readthedocs.build//218/

<!-- readthedocs-preview jaxsim end -->