### PR TITLE
Add helper to convert `JaxSimModelData` to `mujoco.mjData`

### DIFF
--- a/src/jaxsim/mujoco/__init__.py
+++ b/src/jaxsim/mujoco/__init__.py
@@ -1,3 +1,4 @@
 from .loaders import RodModelToMjcf, SdfToMjcf, UrdfToMjcf
 from .model import MujocoModelHelper
+from .utils import mujoco_data_from_jaxsim
 from .visualizer import MujocoVideoRecorder, MujocoVisualizer

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -646,7 +646,7 @@ class MujocoCamera:
     def build(cls, **kwargs) -> MujocoCamera:
 
         if not all(isinstance(value, str) for value in kwargs.values()):
-            raise ValueError("Values must be strings")
+            raise ValueError(f"Values must be strings: {kwargs}")
 
         return cls(**kwargs)
 

--- a/src/jaxsim/mujoco/model.py
+++ b/src/jaxsim/mujoco/model.py
@@ -107,7 +107,8 @@ class MujocoModelHelper:
             size = [float(el) for el in hfield_element["@size"].split(" ")]
             size[0], size[1] = heightmap_radius_xy
             size[2] = 1.0
-            size[3] = max(0, -min(hfield))
+            # The following could be zero but Mujoco complains if it's exactly zero.
+            size[3] = max(0.000_001, -min(hfield))
 
             # Replace the 'size' attribute.
             hfields_dict[heightmap_name]["@size"] = " ".join(str(el) for el in size)

--- a/src/jaxsim/mujoco/model.py
+++ b/src/jaxsim/mujoco/model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import pathlib
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import mujoco as mj
@@ -315,7 +315,7 @@ class MujocoModelHelper:
         self.data.qpos[sl] = position
 
     def set_joint_positions(
-        self, joint_names: list[str], positions: npt.NDArray | list[npt.NDArray]
+        self, joint_names: Sequence[str], positions: npt.NDArray | list[npt.NDArray]
     ) -> None:
         """Set the positions of multiple joints."""
 

