### PR TITLE
Add `pyupgrade` configuration and update to latest `ruff` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ select = [
     "I",
     "W",
     "RUF",
+    "UP",
     "YTT",
 ]
 

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -3,6 +3,7 @@ import contextlib
 import dataclasses
 import enum
 import functools
+from collections.abc import Iterator
 
 import jax
 import jax.numpy as jnp
@@ -43,7 +44,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     @contextlib.contextmanager
     def switch_velocity_representation(
         self, velocity_representation: VelRepr
-    ) -> contextlib.AbstractContextManager[Self]:
+    ) -> Iterator[Self]:
         """
         Context manager to temporarily switch the velocity representation.
 

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -3,7 +3,6 @@ import contextlib
 import dataclasses
 import enum
 import functools
-from typing import ContextManager
 
 import jax
 import jax.numpy as jnp
@@ -44,7 +43,7 @@ class ModelDataWithVelocityRepresentation(JaxsimDataclass, abc.ABC):
     @contextlib.contextmanager
     def switch_velocity_representation(
         self, velocity_representation: VelRepr
-    ) -> ContextManager[Self]:
+    ) -> contextlib.AbstractContextManager[Self]:
         """
         Context manager to temporarily switch the velocity representation.
 

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -163,7 +163,7 @@ def collidable_point_dynamics(
             )
 
         case _:
