### PR TITLE
Fix `jaxsim.api.model.link_contact_forces`

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -93,7 +93,10 @@ def collidable_point_velocities(
 
 @jax.jit
 def collidable_point_forces(
-    model: js.model.JaxSimModel, data: js.data.JaxSimModelData
+    model: js.model.JaxSimModel,
+    data: js.data.JaxSimModelData,
+    link_forces: jtp.MatrixLike | None = None,
+    joint_force_references: jtp.VectorLike | None = None,
 ) -> jtp.Matrix:
     """
     Compute the 6D forces applied to each collidable point.
@@ -101,13 +104,23 @@ def collidable_point_forces(
     Args:
         model: The model to consider.
         data: The data of the considered model.
+        link_forces:
+            The 6D external forces to apply to the links expressed in the same
+            representation of data.
+        joint_force_references:
+            The joint force references to apply to the joints.
 
     Returns:
         The 6D forces applied to each collidable point expressed in the frame
         corresponding to the active representation.
     """
 
-    f_Ci, _ = collidable_point_dynamics(model=model, data=data)
+    f_Ci, _ = collidable_point_dynamics(
+        model=model,
+        data=data,
+        link_forces=link_forces,
+        joint_force_references=joint_force_references,
+    )
 
     return f_Ci
 


### PR DESCRIPTION
In this PR I added to the `jaxsim.api.model.link_contact_forces` API the external link forces and joint torques as additional input arguments. These are then passed to `jaxsim.api.contact.collidable_point_forces`. In this way, the contact forces computed with the rigid contact model (but this applies also to relaxed-rigid ones I think) will consider all the forces acting on the model.

I faced an issue when I was performing simulations with @flferretti using rigid contacts, and we noted that the contact forces given by   `jaxsim.api.model.link_contact_forces` were only related to the weight of the model and were not considering other forces potentially acting on the model. 

The computation of the contact forces used inside `model.step` was already correct: through `ode.system_velocity_dynamics` it calls `contact.collidable_point_dynamics` with the correct arguments, while `contact.collidable_point_forces` was not aligned.

Let me know what do you think of this :)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--242.org.readthedocs.build//242/

<!-- readthedocs-preview jaxsim end -->