### PR TITLE
Add safe norm function and refactor usages

### DIFF
--- a/src/jaxsim/math/__init__.py
+++ b/src/jaxsim/math/__init__.py
@@ -8,5 +8,6 @@ from .quaternion import Quaternion
 from .rotation import Rotation
 from .skew import Skew
 from .transform import Transform
+from .utils import safe_norm
 
 from .joint_model import JointModel, supported_joint_motion  # isort:skip

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -4,6 +4,8 @@ import jaxlie
 
 import jaxsim.typing as jtp
 
+from .utils import safe_norm
+
 
 class Quaternion:
     @staticmethod
@@ -111,18 +113,13 @@ class Quaternion:
             operand=quaternion,
         )
 
-        norm_ω = jax.lax.cond(
-            pred=ω.dot(ω) < (1e-6) ** 2,
-            true_fun=lambda _: 1e-6,
-            false_fun=lambda _: jnp.linalg.norm(ω),
-            operand=None,
-        )
+        norm_ω = safe_norm(ω)
 
         qd = 0.5 * (
             Q
             @ jnp.hstack(
                 [
-                    K * norm_ω * (1 - jnp.linalg.norm(quaternion)),
+                    K * norm_ω * (1 - safe_norm(quaternion)),
                     ω,
                 ]
             )

--- a/src/jaxsim/math/utils.py
+++ b/src/jaxsim/math/utils.py
@@ -6,17 +6,26 @@ import jaxsim.typing as jtp
 def safe_norm(array: jtp.ArrayLike, axis=None) -> jtp.Array:
     """
     Provides a calculation for an array norm so that it is safe
-    to compute the gradient and the NaNs are handled.
+    to compute the gradient and handle NaNs.
 
     Args:
         array: The array for which to compute the norm.
         axis: The axis for which to compute the norm.
+
+    Returns:
+        The norm of the array with handling for zero arrays to avoid NaNs.
     """
 
+    # Check if the entire array is composed of zeros.
     is_zero = jnp.allclose(array, 0.0)
 
+    # Replace zeros with an array of ones temporarily to avoid division by zero.
+    # This ensures the computation of norm does not produce NaNs or Infs.
     array = jnp.where(is_zero, jnp.ones_like(array), array)
 
+    # Compute the norm of the array along the specified axis.
     norm = jnp.linalg.norm(array, axis=axis)
 
+    # Use `jnp.where` to set the norm to 0.0 where the input array was all zeros.
+    # This usage supports potential batch processing for future scalability.
     return jnp.where(is_zero, 0.0, norm)

--- a/src/jaxsim/math/utils.py
+++ b/src/jaxsim/math/utils.py
@@ -1,0 +1,22 @@
+import jax.numpy as jnp
+
+import jaxsim.typing as jtp
+
+
+def safe_norm(array: jtp.ArrayLike, axis=None) -> jtp.Array:
+    """
+    Provides a calculation for an array norm so that it is safe
+    to compute the gradient and the NaNs are handled.
+
+    Args:
+        array: The array for which to compute the norm.
+        axis: The axis for which to compute the norm.
+    """
+
+    is_zero = jnp.allclose(array, 0.0)
+
+    array = jnp.where(is_zero, jnp.ones_like(array), array)
+
+    norm = jnp.linalg.norm(array, axis=axis)
+
+    return jnp.where(is_zero, 0.0, norm)

--- a/src/jaxsim/terrain/terrain.py
+++ b/src/jaxsim/terrain/terrain.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 import jax_dataclasses
 import numpy as np
 
+import jaxsim.math
 import jaxsim.typing as jtp
 from jaxsim import exceptions
 
@@ -41,7 +42,7 @@ class Terrain(abc.ABC):
             [(h_xm - h_xp) / (2 * self.delta), (h_ym - h_yp) / (2 * self.delta), 1.0]
         )
 
-        return n / jnp.linalg.norm(n)
+        return n / jaxsim.math.safe_norm(n)
 
 
 @jax_dataclasses.pytree_dataclass


### PR DESCRIPTION
This PR introduces a `safe_norm` function to handle norm calculations safely, preventing division by zero and ensuring gradient compatibility. 

FYI @CarlottaSartore

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--319.org.readthedocs.build//319/

<!-- readthedocs-preview jaxsim end -->