### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    # Disable rebasing automatically existing pull requests.
+    rebase-strategy: "disabled"
     # Group updates to a single PR.
     groups:
       dependencies:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+
+  # Check for updates to GitHub Actions every month.
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
+    # Group updates to a single PR.
+    groups:
+      dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
Frankly speaking, dependabot has always annoyed me mainly because it used to open too frequent PRs. However, I've recently discovered that the rate of updates can be configured granularly, and it's also possible to merge together all necessary updates in a single PR.

I'd like to give it a try by setting one update per month to the actions part of our GitHub workflows. We can fine tune it in the future, if needed.

- https://docs.github.com/en/code-security/dependabot
- `github-actions`: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#github-actions
- `groups`: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--266.org.readthedocs.build//266/

<!-- readthedocs-preview jaxsim end -->