### PR TITLE
Split static and dynamic contact params

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -188,7 +188,6 @@ def collidable_point_dynamics(
                 data=data,
                 link_forces=link_forces,
                 joint_force_references=joint_force_references,
-                solver_tol=1e-3,
             )
 
             aux_data = dict()

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -17,6 +17,12 @@ except ImportError:
 class ContactsParams(JaxsimDataclass):
     """
     Abstract class representing the parameters of a contact model.
+
+    Note:
+        This class is supposed to store only the tunable parameters of the contact
+        model, i.e. all those parameters that can be changed during runtime.
+        If the contact model has also static parameters, they should be stored
+        in the corresponding `ContactModel` class.
     """
 
     @classmethod
@@ -47,7 +53,7 @@ class ContactModel(JaxsimDataclass):
 
     Attributes:
         parameters: The parameters of the contact model.
-        terrain: The terrain model.
+        terrain: The considered terrain.
     """
 
     parameters: ContactsParams
@@ -85,7 +91,7 @@ class ContactModel(JaxsimDataclass):
         Compute the contact forces.
 
         Args:
-            model: The model to consider.
+            model: The robot model considered by the contact model.
             data: The data of the considered model.
 
         Returns:


### PR DESCRIPTION
This PR introduces the support to separate contact parameters in two categories:

- The **static parameters** are stored in the contact model class. A vectorized computation must share the same static parameters.
- The **dynamic parameters** are stored in the contact parameters class. These parameters are copied in `JaxSimModelData` and the user logic can change them during runtime (assuming that the corresponding PyTree remains compatible). These are also the types of parameters over which AD can be performed.

This separation is necessary when the computation of contact forces operates over a JIT primitive that requires a static argument (e.g. fixing the number of iterations of an iterative solver by converting a while loop to a for loop).

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--257.org.readthedocs.build//257/

<!-- readthedocs-preview jaxsim end -->