### PR TITLE
Add GPU usage checks and configuration in the testing suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,3 +268,6 @@ cuda-version = "12.*"
 # Pinning a specific version awaiting the following to get addressed:
 # https://github.com/conda-forge/jaxlib-feedstock/issues/285
 jaxlib = { version = "<0.4.31", build = "*cuda*" }
+
+[tool.pixi.feature.gpu.tasks]
+gpu-tests = { cmd = "pytest --gpu-only", depends_on = ["pipcheck"] }


### PR DESCRIPTION
This PR introduces a GPU usage check in `pytest` to ensure that tests run only when a GPU is available and utilized. Moreover, it updates the `pyproject.toml` to include GPU tests configuration for `pixi`.

Fixes #298

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--303.org.readthedocs.build//303/

<!-- readthedocs-preview jaxsim end -->