### PR TITLE
Fix references representation in `system_velocity_dynamics`

### DIFF
--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -145,7 +145,10 @@ def system_velocity_dynamics(
 
         # Compute the 6D forces W_f ∈ ℝ^{n_c × 6} applied to each collidable point
         # along with contact-specific auxiliary states.
-        with data.switch_velocity_representation(VelRepr.Inertial):
+        with (
+            data.switch_velocity_representation(VelRepr.Inertial),
+            references.switch_velocity_representation(VelRepr.Inertial),
+        ):
             W_f_Ci, aux_data = js.contact.collidable_point_dynamics(
                 model=model,
                 data=data,


### PR DESCRIPTION
In `system_velocity_dynamics` we create a references instance with the input velocity representation of data, then we call `js.contact.collidable_point_dynamics` inside a context manager in which data representation has been switched to Inertial, but in this case the references object has not been switched accordingly, with the result that in the cases of input data representation being `Body` or `Mixed` the link forces passed to `js.contact.collidable_point_dynamics` could be wrong.

Let me know what do you think :)