-            raise ValueError("Invalid contact model {}".format(model.contact_model))
+            raise ValueError(f"Invalid contact model {model.contact_model}")
 
     # Convert the 6D forces to the active representation.
     f_Ci = jax.vmap(

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import functools
-from typing import Sequence
+from collections.abc import Sequence
 
 import jax
 import jax.numpy as jnp

--- a/src/jaxsim/api/frame.py
+++ b/src/jaxsim/api/frame.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Sequence
+from collections.abc import Sequence
 
 import jax
 import jax.numpy as jnp

--- a/src/jaxsim/api/joint.py
+++ b/src/jaxsim/api/joint.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Sequence
+from collections.abc import Sequence
 
 import jax
 import jax.numpy as jnp

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Sequence
+from collections.abc import Sequence
 
 import jax
 import jax.numpy as jnp

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -4,7 +4,8 @@ import copy
 import dataclasses
 import functools
 import pathlib
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import jax
 import jax.numpy as jnp

--- a/src/jaxsim/integrators/common.py
+++ b/src/jaxsim/integrators/common.py
@@ -1,6 +1,6 @@
 import abc
 import dataclasses
-from typing import Any, ClassVar, Generic, Protocol, Type, TypeVar
+from typing import Any, ClassVar, Generic, Protocol, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -64,7 +64,7 @@ class Integrator(JaxsimDataclass, abc.ABC, Generic[State, StateDerivative]):
 
     @classmethod
     def build(
-        cls: Type[Self],
+        cls: type[Self],
         *,
         dynamics: SystemDynamics[State, StateDerivative],
         **kwargs,
@@ -224,7 +224,7 @@ class ExplicitRungeKutta(Integrator[PyTreeType, PyTreeType], Generic[PyTreeType]
     @override
     @classmethod
     def build(
-        cls: Type[Self],
+        cls: type[Self],
         *,
         dynamics: SystemDynamics[State, StateDerivative],
         fsal_enabled_if_supported: jtp.BoolLike = True,

--- a/src/jaxsim/integrators/variable_step.py
+++ b/src/jaxsim/integrators/variable_step.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Any, ClassVar, Generic, Type
+from typing import Any, ClassVar, Generic
 
 try:
     from typing import Self
@@ -495,7 +495,7 @@ class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
     @classmethod
     def build(
-        cls: Type[Self],
+        cls: type[Self],
         *,
         dynamics: SystemDynamics[State, StateDerivative],
         fsal_enabled_if_supported: jtp.BoolLike = True,

--- a/src/jaxsim/logging.py
+++ b/src/jaxsim/logging.py
@@ -1,6 +1,5 @@
 import enum
 import logging
-from typing import Union
 
 import coloredlogs
 
@@ -20,7 +19,7 @@ def _logger() -> logging.Logger:
     return logging.getLogger(name=LOGGER_NAME)
 
 
-def set_logging_level(level: Union[int, LoggingLevel] = LoggingLevel.WARNING):
+def set_logging_level(level: int | LoggingLevel = LoggingLevel.WARNING):
     if isinstance(level, int):
         level = LoggingLevel(level)
 

--- a/src/jaxsim/math/inertia.py
+++ b/src/jaxsim/math/inertia.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import jax.numpy as jnp
 
 import jaxsim.typing as jtp
@@ -39,7 +37,7 @@ class Inertia:
         return M
 
     @staticmethod
-    def to_params(M: jtp.Matrix) -> Tuple[jtp.Float, jtp.Vector, jtp.Matrix]:
+    def to_params(M: jtp.Matrix) -> tuple[jtp.Float, jtp.Vector, jtp.Matrix]:
         """
         Convert a 6x6 inertia matrix to mass, center of mass, and inertia matrix.
 

--- a/src/jaxsim/math/joint_model.py
+++ b/src/jaxsim/math/joint_model.py
@@ -107,7 +107,7 @@ class JointModel:
             λ_H_pre=λ_H_pre,
             suc_H_i=suc_H_i,
             # Static attributes
-            joint_dofs=tuple([base_dofs] + [int(1) for _ in ordered_joints]),
+            joint_dofs=tuple([base_dofs] + [1 for _ in ordered_joints]),
             joint_names=tuple(["world_to_base"] + [j.name for j in ordered_joints]),
             joint_types=tuple([JointType.Fixed] + [j.jtype for j in ordered_joints]),
             joint_axis=tuple(JointGenericAxis(axis=j.axis) for j in ordered_joints),

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import jax
 import jax.numpy as jnp
 import jaxlie
@@ -64,7 +62,7 @@ class Rotation:
         vector = vector.squeeze()
         theta = jnp.linalg.norm(vector)
 
-        def theta_is_not_zero(theta_and_v: Tuple[jtp.Float, jtp.Vector]) -> jtp.Matrix:
+        def theta_is_not_zero(theta_and_v: tuple[jtp.Float, jtp.Vector]) -> jtp.Matrix:
             theta, v = theta_and_v
 
             s = jnp.sin(theta)

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -4,7 +4,8 @@ import dataclasses
 import pathlib
 import tempfile
 import warnings
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import mujoco as mj
 import numpy as np

--- a/src/jaxsim/mujoco/model.py
+++ b/src/jaxsim/mujoco/model.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import functools
 import pathlib
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import mujoco as mj
 import numpy as np

--- a/src/jaxsim/mujoco/visualizer.py
+++ b/src/jaxsim/mujoco/visualizer.py
@@ -1,6 +1,6 @@
 import contextlib
 import pathlib
-from typing import ContextManager, Sequence
+from collections.abc import Sequence
 
 import mediapy as media
 import mujoco as mj
@@ -172,7 +172,7 @@ class MujocoVisualizer:
         distance: float | int | npt.NDArray | None = None,
         azimut: float | int | npt.NDArray | None = None,
         elevation: float | int | npt.NDArray | None = None,
-    ) -> ContextManager[mujoco.viewer.Handle]:
+    ) -> contextlib.AbstractContextManager[mujoco.viewer.Handle]:
         """
         Context manager to open the Mujoco passive viewer.
 

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import itertools
-from typing import Sequence
+from collections.abc import Sequence
 
 from jaxsim import logging
 

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import copy
 import dataclasses
 import functools
-from typing import Any, Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -445,7 +445,7 @@ class KinematicGraph(Sequence[LinkDescription]):
                 msg.format(
                     link_to_remove.name,
                     self.joints_connection_dict[
-                        (parent_of_link_to_remove.name, link_to_remove.name)
+                        parent_of_link_to_remove.name, link_to_remove.name
                     ].name,
                     parent_of_link_to_remove.name,
                 )
@@ -853,7 +853,7 @@ class KinematicGraphTransforms:
 
             # Get the joint between the link and its parent.
             parent_joint = self.graph.joints_connection_dict[
-                (link.parent.name, link.name)
+                link.parent.name, link.name
             ]
 
             # Get the transform of the parent joint.

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -1,6 +1,6 @@
 import dataclasses
 import pathlib
-from typing import Dict, List, NamedTuple, Optional, Union
+from typing import NamedTuple
 
 import jax.numpy as jnp
 import numpy as np
@@ -23,17 +23,17 @@ class SDFData(NamedTuple):
     fixed_base: bool
     base_link_name: str
 
-    link_descriptions: List[descriptions.LinkDescription]
-    joint_descriptions: List[descriptions.JointDescription]
-    frame_descriptions: List[descriptions.LinkDescription]
-    collision_shapes: List[descriptions.CollisionShape]
+    link_descriptions: list[descriptions.LinkDescription]
+    joint_descriptions: list[descriptions.JointDescription]
+    frame_descriptions: list[descriptions.LinkDescription]
+    collision_shapes: list[descriptions.CollisionShape]
 
     sdf_model: rod.Model | None = None
     model_pose: kinematic_graph.RootPose = kinematic_graph.RootPose()
 
 
 def extract_model_data(
-    model_description: Union[pathlib.Path, str, rod.Model],
+    model_description: pathlib.Path | str | rod.Model,
     model_name: str | None = None,
     is_urdf: bool | None = None,
 ) -> SDFData:
@@ -114,7 +114,7 @@ def extract_model_data(
     ]
 
     # Create a dictionary to find easily links.
-    links_dict: Dict[str, descriptions.LinkDescription] = {l.name: l for l in links}
+    links_dict: dict[str, descriptions.LinkDescription] = {l.name: l for l in links}
 
     # ============
     # Parse frames
@@ -304,7 +304,7 @@ def extract_model_data(
     # ================
 
     # Initialize the collision shapes
-    collisions: List[descriptions.CollisionShape] = []
+    collisions: list[descriptions.CollisionShape] = []
 
     # Parse the collisions
     for link in sdf_model.links():
@@ -339,8 +339,8 @@ def extract_model_data(
 
 
 def build_model_description(
-    model_description: Union[pathlib.Path, str, rod.Model],
-    is_urdf: Optional[bool] = False,
+    model_description: pathlib.Path | str | rod.Model,
+    is_urdf: bool | None = False,
 ) -> descriptions.ModelDescription:
     """
     Builds a model description from an SDF/URDF resource.

--- a/src/jaxsim/rbda/rnea.py
+++ b/src/jaxsim/rbda/rnea.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 import jax
 import jax.numpy as jnp
 import jaxlie
@@ -25,7 +23,7 @@ def rnea(
     joint_accelerations: jtp.Vector | None = None,
     link_forces: jtp.Matrix | None = None,
     standard_gravity: jtp.FloatLike = StandardGravity,
-) -> Tuple[jtp.Vector, jtp.Vector]:
+) -> tuple[jtp.Vector, jtp.Vector]:
     """
     Compute inverse dynamics using the Recursive Newton-Euler Algorithm (RNEA).
 
@@ -132,12 +130,12 @@ def rnea(
     # Pass 1
     # ======
 
-    ForwardPassCarry = Tuple[jtp.Matrix, jtp.Matrix, jtp.Matrix, jtp.Matrix]
+    ForwardPassCarry = tuple[jtp.Matrix, jtp.Matrix, jtp.Matrix, jtp.Matrix]
     forward_pass_carry: ForwardPassCarry = (v, a, i_X_0, f)
 
     def forward_pass(
         carry: ForwardPassCarry, i: jtp.Int
-    ) -> Tuple[ForwardPassCarry, None]:
+    ) -> tuple[ForwardPassCarry, None]:
 
         ii = i - 1
         v, a, i_X_0, f = carry
@@ -186,12 +184,12 @@ def rnea(
 
     τ = jnp.zeros_like(s)
 
-    BackwardPassCarry = Tuple[jtp.Vector, jtp.Matrix]
+    BackwardPassCarry = tuple[jtp.Vector, jtp.Matrix]
     backward_pass_carry: BackwardPassCarry = (τ, f)
 
     def backward_pass(
         carry: BackwardPassCarry, i: jtp.Int
-    ) -> Tuple[BackwardPassCarry, None]:
+    ) -> tuple[BackwardPassCarry, None]:
 
         ii = i - 1
         τ, f = carry

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -2,8 +2,8 @@ import abc
 import contextlib
 import dataclasses
 import functools
-from collections.abc import Iterator
-from typing import Any, Callable, ClassVar, Sequence, Type
+from collections.abc import Callable, Iterator, Sequence
+from typing import Any, ClassVar
 
 import jax.flatten_util
 import jax_dataclasses
@@ -337,7 +337,7 @@ class JaxsimDataclass(abc.ABC):
         return self.flatten_fn()(self)
 
     @classmethod
-    def flatten_fn(cls: Type[Self]) -> Callable[[Self], jtp.Vector]:
+    def flatten_fn(cls: type[Self]) -> Callable[[Self], jtp.Vector]:
         """
         Return a function to flatten the object into a 1D vector.
 

--- a/src/jaxsim/utils/wrappers.py
+++ b/src/jaxsim/utils/wrappers.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import Callable, Generic, TypeVar
+from collections.abc import Callable
+from typing import Generic, TypeVar
 
 import jax
 import jax_dataclasses

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -36,7 +36,7 @@ def test_model_creation_and_reduction(
     assert data_full.valid(model=model_full)
 
     # Build the ROD model from the original description.
-    assert isinstance(model_full.built_from, (str, pathlib.Path))
+    assert isinstance(model_full.built_from, str | pathlib.Path)
     rod_sdf = rod.Sdf.load(sdf=model_full.built_from)
     assert len(rod_sdf.models()) == 1
 


### PR DESCRIPTION
This PR applies the necessary modifications to align with the latest `ruff` version. Moreover, the `pyupgrade` configuration has been added to the linter in order to have a simpler control on the codestyle.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--226.org.readthedocs.build//226/

<!-- readthedocs-preview jaxsim end -->