### PR TITLE
Add benchmark tests for model dynamics and kinematics functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ multi_line_output = 3
 profile = "black"
 
 [tool.pytest.ini_options]
-addopts = "-rsxX -v --strict-markers"
+addopts = "-rsxX -v --strict-markers --benchmark-skip"
 minversion = "6.0"
 testpaths = [
     "tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ style = [
 testing = [
     "idyntree >= 12.2.1",
     "pytest >=6.0",
+    "pytest-benchmark",
     "pytest-icdiff",
     "robot-descriptions"
 ]
@@ -241,6 +242,7 @@ idyntree = "*"
 isort = "*"
 pre-commit = "*"
 pytest = "*"
+pytest-benchmark = "*"
 pytest-icdiff = "*"
 robot_descriptions = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,8 @@ jaxsim = { path = "./", editable = true }
 
 [tool.pixi.feature.test.tasks]
 pipcheck = "pip check"
-tests = { cmd = "pytest", depends_on = ["pipcheck"] }
+test = { cmd = "pytest", depends_on = ["pipcheck"] }
+benchmark = { cmd = "pytest --benchmark-only", depends_on = ["pipcheck"] }
 
 [tool.pixi.feature.test.dependencies]
 black = "24.*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,16 +23,17 @@ def pytest_addoption(parser):
     parser.addoption(
         "--batch-size",
         action="store",
-        default="1",
+        default="None",
         help="Batch size for vectorized benchmarks (only applies to benchmark tests)",
     )
 
 
 def pytest_generate_tests(metafunc):
-    if "batch_size" in metafunc.fixturenames:
-        metafunc.parametrize(
-            "batch_size", [1, int(metafunc.config.getoption("--batch-size"))]
-        )
+    if (
+        "batch_size" in metafunc.fixturenames
+        and (batch_size := metafunc.config.getoption("--batch-size")) != "None"
+    ):
+        metafunc.parametrize("batch_size", [1, int(batch_size)])
 
 
 def check_gpu_usage():
@@ -121,6 +122,18 @@ def velocity_representation(request) -> jaxsim.VelRepr:
     """
 
     return request.param
+
+
+@pytest.fixture(scope="session")
+def batch_size(request) -> int:
+    """
+    Fixture providing the batch size for vectorized benchmarks.
+
+    Returns:
+        The batch size for vectorized benchmarks.
+    """
+
+    return 1
 
 
 # ================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,20 @@ def pytest_addoption(parser):
         help="Run tests only if GPU is available and utilized",
     )
 
+    parser.addoption(
+        "--batch-size",
+        action="store",
+        default="1",
+        help="Batch size for vectorized benchmarks (only applies to benchmark tests)",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    if "batch_size" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "batch_size", [1, int(metafunc.config.getoption("--batch-size"))]
+        )
+
 
 def check_gpu_usage():
     # Set environment variable to prioritize GPU.

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,141 @@
+import jax
+import pytest
+
+import jaxsim
+import jaxsim.api as js
+
+
+def vectorize_data(model: js.model.JaxSimModel, batch_size: str):
+    key = jax.random.PRNGKey(seed=0)
+
+    return jax.vmap(
+        lambda key: js.data.random_model_data(
+            model=model,
+            key=key,
+        )
+    )(jax.numpy.repeat(key[None, :], repeats=batch_size, axis=0))
+
+
+def benchmark_test_function(func, model, benchmark, batch_size=None):
+    """Reusability wrapper for benchmark tests."""
+    if batch_size is None:
+        # Phase 1: Run without batch size
+        data = js.data.random_model_data(model=model)
+
+        # Warm-up call to avoid including compilation time
+        func(model, data)
+        benchmark(func, model, data)
+    else:
+        # Phase 2: Run with batch size
+        data = vectorize_data(model=model, batch_size=batch_size)
+
+        # Warm-up call to avoid including compilation time
+        jax.vmap(func, in_axes=(None, 0))(model, data)
+        benchmark(jax.vmap(func, in_axes=(None, 0)), model, data)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_forward_dynamics_aba(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    benchmark_test_function(js.model.forward_dynamics_aba, model, benchmark, batch_size)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_free_floating_bias_forces(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    benchmark_test_function(
+        js.model.free_floating_bias_forces, model, benchmark, batch_size
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_forward_kinematics(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    benchmark_test_function(js.model.forward_kinematics, model, benchmark, batch_size)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_free_floating_mass_matrix(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    benchmark_test_function(
+        js.model.free_floating_mass_matrix, model, benchmark, batch_size
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_free_floating_jacobian(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    benchmark_test_function(
+        js.model.generalized_free_floating_jacobian, model, benchmark, batch_size
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_free_floating_jacobian_derivative(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    benchmark_test_function(
+        js.model.generalized_free_floating_jacobian_derivative,
+        model,
+        benchmark,
+        batch_size,
+    )
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_soft_contact_model(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_rigid_contact_model(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    with model.editable(validate=False) as model:
+        model.contact_model = jaxsim.rbda.contacts.RigidContacts()
+
+    benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("batch_size", [None, 1024])
+def test_relaxed_rigid_contact_model(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    with model.editable(validate=False) as model:
+        model.contact_model = jaxsim.rbda.contacts.RelaxedRigidContacts()
+
+    benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)


### PR DESCRIPTION
This PR introduce benchmark tests for the main dynamics and kinematics computations. It adds testing dependencies with `pytest-benchmark`, and refactors test tasks to accommodate separate benchmark commands and batch size options. 
The functionality is deactivated by default in `pyproject.toml`, but it can be executed using `pytest --benchmark-only`.
It accepts `--gpu-only` argument to force benchmarks on GPU and `batch_size` to execute a scalability benchmark between a single instance and vmap-ped instances.

### Example outputs

`pixi run benchmark`:
```python
------------------------------------------------------------------------------------------------------------ benchmark: 9 tests -----------------------------------------------------------------------------------------------------------
Name (time in us)                                 Min                     Max                    Mean                  StdDev                  Median                     IQR            Outliers         OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_free_floating_mass_matrix               668.9780 (1.0)          995.2040 (1.0)          712.7330 (1.0)           33.4595 (1.0)          706.3365 (1.0)           37.7500 (1.17)       145;28  1,403.0499 (1.0)         846           1
test_free_floating_jacobian                  672.9260 (1.01)       1,289.1520 (1.30)         804.3073 (1.13)          44.7064 (1.34)         802.1930 (1.14)          43.2710 (1.34)       168;43  1,243.3059 (0.89)        994           1
test_free_floating_bias_forces               722.3350 (1.08)      10,419.1420 (10.47)      6,028.8793 (8.46)       1,542.9537 (46.11)      6,201.4970 (8.78)       1,140.9615 (35.41)      102;54    165.8683 (0.12)        545           1
test_forward_kinematics                      735.0250 (1.10)       1,647.0210 (1.65)         878.8692 (1.23)          66.6741 (1.99)         865.4790 (1.23)          69.1180 (2.15)       169;27  1,137.8258 (0.81)        841           1
test_forward_dynamics_aba                    755.6730 (1.13)       1,852.3510 (1.86)       1,023.1366 (1.44)         118.2762 (3.53)       1,002.6300 (1.42)         113.4565 (3.52)        91;26    977.3866 (0.70)        464           1
test_free_floating_jacobian_derivative       777.8730 (1.16)       1,041.6140 (1.05)         846.2553 (1.19)          46.9076 (1.40)         834.3230 (1.18)          32.2220 (1.0)        135;92  1,181.6766 (0.84)        879           1
test_soft_contact_model                      900.1000 (1.35)       2,330.2620 (2.34)       1,345.1338 (1.89)         144.2846 (4.31)       1,329.7120 (1.88)         148.6097 (4.61)       194;43    743.4205 (0.53)        889           1
test_relaxed_rigid_contact_model           1,078.0790 (1.61)      10,514.3700 (10.57)      6,735.0419 (9.45)       1,245.0905 (37.21)      6,802.2275 (9.63)       1,333.8580 (41.40)      139;22    148.4772 (0.11)        572           1
test_rigid_contact_model                   1,138.9810 (1.70)     816,099.6470 (820.03)   500,624.1572 (702.40)   178,718.0517 (>1000.0)  512,070.2870 (724.97)   225,799.3550 (>1000.0)    130;31      1.9975 (0.00)        523           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

`pixi run benchmark -e tasks-gpu --batch-size 512` (The number in square brackets indicates the batch size):

```python
---------------------------------------------------------------------------------------------------- benchmark: 18 tests -----------------------------------------------------------------------------------------------------
Name (time in ms)                                      Min                   Max                  Mean             StdDev                Median                IQR            Outliers       OPS            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_forward_kinematics[1]                          1.8009 (1.0)          4.3127 (1.06)         2.9470 (1.25)      0.9253 (12.30)        3.3940 (1.51)      1.8846 (22.37)       143;0  339.3328 (0.80)        256           1
test_free_floating_jacobian[1]                      2.0132 (1.12)         4.2390 (1.04)         3.2654 (1.38)      0.6851 (9.10)         3.5514 (1.58)      1.4286 (16.96)       128;0  306.2451 (0.72)        372           1
test_free_floating_jacobian_derivative[1]           2.1137 (1.17)         4.3813 (1.07)         2.3581 (1.0)       0.3296 (4.38)         2.2545 (1.0)       0.1271 (1.51)        22;32  424.0673 (1.0)         227           1
test_soft_contact_model[1]                          2.4866 (1.38)         4.0777 (1.0)          2.7673 (1.17)      0.2771 (3.68)         2.6664 (1.18)      0.2139 (2.54)        53;51  361.3670 (0.85)        297           1
test_forward_dynamics_aba[1]                        2.6070 (1.45)        11.1712 (2.74)         5.0564 (2.14)      0.9521 (12.65)        5.2323 (2.32)      0.6709 (7.96)        33;29  197.7706 (0.47)        220           1
test_free_floating_jacobian[512]                    4.8500 (2.69)         6.9356 (1.70)         5.4233 (2.30)      0.6499 (8.64)         5.0692 (2.25)      1.1290 (13.40)        39;0  184.3902 (0.43)        154           1
test_free_floating_mass_matrix[1]                   5.0083 (2.78)        11.3466 (2.78)         5.9254 (2.51)      0.9890 (13.14)        5.5988 (2.48)      0.7360 (8.74)         12;9  168.7660 (0.40)        122           1
test_free_floating_bias_forces[1]                   7.1066 (3.95)         8.6387 (2.12)         7.6323 (3.24)      0.3866 (5.14)         7.5881 (3.37)      0.5891 (6.99)         39;0  131.0223 (0.31)        124           1
test_free_floating_mass_matrix[512]                 8.2956 (4.61)        12.0640 (2.96)         9.1814 (3.89)      0.8170 (10.86)        8.8992 (3.95)      0.5695 (6.76)        16;10  108.9164 (0.26)         85           1
test_free_floating_jacobian_derivative[512]        11.0173 (6.12)        11.4923 (2.82)        11.1830 (4.74)      0.0753 (1.0)         11.1652 (4.95)      0.0843 (1.0)          18;4   89.4216 (0.21)         92           1
test_rigid_contact_model[1]                        25.1228 (13.95)       34.5887 (8.48)        27.3099 (11.58)     2.9030 (38.58)       25.7857 (11.44)     3.9770 (47.20)         8;0   36.6167 (0.09)         31           1
test_relaxed_rigid_contact_model[1]                25.4737 (14.14)       33.1540 (8.13)        26.8563 (11.39)     2.0617 (27.40)       26.2679 (11.65)     0.3905 (4.64)          3;4   37.2352 (0.09)         31           1
test_free_floating_bias_forces[512]                54.3469 (30.18)       68.9552 (16.91)       57.7963 (24.51)     3.6669 (48.73)       56.6147 (25.11)     3.1415 (37.29)         3;2   17.3021 (0.04)         19           1
test_forward_kinematics[512]                       71.4622 (39.68)       78.5475 (19.26)       74.4439 (31.57)     2.6610 (35.36)       73.2366 (32.48)     4.0645 (48.24)         6;0   13.4329 (0.03)         14           1
test_forward_dynamics_aba[512]                     79.6087 (44.20)       83.9795 (20.59)       81.8233 (34.70)     1.3778 (18.31)       81.7144 (36.24)     1.8485 (21.94)         4;0   12.2215 (0.03)         12           1
test_soft_contact_model[512]                      108.8358 (60.43)      125.0750 (30.67)      118.0889 (50.08)     5.6074 (74.52)      120.0801 (53.26)     7.3157 (86.83)         3;0    8.4682 (0.02)          9           1
test_relaxed_rigid_contact_model[512]             530.0063 (294.29)     561.3926 (137.67)     546.0525 (231.56)   12.1117 (160.95)     545.1324 (241.79)   18.0091 (213.76)        2;0    1.8313 (0.00)          5           1
test_rigid_contact_model[512]                   1,582.5083 (878.71)   1,716.5533 (420.96)   1,632.0505 (692.10)   50.7684 (674.65)   1,615.9440 (716.75)   51.1773 (607.44)        1;0    0.6127 (0.00)          5           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
FYI @traversaro 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--308.org.readthedocs.build//308/

<!-- readthedocs-preview jaxsim end -->