### PR TITLE
Update Devcontainer configuration to use `pixi`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,26 +1,19 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
-COPY environment.yml /opt/environment.yml
+# syntax=docker/dockerfile:1.4
+FROM mcr.microsoft.com/devcontainers/base:jammy
 
-# Enable by default the conda environment for all users.
-# The prefix is the one used by the micromamba feature.
-ENV CONDA_PREFIX_JAXSIM=/opt/conda/envs/jaxsim
-RUN echo 'function activate_conda() {' >> /etc/bash.bashrc &&\
-    echo '  eval "$(micromamba shell hook -s bash)"' >> /etc/bash.bashrc &&\
-    echo '  micromamba activate ${CONDA_PREFIX_JAXSIM-$CONDA_PREFIX}' >> /etc/bash.bashrc &&\
-    echo '}' >> /etc/bash.bashrc &&\
-    echo '[[ -x $(which micromamba) && -d ${CONDA_PREFIX_JAXSIM-$CONDA_PREFIX} ]] && activate_conda' >> /etc/bash.bashrc &&\
-    echo '[[ -x $(which micromamba) && ! -x $(which mamba) ]] && alias mamba="$(which micromamba)"' >> /etc/bash.bashrc &&\
-    echo '[[ -x $(which micromamba) && ! -x $(which conda) ]] && alias conda="$(which micromamba)"' >> /etc/bash.bashrc
+ARG PROJECT_NAME=jaxsim
+ARG PIXI_VERSION=v0.35.0
 
-# Provide libGL.so.1 from the host OS
-RUN sudo apt-get update &&\
-    sudo apt-get install -y --no-install-recommends libgl1 &&\
-    rm -rf /var/lib/apt/lists/*
+RUN curl -o /usr/local/bin/pixi -SL https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl \
+    && chmod +x /usr/local/bin/pixi \
+    && pixi info
 
-# The Python extension in VSCode is not able to detect the interpreter installed with micromamba.
-# As documented as follows, we provide a suggestion through an environment variable.
-# https://code.visualstudio.com/docs/python/environments#_where-the-extension-looks-for-environments
-ENV WORKON_HOME=$CONDA_PREFIX_JAXSIM
+# Add LFS repository and install.
+RUN apt-get update && apt-get install -y curl \
+    && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+    && apt install -y git-lfs
 
-# Specify the workdir of the container
-WORKDIR /workspace/jaxsim
+USER vscode
+WORKDIR /home/vscode
+
+RUN echo 'eval "$(pixi completion -s bash)"' >> /home/vscode/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,21 +5,22 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"build": {
 		"context": "..",
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
-		"ghcr.io/mamba-org/devcontainer-features/micromamba:1": {
-			"envFile": "/opt/environment.yml",
-		},
-	},
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+
+    // Put `.pixi` folder in a mounted volume of a case-insensitive filesystem.
+    "mounts": ["source=${localWorkspaceFolderBasename}-pixi,target=${containerWorkspaceFolder}/.pixi,type=volume"],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+	"postCreateCommand": "sudo chown vscode .pixi && git lfs pull --include='pixi.lock' && pixi install --environment=test-cpu",
 
 	// Configure tool-specific properties.
 	// "customizations": {},
@@ -28,7 +29,23 @@
 	// "remoteUser": "root"
 
 	// VSCode extensions
-	"extensions": [
-		"ms-python.python",
-	],
+	"customizations": {
+		"vscode": {
+			"settings": {
+                		"python.pythonPath": "/workspaces/jaxsim/.pixi/envs/test-cpu/bin/python",
+				"python.defaultInterpreterPath": "/workspaces/jaxsim/.pixi/envs/test-cpu/bin/python",
+				"python.terminal.activateEnvironment": true,
+				"python.terminal.activateEnvInCurrentTerminal": true
+			},
+			"extensions": [
+				"ms-python.python",
+				"donjayamanne.python-extension-pack",
+				"ms-toolsai.jupyter",
+				"GitHub.codespaces",
+                		"GitHub.copilot",
+				"ms-azuretools.vscode-docker",
+                		"charliermarsh.ruff"
+			]
+		}
+	}
 }


### PR DESCRIPTION
This pull request updates the Devcontainer configuration by using `pixi` as the base image and installing additional extensions. The Dockerfile has been modified to pull the `pixi.lock` from LFS, create the environment and then use a shell-hook script to activate it. Moreover, the `devcontainer.json` file has been updated to set the default Python interpreter path and add some useful extensions to the VSCode environment.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--276.org.readthedocs.build//276/

<!-- readthedocs-preview jaxsim end -->