### PR TITLE
Remove `*ContactsState` classes

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -144,7 +144,8 @@ def collidable_point_dynamics(
             The joint force references to apply to the joints.
 
     Returns:
-        The 6D force applied to each collidable point and additional data based on the contact model configured:
+        The 6D force applied to each collidable point and additional data based
+        on the contact model configured:
         - Soft: the material deformation rate.
         - Rigid: no additional data.
         - QuasiRigid: no additional data.
@@ -156,21 +157,13 @@ def collidable_point_dynamics(
     """
 
     # Import privately the contacts classes.
-    from jaxsim.rbda.contacts import (
-        RelaxedRigidContacts,
-        RelaxedRigidContactsState,
-        RigidContacts,
-        RigidContactsState,
-        SoftContacts,
-        SoftContactsState,
-    )
+    from jaxsim.rbda.contacts import RelaxedRigidContacts, RigidContacts, SoftContacts
 
     # Build the soft contact model.
     match model.contact_model:
 
         case SoftContacts():
             assert isinstance(model.contact_model, SoftContacts)
-            assert isinstance(data.state.contact, SoftContactsState)
 
             # Compute the 6D force expressed in the inertial frame and applied to each
             # collidable point, and the corresponding material deformation rate.
@@ -187,7 +180,6 @@ def collidable_point_dynamics(
 
         case RigidContacts():
             assert isinstance(model.contact_model, RigidContacts)
-            assert isinstance(data.state.contact, RigidContactsState)
 
             # Compute the 6D force expressed in the inertial frame and applied to each
             # collidable point.
@@ -203,7 +195,6 @@ def collidable_point_dynamics(
 
         case RelaxedRigidContacts():
             assert isinstance(model.contact_model, RelaxedRigidContacts)
-            assert isinstance(data.state.contact, RelaxedRigidContactsState)
 
             # Compute the 6D force expressed in the inertial frame and applied to each
             # collidable point.

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -172,7 +172,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             dtype=float,
         ).squeeze()
 
-        gravity = jnp.zeros(3, dtype=float).at[2].set(-standard_gravity)
+        gravity = jnp.zeros(3).at[2].set(-standard_gravity)
 
         joint_positions = jnp.atleast_1d(
             jnp.array(

--- a/src/jaxsim/rbda/contacts/__init__.py
+++ b/src/jaxsim/rbda/contacts/__init__.py
@@ -1,9 +1,5 @@
 from . import relaxed_rigid, rigid, soft
-from .common import ContactModel, ContactsParams, ContactsState
-from .relaxed_rigid import (
-    RelaxedRigidContacts,
-    RelaxedRigidContactsParams,
-    RelaxedRigidContactsState,
-)
-from .rigid import RigidContacts, RigidContactsParams, RigidContactsState
-from .soft import SoftContacts, SoftContactsParams, SoftContactsState
+from .common import ContactModel, ContactsParams
+from .relaxed_rigid import RelaxedRigidContacts, RelaxedRigidContactsParams
+from .rigid import RigidContacts, RigidContactsParams
+from .soft import SoftContacts, SoftContactsParams

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -53,6 +53,27 @@ class ContactModel(JaxsimDataclass):
     parameters: ContactsParams
     terrain: jaxsim.terrain.Terrain
 
+    @classmethod
+    @abc.abstractmethod
+    def build(
+        cls: type[Self],
+        parameters: ContactsParams,
+        terrain: jaxsim.terrain.Terrain,
+        **kwargs,
+    ) -> Self:
+        """
+        Create a `ContactModel` instance with specified parameters.
+
+        Args:
+            parameters: The parameters of the contact model.
+            terrain: The considered terrain.
+
+        Returns:
+            The `ContactModel` instance.
+        """
+
+        pass
+
     @abc.abstractmethod
     def compute_contact_forces(
         self,

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -14,41 +14,6 @@ except ImportError:
     from typing_extensions import Self
 
 
-class ContactsState(JaxsimDataclass):
-    """
-    Abstract class storing the state of the contacts model.
-    """
-
-    @classmethod
-    @abc.abstractmethod
-    def build(cls: type[Self], **kwargs) -> Self:
-        """
-        Build the contact state object.
-
-        Returns:
-            The contact state object.
-        """
-        pass
-
-    @classmethod
-    @abc.abstractmethod
-    def zero(cls: type[Self], **kwargs) -> Self:
-        """
-        Build a zero contact state.
-
-        Returns:
-            The zero contact state.
-        """
-        pass
-
-    @abc.abstractmethod
-    def valid(self, **kwargs) -> jtp.BoolLike:
-        """
-        Check if the contacts state is valid.
-        """
-        pass
-
-
 class ContactsParams(JaxsimDataclass):
     """
     Abstract class representing the parameters of a contact model.
@@ -108,6 +73,27 @@ class ContactModel(JaxsimDataclass):
         """
 
         pass
+
+    @classmethod
+    def zero_state_variables(cls, model: js.model.JaxSimModel) -> dict[str, jtp.Array]:
+        """
+        Build zero state variables of the contact model.
+
+        Args:
+            model: The robot model considered by the contact model.
+
+        Note:
+            There are contact models that require to extend the state vector of the
+            integrated ODE system with additional variables. Our integrators are
+            capable of operating on a generic state, as long as it is a PyTree.
+            This method builds the zero state variables of the contact model as a
+            dictionary of JAX arrays.
+
+        Returns:
+            A dictionary storing the zero state variables of the contact model.
+        """
+
+        return {}
 
     def initialize_model_and_data(
         self,

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -11,6 +11,7 @@ import optax
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
+from jaxsim import logging
 from jaxsim.api.common import VelRepr
 from jaxsim.math import Adjoint
 from jaxsim.terrain.terrain import FlatTerrain, Terrain
@@ -161,12 +162,40 @@ class RelaxedRigidContacts(ContactModel):
     """Relaxed rigid contacts model."""
 
     parameters: RelaxedRigidContactsParams = dataclasses.field(
-        default_factory=RelaxedRigidContactsParams
+        default_factory=RelaxedRigidContactsParams.build
     )
 
     terrain: jax_dataclasses.Static[Terrain] = dataclasses.field(
-        default_factory=FlatTerrain
+        default_factory=FlatTerrain.build
     )
+
+    @classmethod
+    def build(
+        cls: type[Self],
+        parameters: RelaxedRigidContactsParams | None = None,
+        terrain: Terrain | None = None,
+        **kwargs,
+    ) -> Self:
+        """
+        Create a `RelaxedRigidContacts` instance with specified parameters.
+
+        Args:
+            parameters: The parameters of the rigid contacts model.
+            terrain: The considered terrain.
+
+        Returns:
+            The `RelaxedRigidContacts` instance.
+        """
+
+        if len(kwargs) != 0:
+            logging.debug(msg=f"Ignoring extra arguments: {kwargs}")
+
+        return cls(
+            parameters=(
+                parameters or cls.__dataclass_fields__["parameters"].default_factory()
+            ),
+            terrain=terrain or cls.__dataclass_fields__["terrain"].default_factory(),
+        )
 
     @jax.jit
     def compute_contact_forces(

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -15,7 +15,7 @@ from jaxsim.api.common import VelRepr
 from jaxsim.math import Adjoint
 from jaxsim.terrain.terrain import FlatTerrain, Terrain
 
-from .common import ContactModel, ContactsParams, ContactsState
+from .common import ContactModel, ContactsParams
 
 try:
     from typing import Self
@@ -154,29 +154,6 @@ class RelaxedRigidContactsParams(ContactsParams):
             and jnp.all(self.max_iterations > 0)
             and jnp.all(self.tolerance > 0.0)
         )
-
-
-@jax_dataclasses.pytree_dataclass
-class RelaxedRigidContactsState(ContactsState):
-    """Class storing the state of the relaxed rigid contacts model."""
-
-    def __eq__(self, other: RelaxedRigidContactsState) -> bool:
-        return hash(self) == hash(other)
-
-    @classmethod
-    def build(cls: type[Self]) -> Self:
-        """Create a `RelaxedRigidContactsState` instance"""
-
-        return cls()
-
-    @classmethod
-    def zero(cls: type[Self], **kwargs) -> Self:
-        """Build a zero `RelaxedRigidContactsState` instance from a `JaxSimModel`."""
-
-        return cls.build()
-
-    def valid(self, **kwargs) -> jtp.BoolLike:
-        return True
 
 
 @jax_dataclasses.pytree_dataclass

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -12,7 +12,7 @@ import jaxsim.typing as jtp
 from jaxsim.api.common import ModelDataWithVelocityRepresentation, VelRepr
 from jaxsim.terrain import FlatTerrain, Terrain
 
-from .common import ContactModel, ContactsParams, ContactsState
+from .common import ContactModel, ContactsParams
 
 try:
     from typing import Self
@@ -76,29 +76,6 @@ class RigidContactsParams(ContactsParams):
             and jnp.all(self.K >= 0.0)
             and jnp.all(self.D >= 0.0)
         )
-
-
-@jax_dataclasses.pytree_dataclass
-class RigidContactsState(ContactsState):
-    """Class storing the state of the rigid contacts model."""
-
-    def __eq__(self, other: RigidContactsState) -> bool:
-        return hash(self) == hash(other)
-
-    @classmethod
-    def build(cls: type[Self]) -> Self:
-        """Create a `RigidContactsState` instance"""
-
-        return cls()
-
-    @classmethod
-    def zero(cls: type[Self], **kwargs) -> Self:
-        """Build a zero `RigidContactsState` instance from a `JaxSimModel`."""
-
-        return cls.build()
-
-    def valid(self, **kwargs) -> jtp.BoolLike:
-        return True
 
 
 @jax_dataclasses.pytree_dataclass

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -88,7 +88,7 @@ class RigidContacts(ContactModel):
     )
 
     terrain: jax_dataclasses.Static[Terrain] = dataclasses.field(
-        default_factory=FlatTerrain
+        default_factory=FlatTerrain.build
     )
 
     @classmethod

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -9,6 +9,7 @@ import jax_dataclasses
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
+from jaxsim import logging
 from jaxsim.api.common import ModelDataWithVelocityRepresentation, VelRepr
 from jaxsim.terrain import FlatTerrain, Terrain
 
@@ -89,6 +90,34 @@ class RigidContacts(ContactModel):
     terrain: jax_dataclasses.Static[Terrain] = dataclasses.field(
         default_factory=FlatTerrain
     )
+
+    @classmethod
+    def build(
+        cls: type[Self],
+        parameters: RigidContactsParams | None = None,
+        terrain: Terrain | None = None,
+        **kwargs,
+    ) -> Self:
+        """
+        Create a `RigidContacts` instance with specified parameters.
+
+        Args:
+            parameters: The parameters of the rigid contacts model.
+            terrain: The considered terrain.
+
+        Returns:
+            The `RigidContacts` instance.
+        """
+
+        if len(kwargs) != 0:
+            logging.debug(msg=f"Ignoring extra arguments: {kwargs}")
+
+        return cls(
+            parameters=(
+                parameters or cls.__dataclass_fields__["parameters"].default_factory()
+            ),
+            terrain=terrain or cls.__dataclass_fields__["terrain"].default_factory(),
+        )
 
     @staticmethod
     def detect_contacts(

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -435,8 +435,7 @@ class SoftContacts(ContactModel):
         W_p_C, W_ṗ_C = js.contact.collidable_point_kinematics(model=model, data=data)
 
         # Extract the material deformation corresponding to the collidable points.
-        assert isinstance(data.state.contact, SoftContactsState)
-        m = data.state.contact.tangential_deformation
+        m = data.state.extended["tangential_deformation"]
 
         # Compute the contact forces for all collidable points.
         # Since we treat them as independent, we can vmap the computation.

--- a/src/jaxsim/terrain/terrain.py
+++ b/src/jaxsim/terrain/terrain.py
@@ -49,7 +49,7 @@ class FlatTerrain(Terrain):
     _height: float = dataclasses.field(default=0.0, kw_only=True)
 
     @staticmethod
-    def build(height: jtp.FloatLike) -> FlatTerrain:
+    def build(height: jtp.FloatLike = 0.0) -> FlatTerrain:
 
         return FlatTerrain(_height=float(height))
 

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -8,7 +8,7 @@ import jaxsim.api as js
 import jaxsim.rbda
 import jaxsim.typing as jtp
 from jaxsim import VelRepr
-from jaxsim.rbda.contacts import SoftContacts, SoftContactsParams, SoftContactsState
+from jaxsim.rbda.contacts import SoftContacts, SoftContactsParams
 
 # All JaxSim algorithms, excluding the variable-step integrators, should support
 # being automatically differentiated until second order, both in FWD and REV modes.
@@ -343,16 +343,13 @@ def test_ad_integration(
         model=model, velocity_representation=VelRepr.Inertial, key=subkey
     )
 
-    # Make sure that the active contact model is SoctContacts.
-    assert isinstance(data.state.contact, SoftContactsState)
-
     # State in VelRepr.Inertial representation.
     W_p_B = data.base_position()
     W_Q_B = data.base_orientation(dcm=False)
     s = data.joint_positions(model=model)
     W_v_WB = data.base_velocity()
     ṡ = data.joint_velocities(model=model)
-    m = data.state.contact.tangential_deformation
+    m = data.state.extended["tangential_deformation"]
 
     # Inputs.
     W_f_L = references.link_forces(model=model)
@@ -406,7 +403,7 @@ def test_ad_integration(
                     base_angular_velocity=W_v_WB[3:6],
                     joint_velocities=ṡ,
                 ),
-                contact=js.ode_data.SoftContactsState.build(tangential_deformation=m),
+                extended_state={"tangential_deformation": m},
             ),
         )
 
@@ -425,7 +422,7 @@ def test_ad_integration(
         xf_s = data_xf.joint_positions(model=model)
         xf_W_v_WB = data_xf.base_velocity()
         xf_ṡ = data_xf.joint_velocities(model=model)
-        xf_m = data_xf.state.contact.tangential_deformation
+        xf_m = data_xf.state.extended["tangential_deformation"]
 
         return xf_W_p_B, xf_W_Q_B, xf_s, xf_W_v_WB, xf_ṡ, xf_m
 


### PR DESCRIPTION
In the past few months, JaxSim has received numerous updates and additions to contact management. We now have three contact models (soon four), and the only one that requires to extend the ODE state vector that is integrated with the floating-base dynamics is the original `SoftContacts` model.

- This PR generalizes how additional variables can be introduced to the integrated state vector.
- The material deformation $\mathbf{m}$ used by the `SoftContacts` model is now treated as an augmented ODE state.
- This generalization allow users to use our integrators with their own custom dynamics (potentially including additional effects not currently considered in JaxSim, e.g. actuator dynamics and muskolo-skeletal models).

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--256.org.readthedocs.build//256/

<!-- readthedocs-preview jaxsim end -->