### PR TITLE
Fix `jaxsim.api.model.link_contact_forces`

### DIFF
--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -132,8 +132,15 @@ def system_velocity_dynamics(
     # with the terrain.
     W_f_Li_terrain = jnp.zeros_like(O_f_L).astype(float)
 
+    # Initialize a dictionary of auxiliary data.
+    # This dictionary is used to store additional data computed by the contact model.
     aux_data = {}
+
     if len(model.kin_dyn_parameters.contact_parameters.body) > 0:
+
+        # Note: the following code should be kept in sync with the function
+        # `jaxsim.api.model.link_contact_forces`. We cannot merge them since
+        # here we need to get also aux_data.
 
         # Compute the 6D forces W_f ∈ ℝ^{n_c × 6} applied to each collidable point
         # along with contact-specific auxiliary states.


### PR DESCRIPTION
This function was a leftover from when we updated the velocity representation of the model Jacobian to not use $B$ and $B[W]$ in body-fixed and mixed in favor of $L$ and $L[W]$ (https://github.com/ami-iit/jaxsim/pull/167).

Luckily this method was not used elsewhere in the code -- and probably this is why this leftover got under our radar. However, there was a script on which @xela-95 and us worked that was calling this function. Everything was correct it inerital-fixed, but things were not correct in other velocity representations.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--232.org.readthedocs.build//232/

<!-- readthedocs-preview jaxsim end -->