### PR TITLE
Document environment variables usage

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -1,0 +1,44 @@
+Configuration
+=============
+
+.. _configuration:
+
+Environment Variables
+---------------------
+
+JaxSim uses environment variables to configure the application.
+
+Collision Dynamics
+~~~~~~~~~~~~~~~~~~
+
+The environment variables used to configure the collision dynamics start with
+``JAXSIM_COLLISION_``. The following variables are available:
+
+- ``JAXSIM_COLLISION_SPHERE_POINTS``: The number of collision points to use to approximate the sphere. *The default is ``50``.*
+- ``JAXSIM_COLLISION_MESH_ENABLED``: Enable or disable the mesh collision. *The default is ``False``.*
+- ``JAXSIM_COLLISION_USE_BOTTOM_ONLY``: Use only the bottom half of the box or sphere for collision detection. *The default is ``False``.*
+
+Testing
+~~~~~~~
+
+The environment variables used to configure the testing start with
+``JAXSIM_TEST_``. The following variables are available:
+
+- ``JAXSIM_TEST_SEED``: The seed to use for the random number generator. *The default is ``0``.*
+- ``JAXSIM_TEST_AD_ORDER``: The gradient order to use for the automatic differentiation tests. *The default is ``1``.*
+- ``JAXSIM_TEST_FD_STEP_SIZE``: The step size to use for the finite difference tests. *The default is the cube root of the machine epsilon.*
+
+Joint Dynamics
+~~~~~~~~~~~~~~
+
+The environment variables used to configure the joint dynamics start with
+``JAXSIM_JOINT_``. The following variables are available:
+
+- ``JAXSIM_JOINT_POSITION_LIMIT_DAMPER``: The damper value for the joint position limit. *The default is ``0``.*
+- ``JAXSIM_JOINT_POSITION_LIMIT_SPRING``: The spring value for the joint position limit. *The default is ``0``.*
+
+Logging
+~~~~~~~
+
+The environment variable ``JAXSIM_LOGGING_LEVEL`` can be used to set the logging level.
+The default is ``DEBUG`` for development and ``WARNING`` for production.

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -18,8 +18,8 @@ Environment variables starting with ``JAXSIM_COLLISION_`` are used to configure 
 - ``JAXSIM_COLLISION_USE_BOTTOM_ONLY``: Limits collision detection to only the bottom half of the box or sphere.
   *Default:* ``False``.
 
-  > [!NOTE]
-  > The bottom half is defined as the half of the box or sphere with the lowest z-coordinate in the collision link frame.
+.. note::
+  The bottom half is defined as the half of the box or sphere with the lowest z-coordinate in the collision link frame.
 
 
 Testing

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -18,6 +18,9 @@ Environment variables starting with ``JAXSIM_COLLISION_`` are used to configure 
 - ``JAXSIM_COLLISION_USE_BOTTOM_ONLY``: Limits collision detection to only the bottom half of the box or sphere.
   *Default:* ``False``.
 
+  > [!NOTE]
+  > The bottom half is defined as the half of the box or sphere with the lowest z-coordinate in the collision link frame.
+
 
 Testing
 ~~~~~~~

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -1,44 +1,54 @@
 Configuration
 =============
 
-.. _configuration:
+JaxSim utilizes environment variables for application configuration. Below is a detailed overview of the various configuration categories and their respective variables.
 
-Environment Variables
----------------------
-
-JaxSim uses environment variables to configure the application.
 
 Collision Dynamics
 ~~~~~~~~~~~~~~~~~~
 
-The environment variables used to configure the collision dynamics start with
-``JAXSIM_COLLISION_``. The following variables are available:
+Environment variables starting with ``JAXSIM_COLLISION_`` are used to configure collision dynamics. The available variables are:
 
-- ``JAXSIM_COLLISION_SPHERE_POINTS``: The number of collision points to use to approximate the sphere. *The default is ``50``.*
-- ``JAXSIM_COLLISION_MESH_ENABLED``: Enable or disable the mesh collision. *The default is ``False``.*
-- ``JAXSIM_COLLISION_USE_BOTTOM_ONLY``: Use only the bottom half of the box or sphere for collision detection. *The default is ``False``.*
+- ``JAXSIM_COLLISION_SPHERE_POINTS``: Specifies the number of collision points to approximate the sphere.
+  *Default:* ``50``.
+
+- ``JAXSIM_COLLISION_MESH_ENABLED``: Enables or disables mesh-based collision detection.
+  *Default:* ``False``.
+
+- ``JAXSIM_COLLISION_USE_BOTTOM_ONLY``: Limits collision detection to only the bottom half of the box or sphere.
+  *Default:* ``False``.
+
 
 Testing
 ~~~~~~~
 
