### PR TITLE
Remove deprecated `rod` method from test configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -426,7 +426,7 @@ def jaxsim_model_single_pendulum() -> js.model.JaxSimModel:
 
     rod_model.model.resolve_frames()
 
-    urdf_string = rod.urdf.exporter.UrdfExporter.sdf_to_urdf_string(
+    urdf_string = rod.urdf.exporter.UrdfExporter(pretty=True).to_urdf_string(
         sdf=rod_model.models()[0]
     )
 


### PR DESCRIPTION
This PR removes the deprecated `sdf_to_urdf_string` method from `conftest.py`

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--324.org.readthedocs.build//324/

<!-- readthedocs-preview jaxsim end -->