### PR TITLE
Remove absolute time from `JaxSimModelData` and introduce `JaxSimModel.time_step`

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -32,6 +32,10 @@ class JaxSimModel(JaxsimDataclass):
 
     model_name: Static[str]
 
+    time_step: jaxsim.integrators.TimeStep = dataclasses.field(
+        default_factory=lambda: jnp.array(0.001, dtype=float),
+    )
+
     terrain: Static[jaxsim.terrain.Terrain] = dataclasses.field(
         default_factory=jaxsim.terrain.FlatTerrain.build, repr=False
     )
@@ -64,6 +68,9 @@ class JaxSimModel(JaxsimDataclass):
         if self.model_name != other.model_name:
             return False
 
+        if self.time_step != other.time_step:
+            return False
+
         if self.kin_dyn_parameters != other.kin_dyn_parameters:
             return False
 
@@ -74,6 +81,7 @@ class JaxSimModel(JaxsimDataclass):
         return hash(
             (
                 hash(self.model_name),
+                hash(float(self.time_step)),
                 hash(self.kin_dyn_parameters),
                 hash(self.contact_model),
             )
@@ -88,6 +96,7 @@ class JaxSimModel(JaxsimDataclass):
         model_description: str | pathlib.Path | rod.Model,
         model_name: str | None = None,
         *,
+        time_step: jtp.FloatLike | None = None,
         terrain: jaxsim.terrain.Terrain | None = None,
         contact_model: jaxsim.rbda.contacts.ContactModel | None = None,
         is_urdf: bool | None = None,
@@ -102,6 +111,9 @@ class JaxSimModel(JaxsimDataclass):
                 its content, or a pre-parsed/pre-built rod model.
             model_name:
                 The name of the model. If not specified, it is read from the description.
+            time_step:
+                The default time step to consider for the simulation. It can be
+                manually overridden in the function that steps the simulation.
             terrain: The terrain to consider (the default is a flat infinite plane).
             contact_model:
                 The contact model to consider.
@@ -135,6 +147,7 @@ class JaxSimModel(JaxsimDataclass):
         model = JaxSimModel.build(
             model_description=intermediate_description,
             model_name=model_name,
+            time_step=time_step,
             terrain=terrain,
             contact_model=contact_model,
         )
@@ -150,6 +163,7 @@ class JaxSimModel(JaxsimDataclass):
         model_description: ModelDescription,
         model_name: str | None = None,
         *,
+        time_step: jtp.FloatLike | None = None,
         terrain: jaxsim.terrain.Terrain | None = None,
         contact_model: jaxsim.rbda.contacts.ContactModel | None = None,
     ) -> JaxSimModel:
@@ -162,6 +176,9 @@ class JaxSimModel(JaxsimDataclass):
                 of the model.
             model_name:
                 The name of the model. If not specified, it is read from the description.
+            time_step:
+                The default time step to consider for the simulation. It can be
+                manually overridden in the function that steps the simulation.
             terrain: The terrain to consider (the default is a flat infinite plane).
             contact_model:
                 The contact model to consider.
@@ -179,6 +196,11 @@ class JaxSimModel(JaxsimDataclass):
             terrain or JaxSimModel.__dataclass_fields__["terrain"].default_factory()
         )
 
+        # Consider the default time step if not specified.
+        time_step = (
+            time_step or JaxSimModel.__dataclass_fields__["time_step"].default_factory()
+        )
+
         # Create the default contact model.
         # It will be populated with an initial estimation of good parameters.
         # While these might not be the best, they are a good starting point.
@@ -192,6 +214,7 @@ class JaxSimModel(JaxsimDataclass):
             kin_dyn_parameters=js.kin_dyn_parameters.KynDynParameters.build(
                 model_description=model_description
             ),
+            time_step=time_step,
             terrain=terrain,
             contact_model=contact_model,
             # The following is wrapped as hashless since it's a static argument, and we
