### PR TITLE
Raise error if HTTP request fails

### DIFF
--- a/examples/jaxsim_for_robot_controllers.ipynb
+++ b/examples/jaxsim_for_robot_controllers.ipynb
@@ -109,7 +109,7 @@
     "if response.status_code == 200:\n",
     "    model_urdf_string = response.text\n",
     "else:\n",
-    "    logging.error(\"Failed to fetch data\")"
+    "    raise RuntimeError(\"Failed to fetch data.\")"
    ]
   },
   {


### PR DESCRIPTION
This PR modifies an example notebook so that an error is raised when the HTTP request for downloading the cartpole URDF fails.