### PR TITLE
Disable host callbacks and enforce 32bit precision when running on TPU

### DIFF
--- a/src/jaxsim/__init__.py
+++ b/src/jaxsim/__init__.py
@@ -8,18 +8,34 @@ def _jnp_options() -> None:
 
     import jax
 
-    # Enable by default 64bit precision in JAX.
-    if os.environ.get("JAX_ENABLE_X64", "1") != "0":
+    # Check if running on TPU
+    is_tpu = jax.devices()[0].platform == "tpu"
 
+    # Determine if 64-bit precision is requested
+    use_x64 = os.environ.get("JAX_ENABLE_X64", "1") != "0"
+
+    # Raise an error if 64-bit precision is not allowed on TPU
+    if is_tpu and use_x64:
+        msg = "64-bit precision is not allowed on TPU. Enforcing 32bit precision."
+        logging.error(msg)
+
+    # Enable 64-bit precision in JAX
+    elif not is_tpu and use_x64:
         logging.info("Enabling JAX to use 64bit precision")
         jax.config.update("jax_enable_x64", True)
 
         import jax.numpy as jnp
         import numpy as np
 
+        # Verify 64-bit precision is correctly set
         if jnp.empty(0, dtype=float).dtype != jnp.empty(0, dtype=np.float64).dtype:
             logging.warning("Failed to enable 64bit precision in JAX")
 
+    # Enforce 32-bit precision on TPU
+    elif is_tpu:
+        logging.warning("JAX is running on TPU; 32bit precision is enforced.")
+
+    # Warn about experimental use of 32-bit precision
     else:
         logging.warning(
             "Using 32bit precision in JaxSim is still experimental, please avoid to use variable step integrators."

--- a/src/jaxsim/exceptions.py
+++ b/src/jaxsim/exceptions.py
@@ -17,6 +17,10 @@ def raise_if(
             format string (fmt), whose fields are filled with the args and kwargs.
     """
 
+    # Disable host callback if running on TPU.
+    if jax.devices()[0].platform == "tpu":
+        return
+
     # Check early that the format string is well-formed.
     try:
         _ = msg.format(*args, **kwargs)


### PR DESCRIPTION
This PR introduces two main changes to allow runnning simulations on TPUs:
1. host callbacks are disable by default, since they are not fully supported for TPU architectures
2. 32bit precision is enforced when importing `jaxsim`

Example error on `js.model.step`:
```python
[/usr/local/lib/python3.10/dist-packages/jax/_src/interpreters/pxla.py](https://localhost:8080/#) in __call__(self, *args)
   1275           or self.has_host_callbacks):
   1276         input_bufs = self._add_tokens_to_inputs(input_bufs)
-> 1277         results = self.xla_executable.execute_sharded(
   1278             input_bufs, with_tokens=True
   1279         )

XlaRuntimeError: INVALID_ARGUMENT: Unknown send channel 33 for host callbacks
```

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--263.org.readthedocs.build//263/

<!-- readthedocs-preview jaxsim end -->