### PR TITLE
Switch from `jaxopt` to `optax` in relaxed rigid contact model

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,10 +8,10 @@ dependencies:
   - python >= 3.12.0
   - coloredlogs
   - jax >= 0.4.26
-  - jaxopt >= 0.8.0
   - jaxlib >= 0.4.26
   - jaxlie >= 1.3.0
   - jax-dataclasses >= 1.4.0
+  - optax >= 0.2.3
   - pptree
   - qpax
   - rod >= 0.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,11 @@ classifiers = [
 dependencies = [
     "coloredlogs",
     "jax >= 0.4.26",
-    "jaxopt >= 0.8.0",
     "jaxlib >= 0.4.26",
     "jaxlie >= 1.3.0",
     "jax_dataclasses >= 1.4.0",
     "pptree",
+    "optax >= 0.2.3",
     "qpax",
     "rod >= 0.3.3",
     "typing_extensions ; python_version < '3.12'",


### PR DESCRIPTION
This PR substitutes the `jaxopt` solver with the one from `optax`,  since `jaxopt` will be deprecated soon (see note in [jaxopt/README.md](https://github.com/google/jaxopt/?tab=readme-ov-file#%EF%B8%8F-we-are-in-the-process-of-merging-jaxopt-into-optax-because-of-this-jaxopt-is-now-in-maintenance-mode-and-we-will-not-be-implementing-new-features-%EF%B8%8F)

> [!Warning]
> The RTD action requires https://github.com/conda-forge/optax-feedstock/pull/21

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--244.org.readthedocs.build//244/

<!-- readthedocs-preview jaxsim end -->