### PR TITLE
Allow alternative contact model in example notebook

### DIFF
--- a/examples/jaxsim_as_physics_engine.ipynb
+++ b/examples/jaxsim_as_physics_engine.ipynb
@@ -219,7 +219,12 @@
     "# Note that these parameters are the nominal parameters shared among\n",
     "# all parallel instances. If needed, they can be overridden in the\n",
     "# vectorized data object that will be created later.\n",
-    "print(model.contact_model.parameters)"
+    "print(model.contact_model.parameters)\n",
+    "\n",
+    "# Update the data object with the new contact model parameters.\n",
+    "data_single = data_single.replace(\n",
+    "    contacts_params=model.contact_model.parameters, validate=False\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the `single_data` object with after the initialization of `model.contact_model` attribute. This change introduces support for an alternative contact model in the example notebook `jaxsim_as_physics_engine`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--297.org.readthedocs.build//297/

<!-- readthedocs-preview jaxsim end -->