### PR TITLE
Fix reset of system velocity in `model.step`

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -2156,9 +2156,9 @@ def step(
                     )
                 )
 
-            # Reset the generalized velocity.
-            data_tf = data_tf.reset_base_velocity(BW_nu_post_impact[0:6])
-            data_tf = data_tf.reset_joint_velocities(BW_nu_post_impact[6:])
+                # Reset the generalized velocity.
+                data_tf = data_tf.reset_base_velocity(BW_nu_post_impact[0:6])
+                data_tf = data_tf.reset_joint_velocities(BW_nu_post_impact[6:])
 
     # Restore the input velocity representation.
     data_tf = data_tf.replace(


### PR DESCRIPTION
This PR fixes a regression on the reset of the system velocity in `model.step` for rigid contacts.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--278.org.readthedocs.build//278/

<!-- readthedocs-preview jaxsim end -->