-The environment variables used to configure the testing start with
-``JAXSIM_TEST_``. The following variables are available:
+For testing configurations, environment variables beginning with ``JAXSIM_TEST_`` are used. The following variables are available:
 
-- ``JAXSIM_TEST_SEED``: The seed to use for the random number generator. *The default is ``0``.*
-- ``JAXSIM_TEST_AD_ORDER``: The gradient order to use for the automatic differentiation tests. *The default is ``1``.*
-- ``JAXSIM_TEST_FD_STEP_SIZE``: The step size to use for the finite difference tests. *The default is the cube root of the machine epsilon.*
+- ``JAXSIM_TEST_SEED``: Defines the seed for the random number generator.
+  _Default: ``0``._
+
+- ``JAXSIM_TEST_AD_ORDER``: Specifies the gradient order for automatic differentiation tests.
+  _Default: ``1``._
+
+- ``JAXSIM_TEST_FD_STEP_SIZE``: Sets the step size for finite difference tests.
+  _Default: the cube root of the machine epsilon._
+
 
 Joint Dynamics
 ~~~~~~~~~~~~~~
+Joint dynamics are configured using environment variables starting with ``JAXSIM_JOINT_``. Available variables include:
 
-The environment variables used to configure the joint dynamics start with
-``JAXSIM_JOINT_``. The following variables are available:
+- ``JAXSIM_JOINT_POSITION_LIMIT_DAMPER``: Defines the damper value for joint position limits.
+  _Default: ``0``._
 
-- ``JAXSIM_JOINT_POSITION_LIMIT_DAMPER``: The damper value for the joint position limit. *The default is ``0``.*
-- ``JAXSIM_JOINT_POSITION_LIMIT_SPRING``: The spring value for the joint position limit. *The default is ``0``.*
+- ``JAXSIM_JOINT_POSITION_LIMIT_SPRING``: Defines the spring value for joint position limits.
+  _Default: ``0``._
+
 
 Logging
 ~~~~~~~
 
-The environment variable ``JAXSIM_LOGGING_LEVEL`` can be used to set the logging level.
-The default is ``DEBUG`` for development and ``WARNING`` for production.
+The logging configuration is controlled by the following environment variable:
+
+- ``JAXSIM_LOGGING_LEVEL``: Determines the logging level.
+  *Default:* ``DEBUG`` for development, ``WARNING`` for production.

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -25,24 +25,22 @@ Testing
 For testing configurations, environment variables beginning with ``JAXSIM_TEST_`` are used. The following variables are available:
 
 - ``JAXSIM_TEST_SEED``: Defines the seed for the random number generator.
-  _Default: ``0``._
+  *Default:* ``0``.
 
 - ``JAXSIM_TEST_AD_ORDER``: Specifies the gradient order for automatic differentiation tests.
-  _Default: ``1``._
+  *Default:* ``1``.
 
 - ``JAXSIM_TEST_FD_STEP_SIZE``: Sets the step size for finite difference tests.
-  _Default: the cube root of the machine epsilon._
+  *Default:* the cube root of the machine epsilon.
 
 
 Joint Dynamics
 ~~~~~~~~~~~~~~
 Joint dynamics are configured using environment variables starting with ``JAXSIM_JOINT_``. Available variables include:
 
-- ``JAXSIM_JOINT_POSITION_LIMIT_DAMPER``: Defines the damper value for joint position limits.
-  _Default: ``0``._
+- ``JAXSIM_JOINT_POSITION_LIMIT_DAMPER``: Overrides the damper value for joint position limits of the SDF model.
 
-- ``JAXSIM_JOINT_POSITION_LIMIT_SPRING``: Defines the spring value for joint position limits.
-  _Default: ``0``._
+- ``JAXSIM_JOINT_POSITION_LIMIT_SPRING``: Overrides the spring value for joint position limits of the SDF model.
 
 
 Logging

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@ Features
   :hidden:
 
   guide/install
+  guide/configuration
 
   examples
 


### PR DESCRIPTION
This PR includes a new section on environment variables in the configuration documentation and add a link to this section in the documentation index.

Requires #312

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--313.org.readthedocs.build//313/

<!-- readthedocs-preview jaxsim end -->