### PR TITLE
Add scheduled workflow configuration to update `pixi` lockfile

### DIFF
--- a/.github/workflows/update_pixi_lockfile.yml
+++ b/.github/workflows/update_pixi_lockfile.yml
@@ -30,12 +30,6 @@ jobs:
           set -o pipefail
           pixi update --json | pixi exec pixi-diff-to-markdown --explicit-column > diff.md
 
-      - name: Configure Git for LFS
-        run: |
-          git lfs install
-          git config --global user.name 'github-actions'
-          git config --global user.email 'actions@github.com'
-
       - name: Commit and push changes
         run: |
           echo "BRANCH_NAME=update-pixi-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV

--- a/.github/workflows/update_pixi_lockfile.yml
+++ b/.github/workflows/update_pixi_lockfile.yml
@@ -1,0 +1,56 @@
+name: Update pixi lockfile
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 5 1 * *
+
+jobs:
+  pixi-update:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          run-install: false
+
+      - name: Install pixi-diff-to-markdown
+        run: pip install pixi-diff-to-markdown
+
+      - name: Update pixi lockfile and generate diff
+        run: |
+          set -o pipefail
+          pixi update --json --no-install
+          pixi-diff-to-markdown --explicit-column=true --hide=false > diff.md
+
+      - name: Configure Git for LFS
+        run: |
+          git lfs install
+          git config --global user.name 'github-actions'
+          git config --global user.email 'actions@github.com'
+
+      - name: Commit and push changes
+        run: |
+          git add pixi.lock
+          git commit -m "Update pixi.lock file"
+          git push origin HEAD:update-pixi
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: This PR updates the `pixi` lockfile.
+          title: Update `pixi` lockfile
+          body-path: diff.md
+          branch: update-pixi
+          base: main
+          labels: pixi
+          delete-branch: true

--- a/.github/workflows/update_pixi_lockfile.yml
+++ b/.github/workflows/update_pixi_lockfile.yml
@@ -39,9 +39,11 @@ jobs:
 
       - name: Commit and push changes
         run: |
+          BRANCH_NAME="update-pixi-$(date +'%Y%m%d%H%M%S')"
+          git checkout -b "$BRANCH_NAME"
           git add pixi.lock
           git commit -m "Update pixi.lock file"
-          git push origin HEAD:update-pixi
+          git push origin HEAD:"$BRANCH_NAME"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
@@ -50,7 +52,7 @@ jobs:
           commit-message: This PR updates the `pixi` lockfile.
           title: Update `pixi` lockfile
           body-path: diff.md
-          branch: update-pixi
+          branch: ${{ github.ref_name }}
           base: main
           labels: pixi
           delete-branch: true

--- a/.github/workflows/update_pixi_lockfile.yml
+++ b/.github/workflows/update_pixi_lockfile.yml
@@ -23,13 +23,12 @@ jobs:
           run-install: false
 
       - name: Install pixi-diff-to-markdown
-        run: pip install pixi-diff-to-markdown
+        run: pixi global install pixi-diff-to-markdown
 
       - name: Update pixi lockfile and generate diff
         run: |
           set -o pipefail
-          pixi update --json --no-install
-          pixi-diff-to-markdown --explicit-column=true --hide=false > diff.md
+          pixi update --json | pixi exec pixi-diff-to-markdown --explicit-column > diff.md
 
       - name: Configure Git for LFS
         run: |
@@ -39,20 +38,16 @@ jobs:
 
       - name: Commit and push changes
         run: |
-          BRANCH_NAME="update-pixi-$(date +'%Y%m%d%H%M%S')"
-          git checkout -b "$BRANCH_NAME"
-          git add pixi.lock
-          git commit -m "Update pixi.lock file"
-          git push origin HEAD:"$BRANCH_NAME"
+          echo "BRANCH_NAME=update-pixi-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: This PR updates the `pixi` lockfile.
+          commit-message: Update `pixi.lock`
           title: Update `pixi` lockfile
           body-path: diff.md
-          branch: ${{ github.ref_name }}
+          branch: ${{ env.BRANCH_NAME }}
           base: main
           labels: pixi
           delete-branch: true

--- a/.github/workflows/update_pixi_lockfile.yml
+++ b/.github/workflows/update_pixi_lockfile.yml
@@ -50,4 +50,5 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           base: main
           labels: pixi
+          add-paths: pixi.lock
           delete-branch: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ pytest-icdiff = "*"
 robot_descriptions = "*"
 
 [tool.pixi.feature.gpu]
-dependencies = { cuda-version = "12.*", cuda-cupti = "*", jaxlib = "**cuda*" }
+dependencies = { cuda-version = "12.*", cuda-cupti = "*" }
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.1" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,9 +206,13 @@ pytest-icdiff = "*"
 robot_descriptions = "*"
 
 [tool.pixi.feature.gpu]
-dependencies = { cuda-version = "12.*", cuda-cupti = "*" }
 platforms = ["linux-64"]
 system-requirements = { cuda = "12.1" }
+
+[tool.pixi.feature.gpu.dependencies]
+cuda-cupti = "*"
+cuda-version = "12.*"
+jaxlib = {version = "*", build = "*cuda*"}
 
 [tool.pixi.pypi-dependencies]
 jaxsim = { path = "./", editable = true }


### PR DESCRIPTION
This PR adds a CI configuration to automatically update the `pixi.lock` with LFS support.

For the time being, since we have a PyPI dependecies, the workflow will take a bit more since it will try to install the update dependencies in the CI environment. We can re-add the `--no-install` option removed in https://github.com/ami-iit/jaxsim/pull/221/commits/ec00306cb264cac69fb7e02d340a863409decd04 as soon as https://github.com/conda-forge/staged-recipes/pull/27137 gets merged. 


Note that it will be necessary to allow Github Actions to create/approve PRs from `Settings` :arrow_right:  `Actions` :arrow_right: `General` (already checked with current settings):

![image](https://github.com/user-attachments/assets/d661cacf-244c-4e68-9fd7-eb62f004ae43)

Example PR: https://github.com/flferretti/jaxsim/pull/14

Solves #199 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--221.org.readthedocs.build//221/

<!-- readthedocs-preview jaxsim end -->