### PR TITLE
Use `jax.tree.map` instead of `jax.tree_utils.tree_map`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ dependencies:
   # ===========================
   - python >= 3.12.0
   - coloredlogs
-  - jax >= 0.4.13
+  - jax >= 0.4.26
   - jaxopt >= 0.8.0
-  - jaxlib >= 0.4.13
+  - jaxlib >= 0.4.26
   - jaxlie >= 1.3.0
   - jax-dataclasses >= 1.4.0
   - pptree

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ classifiers = [
 ]
 dependencies = [
     "coloredlogs",
-    "jax >= 0.4.13",
+    "jax >= 0.4.26",
     "jaxopt >= 0.8.0",
-    "jaxlib >= 0.4.13",
+    "jaxlib >= 0.4.26",
     "jaxlie >= 1.3.0",
     "jax_dataclasses >= 1.4.0",
     "pptree",

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -98,9 +98,7 @@ class KynDynParameters(JaxsimDataclass):
         ]
 
         # Create a vectorized object of link parameters.
-        link_parameters = jax.tree_util.tree_map(
-            lambda *l: jnp.stack(l), *link_parameters_list
-        )
+        link_parameters = jax.tree.map(lambda *l: jnp.stack(l), *link_parameters_list)
 
         # =================
         # Joints properties
@@ -114,7 +112,7 @@ class KynDynParameters(JaxsimDataclass):
 
         # Create a vectorized object of joint parameters.
         joint_parameters = (
-            jax.tree_util.tree_map(lambda *l: jnp.stack(l), *joint_parameters_list)
+            jax.tree.map(lambda *l: jnp.stack(l), *joint_parameters_list)
             if len(ordered_joints) > 0
             else JointParameters(
                 index=jnp.array([], dtype=int),

--- a/src/jaxsim/api/link.py
+++ b/src/jaxsim/api/link.py
@@ -154,7 +154,7 @@ def spatial_inertia(
         idx=link_index,
     )
 
-    link_parameters = jax.tree_util.tree_map(
+    link_parameters = jax.tree.map(
         lambda l: l[link_index], model.kin_dyn_parameters.link_parameters
     )
 

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -230,7 +230,7 @@ class RelaxedRigidContacts(ContactModel):
         )
 
         def _detect_contact(x: jtp.Array, y: jtp.Array, z: jtp.Array) -> jtp.Array:
-            x, y, z = jax.tree_map(jnp.squeeze, (x, y, z))
+            x, y, z = jax.tree.map(jnp.squeeze, (x, y, z))
 
             n̂ = self.terrain.normal(x=x, y=y).squeeze()
             h = jnp.array([0, 0, z - model.terrain.height(x=x, y=y)])

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -298,7 +298,7 @@ class JaxsimDataclass(abc.ABC):
         """
 
         # Make a copy calling tree_map.
-        obj = jax.tree_util.tree_map(lambda leaf: leaf, self)
+        obj = jax.tree.map(lambda leaf: leaf, self)
 
         # Make sure that the copied object and all the copied leaves have the same
         # mutability of the original object.


### PR DESCRIPTION
This pull request replaces the usage of `jax.tree_utils.tree_map` with `jax.tree.map` in multiple places in the codebase in order to align with the newer `jax` versions.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--234.org.readthedocs.build//234/

<!-- readthedocs-preview jaxsim end -->