### PR TITLE
Account for joint torques in relaxed rigid contact model

### DIFF
--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -273,6 +273,7 @@ class RelaxedRigidContacts(ContactModel):
                     model=model,
                     data=data,
                     link_forces=references.link_forces(model=model, data=data),
+                    joint_forces=references.joint_force_references(model=model),
                 )
             )
             BW_ν = data.generalized_velocity()


### PR DESCRIPTION
This PR fixes a bug for which the contact model was not able to compensate for tangential forces generated by joint torques.

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <td>
    <video src=https://github.com/user-attachments/assets/d34e0c0c-b3af-4771-bc5e-f3792710f59b>
  </td>
  <td>
    <video src=https://github.com/user-attachments/assets/70d4e45a-81ea-4e94-aeca-842458346e59>
  </td>

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--251.org.readthedocs.build//251/

<!-- readthedocs-preview jaxsim end -->