### PR TITLE
Allow calls to `logging` in `jaxsim.exceptions`

### DIFF
--- a/src/jaxsim/exceptions.py
+++ b/src/jaxsim/exceptions.py
@@ -1,22 +1,22 @@
 import jax
 
 
-def raise_if(
+def handle_if(
     condition: bool | jax.Array, exception: type, msg: str, *args, **kwargs
 ) -> None:
     """
-    Raise a host-side exception if a condition is met. Useful in jit-compiled functions.
+    Handle an exception based on a condition, either by raising it or calling it
+    (if the exception type does not inherit from BaseException). Useful in jit-compiled functions.
 
     Args:
         condition:
             The boolean condition of the evaluated expression that triggers
             the exception during runtime.
-        exception: The type of exception to raise.
+        exception: The type of exception to raise or call.
         msg:
             The message to display when the exception is raised. The message can be a
             format string (fmt), whose fields are filled with the args and kwargs.
     """
-
     # Check early that the format string is well-formed.
     try:
         _ = msg.format(*args, **kwargs)
@@ -24,16 +24,20 @@ def raise_if(
         msg = "Error in formatting exception message with args={} and kwargs={}"
         raise ValueError(msg.format(args, kwargs)) from e
 
-    def _raise_exception(condition: bool, *args, **kwargs) -> None:
+    def _handle_message(condition: bool, *args, **kwargs) -> None:
         """The function called by the JAX callback."""
-
         if condition:
-            raise exception(msg.format(*args, **kwargs))
+            formatted_msg = msg.format(*args, **kwargs)
+            # If the exception is a subclass of BaseException, we raise it.
+            if issubclass(exception, BaseException):
+                raise exception(formatted_msg)
+            else:
+                # Otherwise, we call it.
+                raise exception(formatted_msg)
 
     def _callback(args, kwargs) -> None:
         """The function that calls the JAX callback, executed only when needed."""
-
-        jax.debug.callback(_raise_exception, condition, *args, **kwargs)
+        jax.debug.callback(_handle_message, condition, *args, **kwargs)
 
     # Since running a callable on the host is expensive, we prevent its execution
     # if the condition is False with a low-level conditional expression.
@@ -53,11 +57,11 @@ def raise_runtime_error_if(
     condition: bool | jax.Array, msg: str, *args, **kwargs
 ) -> None:
 
-    return raise_if(condition, RuntimeError, msg, *args, **kwargs)
+    return handle_if(condition, RuntimeError, msg, *args, **kwargs)
 
 
 def raise_value_error_if(
     condition: bool | jax.Array, msg: str, *args, **kwargs
 ) -> None:
 
-    return raise_if(condition, ValueError, msg, *args, **kwargs)
+    return handle_if(condition, ValueError, msg, *args, **kwargs)


### PR DESCRIPTION
This PR is a proposal to adapt the `jaxsim.exceptions` so that it can also work with calls to `jaxsim.logging` or `logging`. Eventually, we could think of just separating the two functionalities or renaming the module.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--243.org.readthedocs.build//243/

<!-- readthedocs-preview jaxsim end -->