### PR TITLE
Consider only enabled collidable points in contact forces computation for `Rigid`, `RelaxedRigid` and `Soft` contact models

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -199,16 +199,22 @@ def collidable_point_dynamics(
     )
 
     # Compute the transforms of the implicit frames `C[L] = (W_p_C, [L])`
-    # associated to each collidable point.
+    # associated to the enabled collidable point.
     # In inertial-fixed representation, the computation of these transforms
     # is not necessary and the conversion below becomes a no-op.
+
+    # Get the indices of the enabled collidable points.
+    indices_of_enabled_collidable_points = (
+        model.kin_dyn_parameters.contact_parameters.indices_of_enabled_collidable_points
+    )
+
     W_H_C = (
         js.contact.transforms(model=model, data=data)
         if data.velocity_representation is not VelRepr.Inertial
         else jnp.zeros(
             shape=(len(model.kin_dyn_parameters.contact_parameters.body), 4, 4)
         )
-    )
+    )[indices_of_enabled_collidable_points]
 
     # Convert the 6D forces to the active representation.
     f_Ci = jax.vmap(

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -743,6 +743,9 @@ class ContactParameters(JaxsimDataclass):
         point:
             The translations between the link frame and the collidable point, expressed
             in the coordinates of the parent link frame.
+        enabled:
+            A tuple of booleans representing, for each collidable point, whether it is
+            enabled or not in contact models.
 
     Note:
         Contrarily to LinkParameters and JointParameters, this class is not meant

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -2287,7 +2287,14 @@ def step(
                 msg="Baumgarte stabilization is not supported with ForwardEuler integrators",
             )
 
-            W_p_C = js.contact.collidable_point_positions(model, data_tf)
+            # Extract the indices corresponding to the enabled collidable points.
+            indices_of_enabled_collidable_points = (
+                model.kin_dyn_parameters.contact_parameters.indices_of_enabled_collidable_points
+            )
+
+            W_p_C = js.contact.collidable_point_positions(model, data_tf)[
+                indices_of_enabled_collidable_points
+            ]
 
             # Compute the penetration depth of the collidable points.
             δ, *_ = jax.vmap(
@@ -2296,8 +2303,9 @@ def step(
             )(W_p_C, jnp.zeros_like(W_p_C), model.terrain)
 
             with data_tf.switch_velocity_representation(VelRepr.Mixed):
-
-                J_WC = js.contact.jacobian(model, data_tf)
+                J_WC = js.contact.jacobian(model, data_tf)[
+                    indices_of_enabled_collidable_points
+                ]
                 M = js.model.free_floating_mass_matrix(model, data_tf)
 
                 # Compute the impact velocity.

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -7,6 +7,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import jax_dataclasses
+import numpy.typing as npt
 import optax
 
 import jaxsim.api as js
@@ -322,18 +323,25 @@ class RelaxedRigidContacts(common.ContactModel):
 
             return jnp.dot(h, n̂)
 
+        # Get the indices of the enabled collidable points.
+        indices_of_enabled_collidable_points = (
+            model.kin_dyn_parameters.contact_parameters.indices_of_enabled_collidable_points
+        )
+
         # Compute the position and linear velocities (mixed representation) of
         # all collidable points belonging to the robot.
-        position, velocity = js.contact.collidable_point_kinematics(
-            model=model, data=data
-        )
+        p, v = js.contact.collidable_point_kinematics(model=model, data=data)
+        position = p[indices_of_enabled_collidable_points]
+        velocity = v[indices_of_enabled_collidable_points]
 
         # Compute the activation state of the collidable points
         δ = jax.vmap(detect_contact)(*position.T)
 
         # Compute the transforms of the implicit frames corresponding to the
         # collidable points.
-        W_H_C = js.contact.transforms(model=model, data=data)
+        W_H_C = js.contact.transforms(model=model, data=data)[
+            indices_of_enabled_collidable_points
+        ]
 
         with (
             references.switch_velocity_representation(VelRepr.Mixed),
@@ -357,13 +365,19 @@ class RelaxedRigidContacts(common.ContactModel):
 
             Jl_WC = jnp.vstack(
                 jax.vmap(lambda J, height: J * (height < 0))(
-                    js.contact.jacobian(model=model, data=data)[:, :3, :], δ
+                    js.contact.jacobian(model=model, data=data)[
+                        indices_of_enabled_collidable_points, :3, :
+                    ],
+                    δ,
                 )
             )
 
             J̇_WC = jnp.vstack(
                 jax.vmap(lambda J̇, height: J̇ * (height < 0))(
-                    js.contact.jacobian_derivative(model=model, data=data)[:, :3], δ
+                    js.contact.jacobian_derivative(model=model, data=data)[
+                        indices_of_enabled_collidable_points, :3
+                    ],
+                    δ,
                 ),
             )
 
@@ -373,6 +387,7 @@ class RelaxedRigidContacts(common.ContactModel):
             penetration=δ,
             velocity=velocity,
             parameters=data.contacts_params,
+            indices_of_enabled_collidable_points=indices_of_enabled_collidable_points,
         )
 
         # Compute the Delassus matrix and the free mixed linear acceleration of
@@ -499,6 +514,7 @@ class RelaxedRigidContacts(common.ContactModel):
         penetration: jtp.Array,
         velocity: jtp.Array,
         parameters: RelaxedRigidContactsParams,
+        indices_of_enabled_collidable_points: npt.NDArray,
     ) -> tuple:
         """
         Compute the contact jacobian and the reference acceleration.
@@ -508,6 +524,7 @@ class RelaxedRigidContacts(common.ContactModel):
             penetration: The penetration of the collidable points.
             velocity: The velocity of the collidable points.
             parameters: The parameters of the relaxed rigid contacts model.
+            indices_of_enabled_collidable_points: The indices of the enabled collidable points.
 
         Returns:
             A tuple containing the reference acceleration, the regularization matrix, the stiffness, and the damping.
@@ -597,7 +614,7 @@ class RelaxedRigidContacts(common.ContactModel):
                 *jax.vmap(compute_row)(
                     link_idx=jnp.array(
                         model.kin_dyn_parameters.contact_parameters.body
-                    ),
+                    )[indices_of_enabled_collidable_points],
                     penetration=penetration,
                     velocity=velocity,
                 ),

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -310,22 +310,16 @@ class RigidContacts(ContactModel):
 
             M = js.model.free_floating_mass_matrix(model=model, data=data)
 
-            J_WC = js.contact.jacobian(model=model, data=data)[
-                indices_of_enabled_collidable_points
-            ]
-            J̇_WC = js.contact.jacobian_derivative(model=model, data=data)[
-                indices_of_enabled_collidable_points
-            ]
+            J_WC = js.contact.jacobian(model=model, data=data)
+            J̇_WC = js.contact.jacobian_derivative(model=model, data=data)
 
-            W_H_C = js.contact.transforms(model=model, data=data)[
-                indices_of_enabled_collidable_points
-            ]
+            W_H_C = js.contact.transforms(model=model, data=data)
 
         # Compute the position and linear velocities (mixed representation) of
-        # all collidable points belonging to the robot.
-        p, v = js.contact.collidable_point_kinematics(model=model, data=data)
-        position = p[indices_of_enabled_collidable_points]
-        velocity = v[indices_of_enabled_collidable_points]
+        # all enabled collidable points belonging to the robot.
+        position, velocity = js.contact.collidable_point_kinematics(
+            model=model, data=data
+        )
 
         # Compute the penetration depth and velocity of the collidable points.
         # Note that this function considers the penetration in the normal direction.

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -285,6 +285,13 @@ class RigidContacts(ContactModel):
         # Import qpax privately just in this method.
         import qpax
 
+        # Get the indices of the enabled collidable points.
+        indices_of_enabled_collidable_points = (
+            model.kin_dyn_parameters.contact_parameters.indices_of_enabled_collidable_points
+        )
+
+        n_collidable_points = len(indices_of_enabled_collidable_points)
+
         link_forces = jnp.atleast_2d(
             jnp.array(link_forces, dtype=float).squeeze()
             if link_forces is not None
@@ -299,24 +306,26 @@ class RigidContacts(ContactModel):
 
         # Compute kin-dyn quantities used in the contact model.
         with data.switch_velocity_representation(VelRepr.Mixed):
-
             BW_ν = data.generalized_velocity()
 
             M = js.model.free_floating_mass_matrix(model=model, data=data)
 
-            J_WC = js.contact.jacobian(model=model, data=data)
-            J̇_WC = js.contact.jacobian_derivative(model=model, data=data)
+            J_WC = js.contact.jacobian(model=model, data=data)[
+                indices_of_enabled_collidable_points
+            ]
+            J̇_WC = js.contact.jacobian_derivative(model=model, data=data)[
+                indices_of_enabled_collidable_points
+            ]
 
-            W_H_C = js.contact.transforms(model=model, data=data)
+            W_H_C = js.contact.transforms(model=model, data=data)[
+                indices_of_enabled_collidable_points
+            ]
 
         # Compute the position and linear velocities (mixed representation) of
         # all collidable points belonging to the robot.
-        position, velocity = js.contact.collidable_point_kinematics(
-            model=model, data=data
-        )
-
-        # Get the number of collidable points.
-        n_collidable_points = len(model.kin_dyn_parameters.contact_parameters.body)
+        p, v = js.contact.collidable_point_kinematics(model=model, data=data)
+        position = p[indices_of_enabled_collidable_points]
+        velocity = v[indices_of_enabled_collidable_points]
 
         # Compute the penetration depth and velocity of the collidable points.
         # Note that this function considers the penetration in the normal direction.
@@ -460,7 +469,7 @@ class RigidContacts(ContactModel):
         return G
 
     @staticmethod
-    def _compute_ineq_bounds(n_collidable_points: jtp.FloatLike) -> jtp.Vector:
+    def _compute_ineq_bounds(n_collidable_points: int) -> jtp.Vector:
 
         n_constraints = 6 * n_collidable_points
         return jnp.zeros(shape=(n_constraints,))

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -454,8 +454,6 @@ class SoftContacts(common.ContactModel):
         # all the collidable points belonging to the robot and extract the ones
         # for the enabled collidable points.
         W_p_C, W_ṗ_C = js.contact.collidable_point_kinematics(model=model, data=data)
-        W_p_C_enabled = W_p_C[indices_of_enabled_collidable_points]
-        W_ṗ_C_enabled = W_ṗ_C[indices_of_enabled_collidable_points]
 
         # Extract the material deformation corresponding to the collidable points.
         m = data.state.extended["tangential_deformation"]
@@ -475,7 +473,7 @@ class SoftContacts(common.ContactModel):
                 parameters=data.contacts_params,
                 terrain=model.terrain,
             )
-        )(W_p_C_enabled, W_ṗ_C_enabled, m_enabled)
+        )(W_p_C, W_ṗ_C, m_enabled)
 
         ṁ = ṁ.at[indices_of_enabled_collidable_points].set(ṁ_enabled)
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -212,6 +212,16 @@ def test_simulation_with_soft_contacts(
         model.contact_model = jaxsim.rbda.contacts.SoftContacts.build(
             terrain=model.terrain,
         )
+        # Enable a subset of the collidable points.
+        enabled_collidable_points_mask = np.zeros(
+            len(model.kin_dyn_parameters.contact_parameters.body), dtype=bool
+        )
+        enabled_collidable_points_mask[[0, 1, 2, 3]] = True
+        model.kin_dyn_parameters.contact_parameters.enabled = tuple(
+            enabled_collidable_points_mask.tolist()
+        )
+
+    assert np.sum(model.kin_dyn_parameters.contact_parameters.enabled) == 4
 
     # Initialize the maximum penetration of each collidable point at steady state.
     max_penetration = 0.001
@@ -296,6 +306,16 @@ def test_simulation_with_rigid_contacts(
         model.contact_model = jaxsim.rbda.contacts.RigidContacts.build(
             terrain=model.terrain,
         )
+        # Enable a subset of the collidable points.
+        enabled_collidable_points_mask = np.zeros(
+            len(model.kin_dyn_parameters.contact_parameters.body), dtype=bool
+        )
+        enabled_collidable_points_mask[[0, 1, 2, 3]] = True
+        model.kin_dyn_parameters.contact_parameters.enabled = tuple(
+            enabled_collidable_points_mask.tolist()
+        )
+
+    assert np.sum(model.kin_dyn_parameters.contact_parameters.enabled) == 4
 
     # Initialize the maximum penetration of each collidable point at steady state.
     # This model is rigid, so we expect (almost) no penetration.
@@ -338,6 +358,16 @@ def test_simulation_with_relaxed_rigid_contacts(
         model.contact_model = jaxsim.rbda.contacts.RelaxedRigidContacts.build(
             terrain=model.terrain,
         )
+        # Enable a subset of the collidable points.
+        enabled_collidable_points_mask = np.zeros(
+            len(model.kin_dyn_parameters.contact_parameters.body), dtype=bool
+        )
+        enabled_collidable_points_mask[[0, 1, 2, 3]] = True
+        model.kin_dyn_parameters.contact_parameters.enabled = tuple(
+            enabled_collidable_points_mask.tolist()
+        )
+
+    assert np.sum(model.kin_dyn_parameters.contact_parameters.enabled) == 4
 
     # Initialize the maximum penetration of each collidable point at steady state.
     # This model is quasi-rigid, so we expect (almost) no penetration.


### PR DESCRIPTION
In this PR I'm adding the possibility to consider only a subset of the available collidable points of the model in the computation of the contact forces. 

I'm extending the behavior already introduced in  #248 for `ViscoElasticContacts` to
- `RigidContacts`
- `RelaxedRigidContacts`
- `SoftContacts`

~The modifications in this PR have the intention of be sufficiently general to easily extend this also to `SoftContacts`.~

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--274.org.readthedocs.build//274/

<!-- readthedocs-preview jaxsim end -->