### PR TITLE
Remove `metadata` attribute from integrators and parametrize simulation tests

### DIFF
--- a/src/jaxsim/integrators/variable_step.py
+++ b/src/jaxsim/integrators/variable_step.py
@@ -481,10 +481,10 @@ class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
                 metadata_next,
                 discarded_steps,
             ) = jax.lax.cond(
-                pred=discarded_steps
-                >= self.max_step_rejections | local_error
-                <= 1.0 | Δt_next
-                < self.dt_min | integrator_init,
+                pred=(discarded_steps >= self.max_step_rejections)
+                | (local_error <= 1.0)
+                | (Δt_next < self.dt_min)
+                | integrator_init,
                 true_fun=accept_step,
                 false_fun=reject_step,
             )

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -201,8 +201,19 @@ def run_simulation(
     return data
 
 
+@pytest.mark.parametrize(
+    "integrator",
+    [
+        jaxsim.integrators.fixed_step.ForwardEuler,
+        jaxsim.integrators.fixed_step.ForwardEulerSO3,
+        jaxsim.integrators.fixed_step.RungeKutta4,
+        jaxsim.integrators.fixed_step.RungeKutta4SO3,
+        jaxsim.integrators.variable_step.BogackiShampineSO3,
+    ],
+)
 def test_simulation_with_soft_contacts(
     jaxsim_model_box: js.model.JaxSimModel,
+    integrator: jaxsim.integrators.Integrator,
 ):
 
     model = jaxsim_model_box
@@ -217,6 +228,11 @@ def test_simulation_with_soft_contacts(
         enabled_collidable_points_mask[[0, 1, 2, 3]] = True
         model.kin_dyn_parameters.contact_parameters.enabled = tuple(
             enabled_collidable_points_mask.tolist()
+        )
+        model.integrator = integrator.build(
+            dynamics=js.ode.wrap_system_dynamics_for_integration(
+                system_dynamics=js.ode.system_dynamics
+            )
         )
 
     assert np.sum(model.kin_dyn_parameters.contact_parameters.enabled) == 4


### PR DESCRIPTION
This PR enhances the `integrators` module by parameterizing simulation tests on the integrator types available. It fixes a boolean conversion issue in  the variable step integrators which were not working and refactors metadata handling

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--323.org.readthedocs.build//323/

<!-- readthedocs-preview jaxsim end -->