--- a/src/jaxsim/mujoco/utils.py
+++ b/src/jaxsim/mujoco/utils.py
@@ -47,14 +47,14 @@ def mujoco_data_from_jaxsim(
     # Create the helper to operate on the Mujoco model and data.
     model_helper = MujocoModelHelper(model=mujoco_model, data=mujoco_data)
 
-    # Set the model position.
+    # If the model is fixed-base, the Mujoco model won't have the joint corresponding
+    # to the floating base, and the helper would raise an exception.
     if jaxsim_model.floating_base():
 
+        # Set the model position.
         model_helper.set_base_position(position=np.array(jaxsim_data.base_position()))
 
-    # Set the model orientation.
-    if jaxsim_model.floating_base():
-
+        # Set the model orientation.
         model_helper.set_base_orientation(
             orientation=np.array(jaxsim_data.base_orientation())
         )
@@ -83,21 +83,17 @@ def mujoco_data_from_jaxsim(
             if j.name not in set(jaxsim_model.joint_names())
         }
 
-        # Get all the joints in the Mujoco and JaxSim models.
-        joints_mujoco = set(model_helper.joint_names())
-
         # Set the positions of the removed joints.
-        for joint_name in set(joints_removed_dict.keys()):
-
-            if joint_name not in joints_mujoco:
-                continue
-
-            _ = [
-                model_helper.set_joint_position(
-                    position=joints_removed_dict[joint_name].initial_position,
-                    joint_name=joint_name,
-                )
-            ]
+        _ = [
+            model_helper.set_joint_position(
+                position=joints_removed_dict[joint_name].initial_position,
+                joint_name=joint_name,
+            )
+            # Select all original joint that have been removed from the JaxSim model
+            # that are still present in the Mujoco model.
+            for joint_name in joints_removed_dict
+            if joint_name in model_helper.joint_names()
+        ]
 
     # Return the mujoco data with updated kinematics.
     mj.mj_forward(mujoco_model, model_helper.data)

--- a/src/jaxsim/mujoco/utils.py
+++ b/src/jaxsim/mujoco/utils.py
@@ -1,0 +1,105 @@
+import mujoco as mj
+import numpy as np
+
+from . import MujocoModelHelper
+
+
+def mujoco_data_from_jaxsim(
+    mujoco_model: mj.MjModel,
+    jaxsim_model,
+    jaxsim_data,
+    mujoco_data: mj.MjData | None = None,
+    update_removed_joints: bool = True,
+) -> mj.MjData:
+    """
+    Create a Mujoco data object from a JaxSim model and data objects.
+
+    Args:
+        mujoco_model: The Mujoco model object corresponding to the JaxSim model.
+        jaxsim_model: The JaxSim model object from which the Mujoco model was created.
+        jaxsim_data: The JaxSim data object containing the state of the model.
+        mujoco_data: An optional Mujoco data object. If None, a new one will be created.
+        update_removed_joints:
+            If True, the positions of the joints that have been removed during the
+            model reduction process will be set to their initial values.
+
+    Returns:
+        The Mujoco data object containing the state of the JaxSim model.
+
+    Note:
+        This method is useful to initialize a Mujoco data object used for visualization
+        with the state of a JaxSim model. In particular, this function takes care of
+        initializing the positions of the joints that have been removed during the
+        model reduction process. After the initial creation of the Mujoco data object,
+        it's faster to update the state using an external MujocoModelHelper object.
+    """
+
+    # The package `jaxsim.mujoco` is supposed to be jax-independent.
+    # We import all the JaxSim resources privately.
+    import jaxsim.api as js
+
+    if not isinstance(jaxsim_model, js.model.JaxSimModel):
+        raise ValueError("The `jaxsim_model` argument must be a JaxSimModel object.")
+
+    if not isinstance(jaxsim_data, js.data.JaxSimModelData):
+        raise ValueError("The `jaxsim_data` argument must be a JaxSimModelData object.")
+
+    # Create the helper to operate on the Mujoco model and data.
+    model_helper = MujocoModelHelper(model=mujoco_model, data=mujoco_data)
+
+    # Set the model position.
+    if jaxsim_model.floating_base():
+
+        model_helper.set_base_position(position=np.array(jaxsim_data.base_position()))
+
+    # Set the model orientation.
+    if jaxsim_model.floating_base():
+
+        model_helper.set_base_orientation(
+            orientation=np.array(jaxsim_data.base_orientation())
+        )
+
+    # Set the joint positions.
+    if jaxsim_model.dofs() > 0:
+
+        model_helper.set_joint_positions(
+            joint_names=list(jaxsim_model.joint_names()),
+            positions=np.array(
+                jaxsim_data.joint_positions(
+                    model=jaxsim_model, joint_names=jaxsim_model.joint_names()
+                )
+            ),
+        )
+
+    # Updating these joints is not necessary after the first time.
+    # Users can disable this update after initialization.
+    if update_removed_joints:
+
+        # Create a dictionary with the joints that have been removed for various reasons
+        # (like link lumping due to model reduction).
+        joints_removed_dict = {
+            j.name: j
+            for j in jaxsim_model.description._joints_removed
+            if j.name not in set(jaxsim_model.joint_names())
+        }
+
+        # Get all the joints in the Mujoco and JaxSim models.
+        joints_mujoco = set(model_helper.joint_names())
+
+        # Set the positions of the removed joints.
+        for joint_name in set(joints_removed_dict.keys()):
+
+            if joint_name not in joints_mujoco:
+                continue
+
+            _ = [
+                model_helper.set_joint_position(
+                    position=joints_removed_dict[joint_name].initial_position,
+                    joint_name=joint_name,
+                )
+            ]
+
+    # Return the mujoco data with updated kinematics.
+    mj.mj_forward(mujoco_model, model_helper.data)
+
+    return model_helper.data

--- a/src/jaxsim/mujoco/visualizer.py
+++ b/src/jaxsim/mujoco/visualizer.py
@@ -89,7 +89,7 @@ class MujocoVideoRecorder:
         if not exist_ok and path.is_file():
             raise FileExistsError(f"The file '{path}' already exists.")
 
-        media.write_video(path=path, images=self.frames, fps=self.fps)
+        media.write_video(path=path, images=np.array(self.frames), fps=self.fps)
 
     @staticmethod
     def compute_down_sampling(original_fps: int, target_min_fps: int) -> int:


### PR DESCRIPTION
The main benefit of using this helper w.r.t. plain usage of `MujocoModelHelper` is the logic to initialize the positions of removed joints. An example usage is the following:

```python
import time

import jax.numpy as jnp
import jaxsim.api as js
import jaxsim.mujoco
import numpy as np
import requests

repo = "icub-tech-iit/ergocub-gazebo-simulations"
url = f"https://raw.githubusercontent.com/{repo}/master/models/stickBot/model.urdf"

# Download and read file.
urdf_string = requests.get(url).text

# Build the model.
model = js.model.JaxSimModel.build_from_model_description(model_description=urdf_string)

# Reduce the model by specifying custom elbow angles.
model = js.model.reduce(
    model=model,
    considered_joints=tuple(
        j
        for j in model.joint_names()
        # Remove upper body and sensors.
        if "neck" not in j
        and "wrist" not in j
        and "torso" not in j
        and "elbow" not in j
        and "shoulder" not in j
        and "lidar" not in j
        and "camera" not in j
    ),
    locked_joint_positions={
        "r_elbow": np.deg2rad(45),
        "l_elbow": np.deg2rad(45),
    },
)

# Create the model data.
data = js.data.JaxSimModelData.build(
    model=model,
    base_position=jnp.array([0, 0, 2.0]),
)

# ===================
# Open the visualizer
# ===================

# Convert the model to MJCF.
mjcf_string, assets = jaxsim.mujoco.UrdfToMjcf().convert(urdf=model.built_from)

# Create the Mujoco model helper.
mj_model_helper = jaxsim.mujoco.MujocoModelHelper.build_from_xml(
    mjcf_description=mjcf_string,
    assets=assets,
)

# Store in the model helper the data initialized from the JaxSim model.
# This is helpful the first time, so that the removed joint positions are
# stored in the Mujoco data object.
mj_model_helper.data = jaxsim.mujoco.mujoco_data_from_jaxsim(
    mujoco_model=mj_model_helper.model,
    jaxsim_model=model,
    jaxsim_data=data,
)

# Create the visualizer.
viz = jaxsim.mujoco.MujocoVisualizer(
    model=mj_model_helper.model, data=mj_model_helper.data
)


with viz.open(
    lookat=np.array(data.base_position()), elevation=-10, distance=5, azimut=180 - 30
) as viewer:

    # Here you can loop over a simulated trajectory.
    # It is not necessary to use the jaxsim.mujoco.mujoco_data_from_jaxsim helper.

    # for ...:
    #     with viewer.lock():
    #         mj_model_helper.set_base_position(position=np.array(...))
    #         mj_model_helper.set_base_orientation(orientation=np.array(...))
    #
    #         if model.dofs() > 0:
    #             mj_model_helper.set_joint_positions(
    #                 joint_names=list(model.joint_names()), positions=np.array(...)
    #             )

    viz.sync(viewer=viewer)

    while viewer.is_running():
        time.sleep(0.500)
```

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--264.org.readthedocs.build//264/

<!-- readthedocs-preview jaxsim end -->