### PR TITLE
Update `ContactModel.compute_contact_forces` APIs

### DIFF
--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -185,20 +185,6 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             )
         )
 
-        contacts_params = (
-            contacts_params
-            if contacts_params is not None
-            else (
-                model.contact_model.parameters
-                if not isinstance(
-                    model.contact_model, jaxsim.rbda.contacts.SoftContacts
-                )
-                else js.contact.estimate_good_soft_contacts_parameters(
-                    model=model, standard_gravity=standard_gravity
-                )
-            )
-        )
-
         W_H_B = jaxsim.math.Transform.from_quaternion_and_translation(
             translation=base_position, quaternion=base_quaternion
         )
@@ -227,6 +213,15 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
 
         if not ode_state.valid(model=model):
             raise ValueError(ode_state)
+
+        if contacts_params is None:
+
+            if isinstance(model.contact_model, jaxsim.rbda.contacts.SoftContacts):
+                contacts_params = js.contact.estimate_good_soft_contacts_parameters(
+                    model=model, standard_gravity=standard_gravity
+                )
+            else:
+                contacts_params = model.contact_model.parameters
 
         return JaxSimModelData(
             time_ns=time_ns,

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -13,7 +13,7 @@ import jaxsim.api as js
 import jaxsim.math
 import jaxsim.rbda
 import jaxsim.typing as jtp
-from jaxsim.rbda.contacts.soft import SoftContacts
+from jaxsim.rbda.contacts import SoftContacts
 from jaxsim.utils import Mutability
 from jaxsim.utils.tracing import not_tracing
 
@@ -37,7 +37,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
 
     gravity: jtp.Array
 
-    contacts_params: jaxsim.rbda.ContactsParams = dataclasses.field(repr=False)
+    contacts_params: jaxsim.rbda.contacts.ContactsParams = dataclasses.field(repr=False)
 
     time_ns: jtp.Int = dataclasses.field(
         default_factory=lambda: jnp.array(
@@ -114,8 +114,8 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         base_angular_velocity: jtp.Vector | None = None,
         joint_velocities: jtp.Vector | None = None,
         standard_gravity: jtp.FloatLike = jaxsim.math.StandardGravity,
-        contact: jaxsim.rbda.ContactsState | None = None,
-        contacts_params: jaxsim.rbda.ContactsParams | None = None,
+        contact: jaxsim.rbda.contacts.ContactsState | None = None,
+        contacts_params: jaxsim.rbda.contacts.ContactsParams | None = None,
         velocity_representation: VelRepr = VelRepr.Inertial,
         time: jtp.FloatLike | None = None,
     ) -> JaxSimModelData:
@@ -185,16 +185,19 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             )
         )
 
