### PR TITLE
Fix simulation test with relaxed rigid contact model

### DIFF
--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -461,8 +461,8 @@ class RelaxedRigidContacts(common.ContactModel):
                 terrain=model.terrain,
                 K=1e6,
                 D=2e3,
-                p=0.0,
-                q=0.0,
+                p=0.5,
+                q=0.5,
                 # No tangential initial forces.
                 mu=0.0,
                 tangential_deformation=jnp.zeros(3),


### PR DESCRIPTION
This PR fixes the simulation test with the relaxed rigid contact model by replacing the mass matrix inversion method with `linalg.inv` for accuracy and by using a non-linear Hunt-Crossley model to reduce the drifts in the tangential directions

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--294.org.readthedocs.build//294/

<!-- readthedocs-preview jaxsim end -->