### PR TITLE
Rigid contacts speedup improvements

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -208,6 +208,7 @@ def collidable_point_dynamics(
                 data=data,
                 link_forces=link_forces,
                 joint_force_references=joint_force_references,
+                solver_tol=1e-3,
             )
 
             aux_data = dict()


### PR DESCRIPTION
This PR updates the RigidContacts class removing redundant calls to get kin-dyn quantities like contact jacobians, system velocity, etc.

It also exposes the QP solver tolerance.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--237.org.readthedocs.build//237/

<!-- readthedocs-preview jaxsim end -->