@@ -1915,8 +1938,8 @@ def step(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    dt: jtp.FloatLike,
     integrator: jaxsim.integrators.Integrator,
+    dt: jtp.FloatLike | None = None,
     integrator_state: dict[str, Any] | None = None,
     link_forces: jtp.MatrixLike | None = None,
     joint_force_references: jtp.VectorLike | None = None,
@@ -1928,9 +1951,9 @@ def step(
     Args:
         model: The model to consider.
         data: The data of the considered model.
-        dt: The time step to consider.
         integrator: The integrator to use.
         integrator_state: The state of the integrator.
+        dt: The time step to consider. If not specified, it is read from the model.
         link_forces:
             The 6D forces to apply to the links expressed in the frame corresponding to
             the velocity representation of `data`.
@@ -1951,17 +1974,20 @@ def step(
 
     integrator_state = integrator_state if integrator_state is not None else dict()
 
-    # Extract the initial resources.
+    # Initialize the time-related variables.
     t0_ns = data.time_ns
     state_t0 = data.state
-    integrator_state_x0 = integrator_state
+    dt = dt if dt is not None else model.time_step
+
+    # Rename the integrator state.
+    integrator_state_t0 = integrator_state
 
     # Step the dynamics forward.
     state_tf, integrator_state_tf = integrator.step(
         x0=state_t0,
-        t0=jnp.array(t0_ns / 1e9).astype(float),
-        dt=dt,
-        params=integrator_state_x0,
+        t0=jnp.array(t0_ns / 1e9, dtype=float),
+        dt=jnp.array(dt).astype(float),
+        params=integrator_state_t0,
         # Always inject the current (model, data) pair into the system dynamics
         # considered by the integrator, and include the input variables represented
         # by the pair (joint_force_references, link_forces).
@@ -1980,6 +2006,7 @@ def step(
         ),
     )
 
+    # Compute the final time, addressing possible overflow (specific to 32bit).
     tf_ns = t0_ns + jnp.array(dt * 1e9, dtype=t0_ns.dtype)
     tf_ns = jnp.where(tf_ns >= t0_ns, tf_ns, jnp.array(0, dtype=t0_ns.dtype))
 
@@ -1991,13 +2018,8 @@ def step(
         false_fun=lambda: None,
     )
 
-    data_tf = (
-        # Store the new state of the model and the new time.
-        data.replace(
-            state=state_tf,
-            time_ns=tf_ns,
-        )
-    )
+    # Store the new state of the model and the new time.
+    data_tf = data.replace(state=state_tf, time_ns=tf_ns)
 
     # Post process the simulation state, if needed.
     match model.contact_model:

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -63,7 +63,6 @@ def wrap_system_dynamics_for_integration(
         # Update the state and time stored inside data.
         with data_f.editable(validate=True) as data_rw:
             data_rw.state = x
-            data_rw.time_ns = jnp.array(t * 1e9).astype(data_rw.time_ns.dtype)
 
         # Evaluate the system dynamics, allowing to override the kwargs originally
         # passed when the closure was created.

--- a/src/jaxsim/rbda/contacts/visco_elastic.py
+++ b/src/jaxsim/rbda/contacts/visco_elastic.py
@@ -928,7 +928,6 @@ class ViscoElasticContacts(common.ContactModel):
         # Create the data at the final time.
         with data.editable(validate=True) as data_tf:
             data_tf: js.data.JaxSimModelData
-            data_tf.time_ns = data.time_ns + (dt * 1e9).astype(data.time_ns.dtype)
 
         data_tf = data_tf.reset_joint_positions(q_plus[7:])
         data_tf = data_tf.reset_base_position(q_plus[0:3])

--- a/src/jaxsim/rbda/contacts/visco_elastic.py
+++ b/src/jaxsim/rbda/contacts/visco_elastic.py
@@ -926,13 +926,10 @@ class ViscoElasticContacts(common.ContactModel):
         )
 
         # Create the data at the final time.
-        with data.editable(validate=True) as data_tf:
-            data_tf: js.data.JaxSimModelData
-
+        data_tf = data.copy()
         data_tf = data_tf.reset_joint_positions(q_plus[7:])
         data_tf = data_tf.reset_base_position(q_plus[0:3])
         data_tf = data_tf.reset_base_quaternion(q_plus[3:7])
-
         data_tf = data_tf.reset_joint_velocities(W_ν_plus[6:])
         data_tf = data_tf.reset_base_velocity(
             W_ν_plus[0:6], velocity_representation=jaxsim.VelRepr.Inertial

--- a/src/jaxsim/rbda/contacts/visco_elastic.py
+++ b/src/jaxsim/rbda/contacts/visco_elastic.py
@@ -956,7 +956,7 @@ def step(
     Args:
         model: The model to consider.
         data: The data of the considered model.
-        dt: The time step to consider.
+        dt: The time step to consider. If not specified, it is read from the model.
         link_forces:
             The 6D forces to apply to the links expressed in the frame corresponding to
             the velocity representation of `data`.
@@ -970,11 +970,14 @@ def step(
     assert isinstance(model.contact_model, ViscoElasticContacts)
     assert isinstance(data.contacts_params, ViscoElasticContactsParams)
 
+    # Initialize the time step.
+    dt = dt if dt is not None else model.time_step
+
     # Compute the contact forces with the exponential integrator.
     W_f̅_C, (W_f̿_C, m_tf) = model.contact_model.compute_contact_forces(
         model=model,
         data=data,
-        dt=dt,
+        dt=jnp.array(dt).astype(float),
         link_forces=link_forces,
         joint_force_references=joint_force_references,
     )

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -70,14 +70,14 @@ def test_box_with_external_forces(
     # Initialize the integrator.
     tf = 0.5
     dt = 0.001
-    T = jnp.arange(start=0, stop=tf * 1e9, step=dt * 1e9, dtype=int)
+    T_ns = jnp.arange(start=0, stop=tf * 1e9, step=dt * 1e9, dtype=int)
     integrator_state = integrator.init(x0=data0.state, t0=0.0, dt=dt)
 
     # Copy the initial data...
     data = data0.copy()
 
     # ... and step the simulation.
-    for t_ns in T:
+    for _ in T_ns:
 
         data, integrator_state = js.model.step(
             model=model,
@@ -89,7 +89,6 @@ def test_box_with_external_forces(
         )
 
     # Check that the box didn't move.
-    assert data.time() == t_ns / 1e9 + dt
     assert data.base_position() == pytest.approx(data0.base_position())
     assert data.base_orientation() == pytest.approx(data0.base_orientation())
 
@@ -158,16 +157,14 @@ def test_box_with_zero_gravity(
 
     # Initialize the integrator.
     tf, dt = 1.0, 0.010
-    T = jnp.arange(start=0, stop=tf * 1e9, step=dt * 1e9, dtype=int)
+    T_ns = jnp.arange(start=0, stop=tf * 1e9, step=dt * 1e9, dtype=int)
     integrator_state = integrator.init(x0=data0.state, t0=0.0, dt=dt)
 
     # Copy the initial data...
     data = data0.copy()
 
     # ... and step the simulation.
-    for t_ns in T:
-
-        assert data.time() == t_ns / 1e9
+    for _ in T_ns:
 
         with (
             data.switch_velocity_representation(velocity_representation),
@@ -182,9 +179,6 @@ def test_box_with_zero_gravity(
                 integrator_state=integrator_state,
                 link_forces=references.link_forces(model=model, data=data),
             )
-
-    # Check the final simulation time.
-    assert data.time() == T[-1] / 1e9 + dt
 
     # Check that the box moved as expected.
     assert data.base_position() == pytest.approx(


### PR DESCRIPTION
In this PR, I'm finally addressing a longstanding problem that complicated the usage of 32-bit precision as described in #136. After having explored more complex solutions, we decided to stop tracking the absolute simulation time within JaxSim, moving the responsibility to downstream code if necessary.

More details:

- Remove `JaxSimData.time()` and `JaxSimData.time_ns`.
- Add a new `JaxSimModel.time_step` that stores the default integration $\Delta t$. This can be useful in some particular cases, for example those system dynamics that need to know the $\Delta t$ used by the integrator (e.g. semi-implicit integrators, visco-elastic contacts, etc).
- Add a new `t0` argument to `jaxsim.api.model.step`, so that it's still possible to run AD w.r.t. the time if the dynamics considered by the integrator is time-dependent (this is rarely the case). 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--262.org.readthedocs.build//262/

<!-- readthedocs-preview jaxsim end -->