### PR TITLE
Speed up various functions avoiding using `jax.vmap` on indexes

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -425,9 +425,9 @@ def jacobian(
     # Compute the contact Jacobian.
     # In inertial-fixed output representation, the Jacobian of the parent link is also
     # the Jacobian of the frame C implicitly associated with the collidable point.
-    W_J_WC = jax.vmap(lambda parent_link_idx: W_J_WL[parent_link_idx])(
+    W_J_WC = W_J_WL[
         jnp.array(model.kin_dyn_parameters.contact_parameters.body, dtype=int)
-    )
+    ]
 
     # Adjust the output representation.
     match output_vel_repr:

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -372,11 +372,9 @@ def transforms(model: js.model.JaxSimModel, data: js.data.JaxSimModelData) -> jt
     """
 
     # Get the transforms of the parent link of all collidable points.
-    W_H_L = jax.vmap(
-        lambda parent_link_idx: js.link.transform(
-            model=model, data=data, link_index=parent_link_idx
-        )
-    )(jnp.array(model.kin_dyn_parameters.contact_parameters.body, dtype=int))
+    W_H_L = js.model.forward_kinematics(model=model, data=data)[
+        jnp.array(model.kin_dyn_parameters.contact_parameters.body, dtype=int)
+    ]
 
     # Build the link-to-point transform from the displacement between the link frame L
     # and the implicit contact frame C.

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -422,9 +422,7 @@ class KynDynParameters(JaxsimDataclass):
         # Note that here we include also the index 0 since suc_H_child[0] stores the
         # optional pose of the base link w.r.t. the root frame of the model.
         # This is supported by SDF when the base link <pose> element is defined.
-        suc_H_i = jax.vmap(lambda i: self.joint_model.successor_H_child(joint_index=i))(
-            jnp.arange(0, 1 + self.number_of_joints())
-        )
+        suc_H_i = self.joint_model.suc_H_i[jnp.arange(0, 1 + self.number_of_joints())]
 
         # Compute the overall transforms from the parent to the child of each joint by
         # composing all the components of our joint model.

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -968,7 +968,7 @@ def free_floating_coriolis_matrix(
             lambda link_index: js.link.jacobian_derivative(
                 model=model, data=data, link_index=link_index
             )
-        )(js.link.names_to_idxs(model=model, link_names=model.link_names()))
+        )(jnp.arange(model.number_of_links()))
 
     L_M_L = link_spatial_inertia_matrices(model=model)
 

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -396,9 +396,7 @@ def total_mass(model: JaxSimModel) -> jtp.Float:
     """
 
     return (
-        jax.vmap(lambda idx: js.link.mass(model=model, link_index=idx))(
-            jnp.arange(model.number_of_links())
-        )
+        js.link.mass(model=model, link_index=jnp.arange(model.number_of_links()))
         .sum()
         .astype(float)
     )

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -395,11 +395,7 @@ def total_mass(model: JaxSimModel) -> jtp.Float:
         The total mass of the model.
     """
 
-    return (
-        js.link.mass(model=model, link_index=jnp.arange(model.number_of_links()))
-        .sum()
-        .astype(float)
-    )
+    return model.kin_dyn_parameters.link_parameters.mass.sum().astype(float)
 
 
 @jax.jit

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -240,9 +240,7 @@ def test_link_bias_acceleration(
 
             W_H_L = js.model.forward_kinematics(model=model, data=data)
 
-            W_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)[
-                jnp.arange(model.number_of_links())
-            ]
+            W_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)
 
             with data.switch_velocity_representation(VelRepr.Body):
 
@@ -250,11 +248,7 @@ def test_link_bias_acceleration(
                     lambda W_H_L: jaxsim.math.Adjoint.from_transform(transform=W_H_L)
                 )(W_H_L)
 
-                L_a_bias_WL = jax.vmap(
-                    lambda index: js.link.bias_acceleration(
-                        model=model, data=data, link_index=index
-                    )
-                )(jnp.arange(model.number_of_links()))
+                L_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)
 
                 W_a_bias_WL_converted = jax.vmap(
                     lambda W_X_L, L_a_bias_WL: W_X_L @ L_a_bias_WL
@@ -267,9 +261,7 @@ def test_link_bias_acceleration(
 
             W_H_L = js.model.forward_kinematics(model=model, data=data)
 
-            L_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)[
-                jnp.arange(model.number_of_links())
-            ]
+            L_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)
 
             with data.switch_velocity_representation(VelRepr.Inertial):
 
@@ -279,9 +271,7 @@ def test_link_bias_acceleration(
                     )
                 )(W_H_L)
 
-                W_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)[
-                    jnp.arange(model.number_of_links())
-                ]
+                W_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)
 
                 L_a_bias_WL_converted = jax.vmap(
                     lambda L_X_W, W_a_bias_WL: L_X_W @ W_a_bias_WL
@@ -317,14 +307,10 @@ def test_link_jacobian_derivative(
         lambda link_index: js.link.jacobian_derivative(
             model=model, data=data, link_index=link_index
         )
-    )(js.link.names_to_idxs(model=model, link_names=model.link_names()))
+    )(jnp.arange(model.number_of_links()))
 
     # Compute the product J̇ν.
-    O_a_bias_WL = jax.vmap(
-        lambda link_index: js.link.bias_acceleration(
-            model=model, data=data, link_index=link_index
-        )
-    )(js.link.names_to_idxs(model=model, link_names=model.link_names()))
+    O_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)
 
     # Compare the two computations.
     assert jnp.einsum("l6g,g->l6", O_J̇_WL_I, I_ν) == pytest.approx(

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -240,11 +240,9 @@ def test_link_bias_acceleration(
 
             W_H_L = js.model.forward_kinematics(model=model, data=data)
 
-            W_a_bias_WL = jax.vmap(
-                lambda index: js.link.bias_acceleration(
-                    model=model, data=data, link_index=index
-                )
-            )(jnp.arange(model.number_of_links()))
+            W_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)[
+                jnp.arange(model.number_of_links())
+            ]
 
             with data.switch_velocity_representation(VelRepr.Body):
 
@@ -269,11 +267,9 @@ def test_link_bias_acceleration(
 
             W_H_L = js.model.forward_kinematics(model=model, data=data)
 
-            L_a_bias_WL = jax.vmap(
-                lambda index: js.link.bias_acceleration(
-                    model=model, data=data, link_index=index
-                )
-            )(jnp.arange(model.number_of_links()))
+            L_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)[
+                jnp.arange(model.number_of_links())
+            ]
 
             with data.switch_velocity_representation(VelRepr.Inertial):
 
@@ -283,11 +279,9 @@ def test_link_bias_acceleration(
                     )
                 )(W_H_L)
 
-                W_a_bias_WL = jax.vmap(
-                    lambda index: js.link.bias_acceleration(
-                        model=model, data=data, link_index=index
-                    )
-                )(jnp.arange(model.number_of_links()))
+                W_a_bias_WL = js.model.link_bias_accelerations(model=model, data=data)[
+                    jnp.arange(model.number_of_links())
+                ]
 
                 L_a_bias_WL_converted = jax.vmap(
                     lambda L_X_W, W_a_bias_WL: L_X_W @ W_a_bias_WL

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -74,7 +74,7 @@ def test_link_inertial_properties(
 
     for link_name, link_idx in zip(
         model.link_names(),
-        js.link.names_to_idxs(model=model, link_names=model.link_names()),
+        jnp.arange(model.number_of_links()),
         strict=True,
     ):
         if link_name == model.base_link():
@@ -164,7 +164,7 @@ def test_link_jacobians(
 
     for link_name, link_idx in zip(
         model.link_names(),
-        js.link.names_to_idxs(model=model, link_names=model.link_names()),
+        jnp.arange(model.number_of_links()),
         strict=True,
     ):
         v_WL_idt = kin_dyn.frame_velocity(frame_name=link_name)
@@ -185,7 +185,7 @@ def test_link_jacobians(
 
         for link_name, link_idx in zip(
             model.link_names(),
-            js.link.names_to_idxs(model=model, link_names=model.link_names()),
+            jnp.arange(model.number_of_links()),
             strict=True,
         ):
             v_WL_idt = kin_dyn_other_repr.frame_velocity(frame_name=link_name)
@@ -220,7 +220,7 @@ def test_link_bias_acceleration(
 
     for name, index in zip(
         model.link_names(),
-        js.link.names_to_idxs(model=model, link_names=model.link_names()),
+        jnp.arange(model.number_of_links()),
         strict=True,
     ):
         Jν_idt = kin_dyn.frame_bias_acc(frame_name=name)

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -263,7 +263,7 @@ def test_ad_jacobian(
     # ====
 
     # Get the link indices.
-    link_indices = js.link.names_to_idxs(model=model, link_names=model.link_names())
+    link_indices = jnp.arange(model.number_of_links())
 
     # Get a closure exposing only the parameters to be differentiated.
     # We differentiate the jacobian of the last link, likely among those


### PR DESCRIPTION
This PR removes the usage of `jax.vmap` on functions that can directly extract from arrays using the numpy-like indexing, e.g. using an index of an array for extracting and then stacking the resulting extracted components. This speeds up the compilation and the runtime performance of the concerned methods.

A couple benchmarks on stickbot model with 23 joints:

```python
In [61]: %timeit js.contact.transforms(model=model, data=data) # previous implementation
11.9 ms ± 176 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [66]: %timeit js.contact.transforms(model=model, data=data) # current implementation
1.63 ms ± 45.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

```python
In [98]: %timeit -r 1 -n 1 js.model.total_mass(model) # previous implementation
5.98 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

In [100]: %timeit -r 1 -n 1 js.model.total_mass(model) # current implementation
1.61 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```

Apart from having a noticeable impact on the single methods, this should speed up all the functionalities that depend on the concerned functions.


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--235.org.readthedocs.build//235/

<!-- readthedocs-preview jaxsim end -->