### PR TITLE
Account for joint torques in the rigid contact models

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -117,6 +117,7 @@ def collidable_point_dynamics(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
     link_forces: jtp.MatrixLike | None = None,
+    joint_force_references: jtp.VectorLike | None = None,
 ) -> tuple[jtp.Matrix, dict[str, jtp.Array]]:
     r"""
     Compute the 6D force applied to each collidable point.
@@ -127,6 +128,8 @@ def collidable_point_dynamics(
         link_forces:
             The 6D external forces to apply to the links expressed in the same
             representation of data.
+        joint_force_references:
+            The joint force references to apply to the joints.
 
     Returns:
         The 6D force applied to each collidable point and additional data based on the contact model configured:
@@ -191,6 +194,7 @@ def collidable_point_dynamics(
                 model=model,
                 data=data,
                 link_forces=link_forces,
+                joint_force_reference=jacobian_derivative,
             )
 
             aux_data = dict()
@@ -212,6 +216,7 @@ def collidable_point_dynamics(
                 model=model,
                 data=data,
                 link_forces=link_forces,
+                joint_force_references=joint_force_references,
             )
 
             aux_data = dict()

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -194,7 +194,7 @@ def collidable_point_dynamics(
                 model=model,
                 data=data,
                 link_forces=link_forces,
-                joint_force_reference=jacobian_derivative,
+                joint_force_references=joint_force_references,
             )
 
             aux_data = dict()

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -95,7 +95,7 @@ def system_velocity_dynamics(
     Args:
         model: The model to consider.
         data: The data of the considered model.
-        joint_forces: The joint forces to apply.
+        joint_forces: The joint force references to apply.
         link_forces:
             The 6D forces to apply to the links expressed in the frame corresponding to
             the velocity representation of `data`.
@@ -120,6 +120,7 @@ def system_velocity_dynamics(
     references = js.references.JaxSimModelReferences.build(
         model=model,
         link_forces=O_f_L,
+        joint_forces=joint_forces,
         data=data,
         velocity_representation=data.velocity_representation,
     )
@@ -149,6 +150,7 @@ def system_velocity_dynamics(
                 model=model,
                 data=data,
                 link_forces=references.link_forces(model=model, data=data),
+                joint_forces=references.joint_force_references(model=model),
             )
 
         # Construct the vector defining the parent link index of each collidable point.

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -120,7 +120,7 @@ def system_velocity_dynamics(
     references = js.references.JaxSimModelReferences.build(
         model=model,
         link_forces=O_f_L,
-        joint_forces=joint_forces,
+        joint_force_references=joint_forces,
         data=data,
         velocity_representation=data.velocity_representation,
     )
@@ -150,7 +150,7 @@ def system_velocity_dynamics(
                 model=model,
                 data=data,
                 link_forces=references.link_forces(model=model, data=data),
-                joint_forces=references.joint_force_references(model=model),
+                joint_force_references=references.joint_force_references(model=model),
             )
 
         # Construct the vector defining the parent link index of each collidable point.

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -202,7 +202,7 @@ class RelaxedRigidContacts(ContactModel):
             link_forces:
                 Optional `(n_links, 6)` matrix of external forces acting on the links,
                 expressed in the same representation of data.
-            joint_force_reference:
+            joint_force_references:
                 Optional `(n_joints,)` vector of joint forces.
 
         Returns:
@@ -226,6 +226,7 @@ class RelaxedRigidContacts(ContactModel):
             data=data,
             velocity_representation=data.velocity_representation,
             link_forces=link_forces,
+            joint_force_references=joint_force_references,
         )
 
         def _detect_contact(x: jtp.Array, y: jtp.Array, z: jtp.Array) -> jtp.Array:

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -189,12 +189,19 @@ class RelaxedRigidContacts(ContactModel):
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData,
         link_forces: jtp.MatrixLike | None = None,
+        joint_force_references: jtp.VectorLike | None = None,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
 
         link_forces = (
             link_forces
             if link_forces is not None
             else jnp.zeros((model.number_of_links(), 6))
+        )
+
+        joint_force_references = (
+            joint_force_references
+            if joint_force_references is not None
+            else jnp.zeros((model.number_of_joints(),))
         )
 
         references = js.references.JaxSimModelReferences.build(

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -191,6 +191,23 @@ class RelaxedRigidContacts(ContactModel):
         link_forces: jtp.MatrixLike | None = None,
         joint_force_references: jtp.VectorLike | None = None,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
+        """
+        Compute the contact forces.
+
+        Args:
+            position: The position of the collidable point.
+            velocity: The linear velocity of the collidable point.
+            model: The `JaxSimModel` instance.
+            data: The `JaxSimModelData` instance.
+            link_forces:
+                Optional `(n_links, 6)` matrix of external forces acting on the links,
+                expressed in the same representation of data.
+            joint_force_reference:
+                Optional `(n_joints,)` vector of joint forces.
+
+        Returns:
+            A tuple containing the contact forces.
+        """
 
         link_forces = (
             link_forces

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -218,7 +218,7 @@ class RelaxedRigidContacts(ContactModel):
         joint_force_references = (
             joint_force_references
             if joint_force_references is not None
-            else jnp.zeros((model.number_of_joints(),))
+            else jnp.zeros(model.number_of_joints())
         )
 
         references = js.references.JaxSimModelReferences.build(

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -213,6 +213,7 @@ class RigidContacts(ContactModel):
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData,
         link_forces: jtp.MatrixLike | None = None,
+        joint_force_reference: jtp.VectorLike | None = None,
         regularization_term: jtp.FloatLike = 1e-6,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
         """
