### PR TITLE
Simplify `pixi` configuration and enhance testing tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,8 +232,9 @@ jaxsim = { path = "./", editable = true }
 
 [tool.pixi.feature.test.tasks]
 pipcheck = "pip check"
-test = { cmd = "pytest", depends_on = ["pipcheck"] }
 benchmark = { cmd = "pytest --benchmark-only", depends_on = ["pipcheck"] }
+lint = { cmd = "pre-commit run --all-files --hook-stage=manual" }
+test = { cmd = "pytest", depends_on = ["pipcheck"] }
 
 [tool.pixi.feature.test.dependencies]
 black-jupyter = "24.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,7 +236,7 @@ test = { cmd = "pytest", depends_on = ["pipcheck"] }
 benchmark = { cmd = "pytest --benchmark-only", depends_on = ["pipcheck"] }
 
 [tool.pixi.feature.test.dependencies]
-black = "24.*"
+black-jupyter = "24.*"
 idyntree = "*"
 isort = "*"
 pre-commit = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,9 +266,7 @@ system-requirements = { cuda = "12" }
 
 [tool.pixi.feature.gpu.dependencies]
 cuda-version = "12.*"
-# Pinning a specific version awaiting the following to get addressed:
-# https://github.com/conda-forge/jaxlib-feedstock/issues/285
-jaxlib = { version = "<0.4.31", build = "*cuda*" }
+jaxlib = { version = "*", build = "*cuda*" }
 
 [tool.pixi.feature.gpu.tasks]
 gpu-tests = { cmd = "pytest --gpu-only", depends_on = ["pipcheck"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,4 +269,4 @@ cuda-version = "12.*"
 jaxlib = { version = "*", build = "*cuda*" }
 
 [tool.pixi.feature.gpu.tasks]
-gpu-tests = { cmd = "pytest --gpu-only", depends_on = ["pipcheck"] }
+test-gpu = { cmd = "pytest --gpu-only", depends_on = ["pipcheck"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,10 +187,8 @@ platforms = ["linux-64", "osx-arm64", "osx-64"]
 [tool.pixi.environments]
 # We resolve only two groups: cpu and gpu.
 # Then, multiple environments can be created from these groups.
-default = { solve-group = "cpugroup" }
-gpu = { features = ["gpu"], solve-group = "gpugroup" }
-tasks-cpu = { features = ["test", "examples"], solve-group = "cpugroup" }
-tasks-gpu = { features = ["test", "examples", "gpu"], solve-group = "gpugroup" }
+default = { features = ["test", "examples"] }
+gpu = { features = ["test", "examples", "gpu"] }
 
 # ---------------
 # feature.default


### PR DESCRIPTION
This PR streamlines `pixi` environments by removing unnecessary constraints and renaming tasks for clarity. Add a `jupyter` extra to the `black` dependency and introduce a `lint` task to ease-out development

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--315.org.readthedocs.build//315/

<!-- readthedocs-preview jaxsim end -->