### PR TITLE
Fix timeout in ReadTheDocs build

### DIFF
--- a/examples/jaxsim_for_robot_controllers.ipynb
+++ b/examples/jaxsim_for_robot_controllers.ipynb
@@ -93,23 +93,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.path.abspath(\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "PZM7hEvFZH4h"
    },
    "outputs": [],
    "source": [
-    "# @title Download the URDF model\n",
+    "# @title Load the URDF model\n",
+    "import pathlib\n",
     "\n",
-    "import requests\n",
-    "\n",
-    "url = \"https://raw.githubusercontent.com/ami-iit/jaxsim/main/examples/assets/cartpole.urdf\"\n",
-    "\n",
-    "response = requests.get(url)\n",
-    "\n",
-    "if response.status_code == 200:\n",
-    "    model_urdf_string = response.text\n",
-    "else:\n",
-    "    raise RuntimeError(\"Failed to fetch data.\")"
+    "model_urdf_string = pathlib.Path(\n",
+    "    os.path.abspath(\"\") + \"/assets/cartpole.urdf\"\n",
+    ").read_text()"
    ]
   },
   {


### PR DESCRIPTION
Adjust the timeout settings to fix timeout errors during RTD builds.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--288.org.readthedocs.build//288/

<!-- readthedocs-preview jaxsim end -->