### PR TITLE
Add support for sampling `JaxSimModelData` objects with random base orientation

### DIFF
--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -739,6 +739,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         )
 
 
+@functools.partial(jax.jit, static_argnames=["velocity_representation", "base_rpy_seq"])
 def random_model_data(
     model: js.model.JaxSimModel,
     *,


### PR DESCRIPTION
The logic uses a sequence of three Euler angles and allows to specify the sequence with a string compatible with [`scipy.spatial.transform.Rotation.from_euler()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.transform.Rotation.from_euler.html).

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--230.org.readthedocs.build//230/

<!-- readthedocs-preview jaxsim end -->