### PR TITLE
Inherit integrator attribute when reducing a `JaxSimModel`

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -477,6 +477,7 @@ def reduce(
         time_step=model.time_step,
         terrain=model.terrain,
         contact_model=model.contact_model,
+        integrator=model.integrator,
     )
 
     # Store the origin of the model, in case downstream logic needs it.

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -98,6 +98,15 @@ def test_model_creation_and_reduction(
     # Check that the reduced model maintains the same terrain of the full model.
     assert model_full.terrain == model_reduced.terrain
 
+    # Check that the reduced model maintains the same contact model of the full model.
+    assert model_full.contact_model == model_reduced.contact_model
+
+    # Check that the reduced model maintains the same integration step of the full model.
+    assert model_full.time_step == model_reduced.time_step
+
+    # Check that the reduced model maintains the same integrator of the full model.
+    assert model_full.integrator == model_reduced.integrator
+
     # Build the data of the reduced model.
     data_reduced = js.data.JaxSimModelData.build(
         model=model_reduced,


### PR DESCRIPTION
This PR ensures that the `integrator` is inherited from the full `JaxSimModel`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--318.org.readthedocs.build//318/

<!-- readthedocs-preview jaxsim end -->