-        if isinstance(model.contact_model, SoftContacts):
-            contacts_params = (
-                contacts_params
-                if contacts_params is not None
+        contacts_params = (
+            contacts_params
+            if contacts_params is not None
+            else (
+                model.contact_model.parameters
+                if not isinstance(
+                    model.contact_model, jaxsim.rbda.contacts.SoftContacts
+                )
                 else js.contact.estimate_good_soft_contacts_parameters(
                     model=model, standard_gravity=standard_gravity
                 )
             )
-        else:
-            contacts_params = model.contact_model.parameters
+        )
 
         W_H_B = jaxsim.math.Transform.from_quaternion_and_translation(
             translation=base_position, quaternion=base_quaternion

--- a/src/jaxsim/api/ode_data.py
+++ b/src/jaxsim/api/ode_data.py
@@ -5,13 +5,15 @@ import jax_dataclasses
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.rbda import ContactsState
-from jaxsim.rbda.contacts.relaxed_rigid import (
+from jaxsim.rbda.contacts import (
+    ContactsState,
     RelaxedRigidContacts,
     RelaxedRigidContactsState,
+    RigidContacts,
+    RigidContactsState,
+    SoftContacts,
+    SoftContactsState,
 )
-from jaxsim.rbda.contacts.rigid import RigidContacts, RigidContactsState
-from jaxsim.rbda.contacts.soft import SoftContacts, SoftContactsState
 from jaxsim.utils import JaxsimDataclass
 
 # =============================================================================
@@ -165,8 +167,11 @@ class ODEState(JaxsimDataclass):
 
         # Get the contact model from the `JaxSimModel`.
         match model.contact_model:
+
             case SoftContacts():
+
                 tangential_deformation = kwargs.get("tangential_deformation", None)
+
                 contact = SoftContactsState.build_from_jaxsim_model(
                     model=model,
                     **(
@@ -182,7 +187,7 @@ class ODEState(JaxsimDataclass):
                 contact = RelaxedRigidContactsState.build()
 
             case _:
-                raise ValueError("Unable to determine contact state class prefix.")
+                raise ValueError("Unsupported contact model.")
 
         return ODEState.build(
             model=model,

--- a/src/jaxsim/rbda/__init__.py
+++ b/src/jaxsim/rbda/__init__.py
@@ -1,6 +1,6 @@
+from . import contacts
 from .aba import aba
 from .collidable_points import collidable_points_pos_vel
-from .contacts.common import ContactModel, ContactsParams, ContactsState
 from .crba import crba
 from .forward_kinematics import forward_kinematics, forward_kinematics_model
 from .jacobian import (

--- a/src/jaxsim/rbda/contacts/__init__.py
+++ b/src/jaxsim/rbda/contacts/__init__.py
@@ -1,3 +1,4 @@
+from . import relaxed_rigid, rigid, soft
 from .common import ContactModel, ContactsParams, ContactsState
 from .relaxed_rigid import (
     RelaxedRigidContacts,

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 from typing import Any
 
+import jaxsim.api as js
 import jaxsim.terrain
 import jaxsim.typing as jtp
 from jaxsim.utils import JaxsimDataclass
@@ -90,20 +91,20 @@ class ContactModel(JaxsimDataclass):
     @abc.abstractmethod
     def compute_contact_forces(
         self,
-        position: jtp.VectorLike,
-        velocity: jtp.VectorLike,
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
         **kwargs,
     ) -> tuple[jtp.Vector, tuple[Any, ...]]:
         """
         Compute the contact forces.
 
         Args:
-            position: The position of the collidable point w.r.t. the world frame.
-            velocity:
-                The linear velocity of the collidable point (linear component of the mixed 6D velocity).
+            model: The model to consider.
+            data: The data of the considered model.
 
         Returns:
             A tuple containing as first element the computed 6D contact force applied to the contact point and expressed in the world frame,
             and as second element a tuple of optional additional information.
         """
+
         pass

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -108,3 +108,31 @@ class ContactModel(JaxsimDataclass):
         """
 
         pass
+
+    def initialize_model_and_data(
+        self,
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
+        validate: bool = True,
+    ) -> tuple[js.model.JaxSimModel, js.data.JaxSimModelData]:
+        """
+        Helper function to initialize the active model and data objects.
+
+        Args:
+            model: The robot model considered by the contact model.
+            data: The data of the considered robot model.
+            validate:
+                Whether to validate if the model and data objects have been
+                initialized with the current contact model.
+
+        Returns:
+            The initialized model and data objects.
+        """
+
+        with model.editable(validate=validate) as model_out:
+            model_out.contact_model = self
+
+        with data.editable(validate=validate) as data_out:
+            data_out.contacts_params = data.contacts_params
+
+        return model_out, data_out

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -215,6 +215,11 @@ class RelaxedRigidContacts(ContactModel):
             A tuple containing the contact forces.
         """
 
+        # Initialize the model and data this contact model is operating on.
+        # This will raise an exception if either the contact model or the
+        # contact parameters are not compatible.
+        model, data = self.initialize_model_and_data(model=model, data=data)
+
         link_forces = (
             link_forces
             if link_forces is not None

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -247,6 +247,11 @@ class RigidContacts(ContactModel):
             A tuple containing the contact forces.
         """
 
+        # Initialize the model and data this contact model is operating on.
+        # This will raise an exception if either the contact model or the
+        # contact parameters are not compatible.
+        model, data = self.initialize_model_and_data(model=model, data=data)
+
         # Import qpax just in this method
         import qpax
 

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -370,6 +370,11 @@ class SoftContacts(ContactModel):
         data: js.data.JaxSimModelData,
     ) -> tuple[jtp.Vector, tuple[jtp.Vector]]:
 
+        # Initialize the model and data this contact model is operating on.
+        # This will raise an exception if either the contact model or the
+        # contact parameters are not compatible.
+        model, data = self.initialize_model_and_data(model=model, data=data)
+
         # Compute the position and linear velocities (mixed representation) of
         # all collidable points belonging to the robot.
         W_p_C, W_ṗ_C = js.contact.collidable_point_kinematics(model=model, data=data)

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
 
 import jax
 import jax.numpy as jnp
@@ -198,30 +199,32 @@ class SoftContacts(ContactModel):
         default_factory=FlatTerrain
     )
 
-    def compute_contact_forces(
-        self,
+    @staticmethod
+    @functools.partial(jax.jit, static_argnames=("terrain",))
+    def hunt_crossley_contact_model(
         position: jtp.VectorLike,
         velocity: jtp.VectorLike,
-        *,
         tangential_deformation: jtp.VectorLike,
-    ) -> tuple[jtp.Vector, tuple[jtp.Vector]]:
+        terrain: Terrain,
+        K: jtp.FloatLike,
+        D: jtp.FloatLike,
+        mu: jtp.FloatLike,
+        p: jtp.FloatLike = 0.5,
+        q: jtp.FloatLike = 0.5,
+    ) -> tuple[jtp.Vector, jtp.Vector]:
 
         # Convert the input vectors to arrays.
         W_p_C = jnp.array(position, dtype=float).squeeze()
         W_ṗ_C = jnp.array(velocity, dtype=float).squeeze()
         m = jnp.array(tangential_deformation, dtype=float).squeeze()
 
-        # Short name of parameters.
-        K = self.parameters.K
-        D = self.parameters.D
-        μ = self.parameters.mu
+        # Use symbol for the static friction.
+        μ = mu
 
         # Compute the penetration depth, its rate, and the considered terrain normal.
-        δ, δ̇, n̂ = self.compute_penetration_data(p=W_p_C, v=W_ṗ_C, terrain=self.terrain)
-
-        # Get the exponents of the Hunt/Crossley model non-linear terms.
-        p = self.parameters.p
-        q = self.parameters.q
+        δ, δ̇, n̂ = SoftContacts.compute_penetration_data(
+            p=W_p_C, v=W_ṗ_C, terrain=terrain
+        )
 
         # There are few operations like computing the norm of a vector with zero length
         # or computing the square root of zero that are problematic in an AD context.
@@ -256,14 +259,15 @@ class SoftContacts(ContactModel):
         # Extract the tangential component of the velocity.
         v_tangential = W_ṗ_C - jnp.dot(W_ṗ_C, n̂) * n̂
 
-        # Extract the tangential component of the material deformation.
-        # This should not be necessary if the sticking-slipping transition occurs
-        # in a terrain area with a locally constant normal. However, this assumption
-        # is not true in general for highly uneven terrains.
+        # Extract the normal and tangential components of the material deformation.
         m_normal = jnp.dot(m, n̂) * n̂
         m_tangential = m - jnp.dot(m, n̂) * n̂
 
         # Compute the tangential force in the sticking case.
+        # Using the tangential component of the material deformation should not be
+        # necessary if the sticking-slipping transition occurs in a terrain area
+        # with a locally constant normal. However, this assumption is not true in
+        # general, especially for highly uneven terrains.
         f_tangential = -((K * δp) * m_tangential + (D * δq) * v_tangential)
 
         # Detect the contact type (sticking or slipping).
@@ -298,6 +302,9 @@ class SoftContacts(ContactModel):
         # =====================================
 
         # Compute the derivative of the material deformation.
+        # Note that we included an additional relaxation of `m_normal` in the
+        # sticking case, so that the normal deformation that could have accumulated
+        # from a previous slipping phase can relax to zero.
         ṁ_no_contact = -(K / D) * m
         ṁ_sticking = v_tangential - (K / D) * m_normal
         ṁ_slipping = -(f_tangential + (K * δp) * m_tangential) / (D * δq)
@@ -316,15 +323,74 @@ class SoftContacts(ContactModel):
         # Compute and return the final contact force
         # ==========================================
 
-        # Sum the normal and tangential forces and create a mixed 6D force.
-        CW_f = jnp.hstack([f_normal + f_tangential, jnp.zeros(3)])
+        # Sum the normal and tangential forces.
+        CW_fl = f_normal + f_tangential
+
+        return CW_fl, ṁ
+
+    @staticmethod
+    @functools.partial(jax.jit, static_argnames=("terrain",))
+    def compute_contact_force(
+        position: jtp.VectorLike,
+        velocity: jtp.VectorLike,
+        tangential_deformation: jtp.VectorLike,
+        parameters: SoftContactsParams,
+        terrain: Terrain,
+    ) -> tuple[jtp.Vector, jtp.Vector]:
+
+        CW_fl, ṁ = SoftContacts.hunt_crossley_contact_model(
+            position=position,
+            velocity=velocity,
+            tangential_deformation=tangential_deformation,
+            terrain=terrain,
+            K=parameters.K,
+            D=parameters.D,
+            mu=parameters.mu,
+            p=parameters.p,
+            q=parameters.q,
+        )
+
+        # Pack a mixed 6D force.
+        CW_f = jnp.hstack([CW_fl, jnp.zeros(3)])
 
         # Compute the 6D force transform from the mixed to the inertial-fixed frame.
         W_Xf_CW = jaxsim.math.Adjoint.from_quaternion_and_translation(
-            translation=W_p_C, inverse=True
+            translation=jnp.array(position), inverse=True
         ).T
 
-        return W_Xf_CW @ CW_f, (ṁ,)
+        # Compute the 6D force in the inertial-fixed frame.
+        W_f = W_Xf_CW @ CW_f
+
+        return W_f, ṁ
+
+    @jax.jit
+    def compute_contact_forces(
+        self,
+        model: js.model.JaxSimModel,
+        data: js.data.JaxSimModelData,
+    ) -> tuple[jtp.Vector, tuple[jtp.Vector]]:
+
+        # Compute the position and linear velocities (mixed representation) of
+        # all collidable points belonging to the robot.
+        W_p_C, W_ṗ_C = js.contact.collidable_point_kinematics(model=model, data=data)
+
+        # Extract the material deformation corresponding to the collidable points.
+        assert isinstance(data.state.contact, SoftContactsState)
+        m = data.state.contact.tangential_deformation
+
+        # Compute the contact forces for all collidable points.
+        # Since we treat them as independent, we can vmap the computation.
+        W_f, ṁ = jax.vmap(
+            lambda p, v, m: SoftContacts.compute_contact_force(
+                position=p,
+                velocity=v,
+                tangential_deformation=m,
+                parameters=self.parameters,
+                terrain=self.terrain,
+            )
+        )(W_p_C, W_ṗ_C, m)
+
+        return W_f, (ṁ,)
 
     @staticmethod
     @jax.jit

--- a/src/jaxsim/terrain/terrain.py
+++ b/src/jaxsim/terrain/terrain.py
@@ -155,7 +155,7 @@ class PlaneTerrain(FlatTerrain):
             (
                 hash(self._height),
                 HashedNumpyArray.hash_of_array(
-                    array=jnp.array(self._normal, dtype=float)
+                    array=np.array(self._normal, dtype=float)
                 ),
             )
         )


### PR DESCRIPTION
The new contact models that have been introduced recently need to consider the whole system dynamics to compute the contact forces. This was not necessary in the original `SoftContacts` model. However, this is just a simplification specific to the `SoftContacts` model implementation, and it is the main reason why they can run so fast compared to the new models.

I believe that the most generic APIs take `model` and `data` as input arguments instead of `position` and `velocity`. This also aligns the disparity in which the `position|velocity` arguments of `SoftContacts` were the individual ones, while for the other contact models were the vmapped ones. Furthermore, it removes the ambiguity for the other contact models in which the passed  `position|velocity` could differ from the kinematics that can be computed from `model|data`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--247.org.readthedocs.build//247/

<!-- readthedocs-preview jaxsim end -->