@@ -226,6 +227,8 @@ class RigidContacts(ContactModel):
             link_forces:
                 Optional `(n_links, 6)` matrix of external forces acting on the links,
                 expressed in the same representation of data.
+            joint_force_reference:
+                Optional `(n_joints,)` vector of joint forces.
             regularization_term:
                 The regularization term to add to the diagonal of the Delassus
                 matrix for better numerical conditioning.
@@ -241,6 +244,12 @@ class RigidContacts(ContactModel):
             link_forces
             if link_forces is not None
             else jnp.zeros((model.number_of_links(), 6))
+        )
+
+        joint_force_reference = (
+            joint_force_reference
+            if joint_force_reference is not None
+            else jnp.zeros((model.number_of_joints(),))
         )
 
         # Compute kin-dyn quantities used in the contact model

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -213,7 +213,7 @@ class RigidContacts(ContactModel):
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData,
         link_forces: jtp.MatrixLike | None = None,
-        joint_force_reference: jtp.VectorLike | None = None,
+        joint_force_references: jtp.VectorLike | None = None,
         regularization_term: jtp.FloatLike = 1e-6,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
         """
@@ -227,7 +227,7 @@ class RigidContacts(ContactModel):
             link_forces:
                 Optional `(n_links, 6)` matrix of external forces acting on the links,
                 expressed in the same representation of data.
-            joint_force_reference:
+            joint_force_references:
                 Optional `(n_joints,)` vector of joint forces.
             regularization_term:
                 The regularization term to add to the diagonal of the Delassus
@@ -246,9 +246,9 @@ class RigidContacts(ContactModel):
             else jnp.zeros((model.number_of_links(), 6))
         )
 
-        joint_force_reference = (
-            joint_force_reference
-            if joint_force_reference is not None
+        joint_force_references = (
+            joint_force_references
+            if joint_force_references is not None
             else jnp.zeros((model.number_of_joints(),))
         )
 
@@ -278,6 +278,7 @@ class RigidContacts(ContactModel):
             data=data,
             velocity_representation=data.velocity_representation,
             link_forces=link_forces,
+            joint_force_references=joint_force_references,
         )
 
         with (


### PR DESCRIPTION
This pull request includes several updates to the contact models in the codebase. The `jaxsim.api.contact.collidable_point_dynamics` function now takes into account the applied torques in the rigid contact models.  The `RelaxedRigidContacts` class have been updated to include docstrings and a deprecation warning on `jax.tree_map` has been fixed

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--233.org.readthedocs.build//233/

<!-- readthedocs-preview jaxsim end -->