### PR TITLE
Change neutral element transform matrix in contact

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -211,7 +211,7 @@ def collidable_point_dynamics(
     W_H_C = (
         js.contact.transforms(model=model, data=data)
         if data.velocity_representation is not VelRepr.Inertial
-        else jnp.zeros(shape=(len(indices_of_enabled_collidable_points), 4, 4))
+        else jnp.eye(shape=(len(indices_of_enabled_collidable_points), 4, 4))
     )
 
     # Convert the 6D forces to the active representation.

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -211,7 +211,7 @@ def collidable_point_dynamics(
     W_H_C = (
         js.contact.transforms(model=model, data=data)
         if data.velocity_representation is not VelRepr.Inertial
-        else jnp.eye(shape=(len(indices_of_enabled_collidable_points), 4, 4))
+        else jnp.stack([jnp.eye(4)] * len(indices_of_enabled_collidable_points))
     )
 
     # Convert the 6D forces to the active representation.


### PR DESCRIPTION
In this PR we change the neutral element for the transformation matrix from `jnp.zeros` to `jnp.eye` in the `collidable_point_dynamics` method of the contact class. 

This will have no effect on the code execution since such transform matrix was not used, this change is done only to avoid confusion by declaring the correct neutral element for the transformation matrix. 


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--305.org.readthedocs.build//305/

<!-- readthedocs-preview jaxsim end -->