### PR TITLE
Remove `is_urdf` argument when building the model

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - jax-dataclasses >= 1.4.0
   - pptree
   - qpax
-  - rod >= 0.3.0
+  - rod >= 0.3.3
   - typing_extensions # python<3.12
   # ====================================
   # Optional dependencies from setup.cfg

--- a/examples/PD_controller.ipynb
+++ b/examples/PD_controller.ipynb
@@ -100,7 +100,7 @@
     "num_steps = int(integration_time / dt)\n",
     "\n",
     "model = js.model.JaxSimModel.build_from_model_description(\n",
-    "    model_description=model_urdf_string, is_urdf=True\n",
+    "    model_description=model_urdf_string\n",
     ")\n",
     "data = js.data.JaxSimModelData.build(model=model)\n",
     "integrator = integrators.fixed_step.RungeKutta4SO3.build(\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "jax_dataclasses >= 1.4.0",
     "pptree",
     "qpax",
-    "rod >= 0.3.0",
+    "rod >= 0.3.3",
     "typing_extensions ; python_version < '3.12'",
 ]
 

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -106,8 +106,8 @@ class JaxSimModel(JaxsimDataclass):
             terrain:
                 The optional terrain to consider.
             is_urdf:
-                Whether the model description is a URDF or an SDF. This is
-                automatically inferred if the model description is a path to a file.
+                The optional flag to force the model description to be parsed as a
+                URDF or a SDF. This is otherwise automatically inferred.
             considered_joints:
                 The list of joints to consider. If None, all joints are considered.
 
@@ -120,7 +120,7 @@ class JaxSimModel(JaxsimDataclass):
         # Parse the input resource (either a path to file or a string with the URDF/SDF)
         # and build the -intermediate- model description.
         intermediate_description = jaxsim.parsers.rod.build_model_description(
-            model_description=model_description, is_urdf=is_urdf
+            model_description=model_description
         )
 
         # Lump links together if not all joints are considered.

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -25,7 +25,7 @@ def load_rod_model(
 
     Args:
         model_description: The URDF/SDF file or ROD model to load.
-        is_urdf: Whether the model description is a URDF file.
+        is_urdf: Whether to force parsing the model description as a URDF file.
         model_name: The name of the model to load from the resource.
 
     Returns:
@@ -558,7 +558,6 @@ class UrdfToMjcf:
         # Get the ROD model.
         rod_model = load_rod_model(
             model_description=urdf,
-            is_urdf=True,
             model_name=model_name,
         )
 
@@ -605,7 +604,6 @@ class SdfToMjcf:
         # Get the ROD model.
         rod_model = load_rod_model(
             model_description=sdf,
-            is_urdf=False,
             model_name=model_name,
         )
 

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -558,6 +558,7 @@ class UrdfToMjcf:
         # Get the ROD model.
         rod_model = load_rod_model(
             model_description=urdf,
+            is_urdf=True,
             model_name=model_name,
         )
 
@@ -604,6 +605,7 @@ class SdfToMjcf:
         # Get the ROD model.
         rod_model = load_rod_model(
             model_description=sdf,
+            is_urdf=False,
             model_name=model_name,
         )
 

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -33,7 +33,7 @@ class SDFData(NamedTuple):
 
 
 def extract_model_data(
-    model_description: pathlib.Path | str | rod.Model,
+    model_description: pathlib.Path | str | rod.Model | rod.Sdf,
     model_name: str | None = None,
     is_urdf: bool | None = None,
 ) -> SDFData:
@@ -56,13 +56,13 @@ def extract_model_data(
     match model_description:
         case rod.Model():
             sdf_model = model_description
-        case rod.Sdf(None):
-            sdf_model = model_description.model
-        case str() | pathlib.Path():
-            # Parse the SDF resource.
-            sdf_element = rod.Sdf.load(sdf=model_description, is_urdf=is_urdf)
-
-            if len(sdf_element.models()) == 0:
+        case rod.Sdf() | str() | pathlib.Path():
+            sdf_element = (
+                model_description
+                if isinstance(model_description, rod.Sdf)
+                else rod.Sdf.load(sdf=model_description, is_urdf=is_urdf)
+            )
+            if not sdf_element.models():
                 raise RuntimeError("Failed to find any model in SDF resource")
 
             # Assume the SDF resource has only one model, or the desired model name is given.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,24 +83,9 @@ def build_jaxsim_model(
         A JaxSim model built from the provided description.
     """
 
-    is_urdf = None
-
-    # If the provided description is a string, automatically detect if it
-    # contains the content of a URDF or SDF file.
-    if isinstance(model_description, str):
-        if "<robot" in model_description:
-            is_urdf = True
-
-        elif "<sdf>" in model_description:
-            is_urdf = False
-
-        else:
-            is_urdf = None
-
     # Build the JaxSim model.
     model = js.model.JaxSimModel.build_from_model_description(
         model_description=model_description,
-        is_urdf=is_urdf,
     )
 
     return model

--- a/tests/test_api_contact.py
+++ b/tests/test_api_contact.py
@@ -85,7 +85,7 @@ def test_contact_jacobian_derivative(
     W_p_Ci = model.kin_dyn_parameters.contact_parameters.point
 
     # Load the model in ROD.
-    rod_model = rod.Sdf.load(sdf=model.built_from, is_urdf=True).model
+    rod_model = rod.Sdf.load(sdf=model.built_from).model
 
     # Add dummy frames on the contact points.
     for idx, (link_name, W_p_C) in enumerate(

--- a/tests/test_pytree.py
+++ b/tests/test_pytree.py
@@ -14,14 +14,12 @@ def test_call_jit_compiled_function_passing_different_objects(
 
     # Create a first model from the URDF.
     model1 = js.model.JaxSimModel.build_from_model_description(
-        model_description=ergocub_model_description_path,
-        is_urdf=True,
+        model_description=ergocub_model_description_path
     )
 
     # Create a second model from the URDF.
     model2 = js.model.JaxSimModel.build_from_model_description(
-        model_description=ergocub_model_description_path,
-        is_urdf=True,
+        model_description=ergocub_model_description_path
     )
 
     # The objects should be different, but the comparison should return True.


### PR DESCRIPTION
This PR removes the `is_urdf` argument, as it can get automatically detected by `rod`. Furthermore, it enables using a `rod.Sdf` instance to build a `JaxSimModel`.

> [!Warning]
> Requires https://github.com/ami-iit/rod/pull/42

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--238.org.readthedocs.build//238/

<!-- readthedocs-preview jaxsim end -->