### PR TITLE
Allow `Rigid*ContactsState` to accept kwargs

### DIFF
--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -169,7 +169,7 @@ class RelaxedRigidContactsState(ContactsState):
         return cls()
 
     @classmethod
-    def zero(cls: type[Self]) -> Self:
+    def zero(cls: type[Self], **kwargs) -> Self:
         """Build a zero `RelaxedRigidContactsState` instance from a `JaxSimModel`."""
 
         return cls.build()

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -174,7 +174,7 @@ class RelaxedRigidContactsState(ContactsState):
 
         return cls.build()
 
-    def valid(self, *, model: js.model.JaxSimModel) -> jtp.BoolLike:
+    def valid(self, **kwargs) -> jtp.BoolLike:
         return True
 
 

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -97,7 +97,7 @@ class RigidContactsState(ContactsState):
 
         return cls.build()
 
-    def valid(self) -> jtp.BoolLike:
+    def valid(self, **kwargs) -> jtp.BoolLike:
         return True
 
 

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -92,7 +92,7 @@ class RigidContactsState(ContactsState):
         return cls()
 
     @classmethod
-    def zero(cls: type[Self]) -> Self:
+    def zero(cls: type[Self], **kwargs) -> Self:
         """Build a zero `RigidContactsState` instance from a `JaxSimModel`."""
 
         return cls.build()


### PR DESCRIPTION
This fixes a regression introduced from a suggestion I made in https://github.com/ami-iit/jaxsim/pull/245. When the zero-ed ODEState is created in https://github.com/ami-iit/jaxsim/blob/a4d14766766ba838ea784ddf15df6feb36465164/src/jaxsim/api/ode_data.py#L250-L252
this raises an error in rigid contact models:

```python
TypeError: RelaxedRigidContactsState.zero() got an unexpected keyword argument 'model'
```

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--246.org.readthedocs.build//246/

<!-- readthedocs-preview jaxsim end -->