### PR TITLE
Improve docstring quality and consistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ preview = true
 # https://docs.astral.sh/ruff/rules/
 select = [
     "B",
+    "D",
     "E",
     "F",
     "I",
@@ -162,6 +163,15 @@ select = [
 ignore = [
     "B008", # Function call in default argument
     "B024", # Abstract base class without abstract methods
+    "D100", # Missing docstring in public module
+    "D104", # Missing docstring in public package
+    "D105", # Missing docstring in magic method
+    "D200", # One-line docstring should fit on one line with quotes
+    "D202", # No blank lines allowed after function docstring
+    "D205", # 1 blank line required between summary line and description
+    "D212", # Multi-line docstring summary should start at the first line
+    "D411", # Missing blank line before section
+    "D413", # Missing blank line after last section
     "E402", # Module level import not at top of file
     "E501", # Line too long
     "E731", # Do not assign a `lambda` expression, use a `def`
@@ -173,9 +183,11 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 # Ignore `E402` (import violations) in all `__init__.py` files
 "**/{tests,docs,tools}/*" = ["E402"]
-"**/{tests}/*" = ["B007"]
+"**/{tests,examples}/*" = ["B007", "D100", "D102", "D103"]
 "__init__.py" = ["F401"]
 "docs/conf.py" = ["F401"]
+"src/jaxsim/exceptions.py" = ["D401"]
+"src/jaxsim/logging.py" = ["D101", "D103"]
 
 # ==================
 # Pixi configuration

--- a/src/jaxsim/api/com.py
+++ b/src/jaxsim/api/com.py
@@ -279,7 +279,7 @@ def bias_acceleration(
         C_v̇_WL: jtp.Vector, C_v_WC: jtp.Vector, L_H_C: jtp.Matrix, L_v_LC: jtp.Vector
     ) -> jtp.Vector:
         """
-        Helper to convert the body-fixed representation of the link bias acceleration
+        Convert the body-fixed representation of the link bias acceleration
         C_v̇_WL expressed in a generic frame C to the body-fixed representation L_v̇_WL.
         """
 

--- a/src/jaxsim/api/common.py
+++ b/src/jaxsim/api/common.py
@@ -26,7 +26,7 @@ _R = TypeVar("_R")
 
 
 def named_scope(fn, name: str | None = None) -> Callable[_P, _R]:
-    """Applies a JAX named scope to a function for improved profiling and clarity."""
+    """Apply a JAX named scope to a function for improved profiling and clarity."""
 
     @functools.wraps(fn)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:

--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -293,6 +293,9 @@ def in_contact(
 def estimate_good_soft_contacts_parameters(
     *args, **kwargs
 ) -> jaxsim.rbda.contacts.ContactParamsTypes:
+    """
+    Estimate good soft contacts parameters. Deprecated, use `estimate_good_contact_parameters` instead.
+    """
 
     msg = "This method is deprecated, please use `{}`."
     logging.warning(msg.format(estimate_good_contact_parameters.__name__))

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -456,7 +456,8 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
     @jax.jit
     def generalized_velocity(self) -> jtp.Vector:
         r"""
-        Get the generalized velocity
+        Get the generalized velocity.
+
         :math:`\boldsymbol{\nu} = (\boldsymbol{v}_{W,B};\, \boldsymbol{\omega}_{W,B};\, \mathbf{s}) \in \mathbb{R}^{6+n}`
 
         Returns:

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -52,10 +52,16 @@ class KinDynParameters(JaxsimDataclass):
 
     @property
     def parent_array(self) -> jtp.Vector:
+        r"""
+        Return the parent array :math:`\lambda(i)` of the model.
+        """
         return self._parent_array.get()
 
     @property
     def support_body_array_bool(self) -> jtp.Matrix:
+        r"""
+        Return the boolean support parent array :math:`\kappa_{b}(i)` of the model.
+        """
         return self._support_body_array_bool.get()
 
     @staticmethod
@@ -648,7 +654,16 @@ class LinkParameters(JaxsimDataclass):
     def build_from_flat_parameters(
         index: jtp.IntLike, parameters: jtp.VectorLike
     ) -> LinkParameters:
+        """
+        Build a LinkParameters object from a flat vector of parameters.
 
+        Args:
+            index: The index of the link.
+            parameters: The flat vector of parameters.
+
+        Returns:
+            The LinkParameters object.
+        """
         index = jnp.array(index).squeeze().astype(int)
 
         m = jnp.array(parameters[0]).squeeze().astype(float)
@@ -772,7 +787,9 @@ class ContactParameters(JaxsimDataclass):
 
     @property
     def indices_of_enabled_collidable_points(self) -> npt.NDArray:
-
+        """
+        Return the indices of the enabled collidable points.
+        """
         return np.where(np.array(self.enabled))[0]
 
     @staticmethod

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -63,6 +63,9 @@ class JaxSimModel(JaxsimDataclass):
 
     @property
     def description(self) -> ModelDescription:
+        """
+        Return the model description.
+        """
         return self._description.get()
 
     def __eq__(self, other: JaxSimModel) -> bool:

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1015,7 +1015,7 @@ def forward_dynamics_aba(
         W_v̇_WB: jtp.Vector, W_H_C: jtp.Matrix, W_v_WB: jtp.Vector, W_v_WC: jtp.Vector
     ) -> jtp.Vector:
         """
-        Helper to convert the inertial-fixed apparent base acceleration W_v̇_WB to
+        Convert the inertial-fixed apparent base acceleration W_v̇_WB to
         another representation C_v̇_WB expressed in a generic frame C.
         """
 
@@ -1376,7 +1376,7 @@ def inverse_dynamics(
 
     def to_inertial(C_v̇_WB, W_H_C, C_v_WB, W_v_WC):
         """
-        Helper to convert the active representation of the base acceleration C_v̇_WB
+        Convert the active representation of the base acceleration C_v̇_WB
         expressed in a generic frame C to the inertial-fixed representation W_v̇_WB.
         """
 
@@ -1825,7 +1825,7 @@ def link_bias_accelerations(
         C_v̇_WB: jtp.Vector, C_v_WB: jtp.Vector, W_H_C: jtp.Matrix, W_v_WC: jtp.Vector
     ) -> jtp.Vector:
         """
-        Helper to convert the active representation of the base acceleration C_v̇_WB
+        Convert the active representation of the base acceleration C_v̇_WB
         expressed in a generic frame C to the inertial-fixed representation W_v̇_WB.
         """
 
@@ -1961,7 +1961,7 @@ def link_bias_accelerations(
         L_v̇_WL: jtp.Vector, L_v_WL: jtp.Vector, C_H_L: jtp.Matrix, L_v_CL: jtp.Vector
     ) -> jtp.Vector:
         """
-        Helper to convert the body-fixed apparent acceleration L_v̇_WL to
+        Convert the body-fixed apparent acceleration L_v̇_WL to
         another representation C_v̇_WL expressed in a generic frame C.
         """
 

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -15,12 +15,32 @@ from .ode_data import ODEState
 
 
 class SystemDynamicsFromModelAndData(Protocol):
+    """
+    Protocol defining the signature of a function computing the system dynamics
+    given a model and data object.
+    """
+
     def __call__(
         self,
         model: js.model.JaxSimModel,
         data: js.data.JaxSimModelData,
         **kwargs: dict[str, Any],
-    ) -> tuple[ODEState, dict[str, Any]]: ...
+    ) -> tuple[ODEState, dict[str, Any]]:
+        """
+        Compute the system dynamics given a model and data object.
+
+        Args:
+            model: The model to consider.
+            data: The data of the considered model.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            A tuple with an `ODEState` object storing in each of its attributes the
+            corresponding derivative, and the dictionary of auxiliary data returned
+            by the system dynamics evaluation.
+        """
+
+        pass
 
 
 def wrap_system_dynamics_for_integration(

--- a/src/jaxsim/exceptions.py
+++ b/src/jaxsim/exceptions.py
@@ -17,6 +17,8 @@ def raise_if(
         msg:
             The message to display when the exception is raised. The message can be a
             format string (fmt), whose fields are filled with the args and kwargs.
+        *args: The arguments to fill the format string.
+        **kwargs: The keyword arguments to fill the format string
     """
 
     # Disable host callback if running on unsupported hardware or if the user

--- a/src/jaxsim/exceptions.py
+++ b/src/jaxsim/exceptions.py
@@ -61,6 +61,9 @@ def raise_if(
 def raise_runtime_error_if(
     condition: bool | jax.Array, msg: str, *args, **kwargs
 ) -> None:
+    """
+    Raise a RuntimeError if a condition is met. Useful in jit-compiled functions.
+    """
 
     return raise_if(condition, RuntimeError, msg, *args, **kwargs)
 
@@ -68,5 +71,8 @@ def raise_runtime_error_if(
 def raise_value_error_if(
     condition: bool | jax.Array, msg: str, *args, **kwargs
 ) -> None:
+    """
+    Raise a ValueError if a condition is met. Useful in jit-compiled functions.
+    """
 
     return raise_if(condition, ValueError, msg, *args, **kwargs)

--- a/src/jaxsim/integrators/fixed_step.py
+++ b/src/jaxsim/integrators/fixed_step.py
@@ -17,6 +17,9 @@ ODEStateDerivative = js.ode_data.ODEState
 
 @jax_dataclasses.pytree_dataclass
 class ForwardEuler(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
+    """
+    Forward Euler integrator.
+    """
 
     A: ClassVar[jtp.Matrix] = jnp.atleast_2d(0).astype(float)
 
@@ -30,6 +33,9 @@ class ForwardEuler(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
 @jax_dataclasses.pytree_dataclass
 class Heun2(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
+    """
+    Heun's second-order integrator.
+    """
 
     A: ClassVar[jtp.Matrix] = jnp.array(
         [
@@ -56,6 +62,9 @@ class Heun2(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
 @jax_dataclasses.pytree_dataclass
 class RungeKutta4(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
+    """
+    Fourth-order Runge-Kutta integrator.
+    """
 
     A: ClassVar[jtp.Matrix] = jnp.array(
         [
@@ -89,14 +98,26 @@ class RungeKutta4(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
 @jax_dataclasses.pytree_dataclass
 class ForwardEulerSO3(ExplicitRungeKuttaSO3Mixin, ForwardEuler[js.ode_data.ODEState]):
+    """
+    Forward Euler integrator for SO(3) states.
+    """
+
     pass
 
 
 @jax_dataclasses.pytree_dataclass
 class Heun2SO3(ExplicitRungeKuttaSO3Mixin, Heun2[js.ode_data.ODEState]):
+    """
+    Heun's second-order integrator for SO(3) states.
+    """
+
     pass
 
 
 @jax_dataclasses.pytree_dataclass
 class RungeKutta4SO3(ExplicitRungeKuttaSO3Mixin, RungeKutta4[js.ode_data.ODEState]):
+    """
+    Fourth-order Runge-Kutta integrator for SO(3) states.
+    """
+
     pass

--- a/src/jaxsim/integrators/variable_step.py
+++ b/src/jaxsim/integrators/variable_step.py
@@ -216,6 +216,17 @@ def local_error_estimation(
 
 @jax_dataclasses.pytree_dataclass
 class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
+    """
+    An Embedded Runge-Kutta integrator.
+
+    This class implements a general-purpose Embedded Runge-Kutta integrator
+    that can be used to solve ordinary differential equations with adaptive
+    step sizes.
+
+    The integrator is based on an Explicit Runge-Kutta method, and it uses
+    two different solutions to estimate the local integration error. The
+    error is then used to adapt the step size to reach a desired accuracy.
+    """
 
     AfterInitKey: ClassVar[str] = "after_init"
     InitializingKey: ClassVar[str] = "initializing"
@@ -257,6 +268,7 @@ class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
             x0: The initial state of the system.
             t0: The initial time of the system.
             dt: The time step of the integration.
+            **kwargs: Additional parameters.
 
         Returns:
             The metadata of the integrator to be passed to the first step.
@@ -296,6 +308,9 @@ class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
     def __call__(
         self, x0: State, t0: Time, dt: TimeStep, **kwargs
     ) -> tuple[NextState, dict[str, Any]]:
+        """
+        Integrate the system for a single step.
+        """
 
         # This method is called differently in three stages:
         #
@@ -512,10 +527,16 @@ class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
     @property
     def order_of_solution(self) -> int:
+        """
+        The order of the solution.
+        """
         return self.order_of_bT_rows[self.row_index_of_solution]
 
     @property
     def order_of_solution_estimate(self) -> int:
+        """
+        The order of the solution estimate.
+        """
         return self.order_of_bT_rows[self.row_index_of_solution_estimate]
 
     @classmethod
@@ -534,6 +555,23 @@ class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
         max_step_rejections: jtp.IntLike = MAX_STEP_REJECTIONS_DEFAULT,
         **kwargs,
     ) -> Self:
+        """
+        Build an Embedded Runge-Kutta integrator.
+
+        Args:
+            dynamics: The system dynamics function.
+            fsal_enabled_if_supported:
+                Whether to enable the FSAL property if supported by the integrator.
+            dt_max: The maximum step size.
+            dt_min: The minimum step size.
+            rtol: The relative tolerance.
+            atol: The absolute tolerance.
+            safety: The safety factor to shrink the step size.
+            beta_max: The maximum factor to increase the step size.
+            beta_min: The minimum factor to increase the step size.
+            max_step_rejections: The maximum number of step rejections.
+            **kwargs: Additional parameters.
+        """
 
         # Check that b.T has enough rows based on the configured index of the
         # solution estimate. This is necessary for embedded methods.
@@ -569,6 +607,9 @@ class EmbeddedRungeKutta(ExplicitRungeKutta[PyTreeType], Generic[PyTreeType]):
 
 @jax_dataclasses.pytree_dataclass
 class HeunEulerSO3(EmbeddedRungeKutta[PyTreeType], ExplicitRungeKuttaSO3Mixin):
+    """
+    The Heun-Euler integrator for SO(3) dynamics.
+    """
 
     A: ClassVar[jtp.Matrix] = jnp.array(
         [
@@ -602,6 +643,9 @@ class HeunEulerSO3(EmbeddedRungeKutta[PyTreeType], ExplicitRungeKuttaSO3Mixin):
 
 @jax_dataclasses.pytree_dataclass
 class BogackiShampineSO3(EmbeddedRungeKutta[PyTreeType], ExplicitRungeKuttaSO3Mixin):
+    """
+    The Bogacki-Shampine integrator for SO(3) dynamics.
+    """
 
     A: ClassVar[jtp.Matrix] = jnp.array(
         [

--- a/src/jaxsim/math/adjoint.py
+++ b/src/jaxsim/math/adjoint.py
@@ -18,11 +18,10 @@ class Adjoint:
         Create an adjoint matrix from a quaternion and a translation.
 
         Args:
-            quaternion (jtp.Vector): A quaternion vector (4D) representing orientation.
-            translation (jtp.Vector): A translation vector (3D).
-            inverse (bool): Whether to compute the inverse adjoint. Default is False.
-            normalize_quaternion (bool): Whether to normalize the quaternion before creating the adjoint.
-                                         Default is False.
+            quaternion: A quaternion vector (4D) representing orientation.
+            translation: A translation vector (3D).
+            inverse: Whether to compute the inverse adjoint.
+            normalize_quaternion: Whether to normalize the quaternion before creating the adjoint.
 
         Returns:
             jtp.Matrix: The adjoint matrix.
@@ -69,9 +68,9 @@ class Adjoint:
         Create an adjoint matrix from a rotation matrix and a translation vector.
 
         Args:
-            rotation (jtp.Matrix): A 3x3 rotation matrix.
-            translation (jtp.Vector): A translation vector (3D).
-            inverse (bool): Whether to compute the inverse adjoint. Default is False.
+            rotation: A 3x3 rotation matrix.
+            translation: A translation vector (3D).
+            inverse: Whether to compute the inverse adjoint. Default is False.
 
         Returns:
             jtp.Matrix: The adjoint matrix.
@@ -105,7 +104,7 @@ class Adjoint:
         Convert an adjoint matrix to a transformation matrix.
 
         Args:
-            adjoint (jtp.Matrix): The adjoint matrix (6x6).
+            adjoint: The adjoint matrix (6x6).
 
         Returns:
             jtp.Matrix: The transformation matrix (4x4).
@@ -131,7 +130,7 @@ class Adjoint:
         Compute the inverse of an adjoint matrix.
 
         Args:
-            adjoint (jtp.Matrix): The adjoint matrix.
+            adjoint: The adjoint matrix.
 
         Returns:
             jtp.Matrix: The inverse adjoint matrix.

--- a/src/jaxsim/math/adjoint.py
+++ b/src/jaxsim/math/adjoint.py
@@ -7,6 +7,10 @@ from .skew import Skew
 
 
 class Adjoint:
+    """
+    A utility class for adjoint matrix operations.
+    """
+
     @staticmethod
     def from_quaternion_and_translation(
         quaternion: jtp.Vector = jnp.array([1.0, 0, 0, 0]),

--- a/src/jaxsim/math/cross.py
+++ b/src/jaxsim/math/cross.py
@@ -12,7 +12,7 @@ class Cross:
         Compute the cross product matrix for 6D velocities.
 
         Args:
-            velocity_sixd (jtp.Vector): A 6D velocity vector [v, ω].
+            velocity_sixd: A 6D velocity vector [v, ω].
 
         Returns:
             jtp.Matrix: The cross product matrix (6x6).
@@ -37,7 +37,7 @@ class Cross:
         Compute the negative transpose of the cross product matrix for 6D velocities.
 
         Args:
-            velocity_sixd (jtp.Vector): A 6D velocity vector [v, ω].
+            velocity_sixd: A 6D velocity vector [v, ω].
 
         Returns:
             jtp.Matrix: The negative transpose of the cross product matrix (6x6).

--- a/src/jaxsim/math/cross.py
+++ b/src/jaxsim/math/cross.py
@@ -6,6 +6,10 @@ from .skew import Skew
 
 
 class Cross:
+    """
+    A utility class for cross product matrix operations.
+    """
+
     @staticmethod
     def vx(velocity_sixd: jtp.Vector) -> jtp.Matrix:
         """

--- a/src/jaxsim/math/inertia.py
+++ b/src/jaxsim/math/inertia.py
@@ -6,6 +6,10 @@ from .skew import Skew
 
 
 class Inertia:
+    """
+    A utility class for inertia matrix operations.
+    """
+
     @staticmethod
     def to_sixd(mass: jtp.Float, com: jtp.Vector, I: jtp.Matrix) -> jtp.Matrix:
         """

--- a/src/jaxsim/math/inertia.py
+++ b/src/jaxsim/math/inertia.py
@@ -12,9 +12,9 @@ class Inertia:
         Convert mass, center of mass, and inertia matrix to a 6x6 inertia matrix.
 
         Args:
-            mass (jtp.Float): The mass of the body.
-            com (jtp.Vector): The center of mass position (3D).
-            I (jtp.Matrix): The 3x3 inertia matrix.
+            mass: The mass of the body.
+            com: The center of mass position (3D).
+            I: The 3x3 inertia matrix.
 
         Returns:
             jtp.Matrix: The 6x6 inertia matrix.
@@ -42,7 +42,7 @@ class Inertia:
         Convert a 6x6 inertia matrix to mass, center of mass, and inertia matrix.
 
         Args:
-            M (jtp.Matrix): The 6x6 inertia matrix.
+            M: The 6x6 inertia matrix.
 
         Returns:
             tuple[jtp.Float, jtp.Vector, jtp.Matrix]: A tuple containing mass, center of mass (3D), and inertia matrix (3x3).

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -8,6 +8,10 @@ from .utils import safe_norm
 
 
 class Quaternion:
+    """
+    A utility class for quaternion operations.
+    """
+
     @staticmethod
     def to_xyzw(wxyz: jtp.Vector) -> jtp.Vector:
         """

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -14,7 +14,7 @@ class Quaternion:
         Convert a quaternion from WXYZ to XYZW representation.
 
         Args:
-            wxyz (jtp.Vector): Quaternion in WXYZ representation.
+            wxyz: Quaternion in WXYZ representation.
 
         Returns:
             jtp.Vector: Quaternion in XYZW representation.
@@ -27,7 +27,7 @@ class Quaternion:
         Convert a quaternion from XYZW to WXYZ representation.
 
         Args:
-            xyzw (jtp.Vector): Quaternion in XYZW representation.
+            xyzw: Quaternion in XYZW representation.
 
         Returns:
             jtp.Vector: Quaternion in WXYZ representation.
@@ -40,7 +40,7 @@ class Quaternion:
         Convert a quaternion to a direction cosine matrix (DCM).
 
         Args:
-            quaternion (jtp.Vector): Quaternion in XYZW representation.
+            quaternion: Quaternion in XYZW representation.
 
         Returns:
             jtp.Matrix: Direction cosine matrix (DCM).
@@ -53,7 +53,7 @@ class Quaternion:
         Convert a direction cosine matrix (DCM) to a quaternion.
 
         Args:
-            dcm (jtp.Matrix): Direction cosine matrix (DCM).
+            dcm: Direction cosine matrix (DCM).
 
         Returns:
             jtp.Vector: Quaternion in XYZW representation.
@@ -71,8 +71,8 @@ class Quaternion:
         Compute the derivative of a quaternion given angular velocity.
 
         Args:
-            quaternion (jtp.Vector): Quaternion in XYZW representation.
-            omega (jtp.Vector): Angular velocity vector.
+            quaternion: Quaternion in XYZW representation.
+            omega: Angular velocity vector.
             omega_in_body_fixed (bool): Whether the angular velocity is in the body-fixed frame.
             K (float): A scaling factor.
 

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -15,7 +15,7 @@ class Rotation:
         Generate a 3D rotation matrix around the X-axis.
 
         Args:
-            theta (jtp.Float): Rotation angle in radians.
+            theta: Rotation angle in radians.
 
         Returns:
             jtp.Matrix: 3D rotation matrix.
@@ -29,7 +29,7 @@ class Rotation:
         Generate a 3D rotation matrix around the Y-axis.
 
         Args:
-            theta (jtp.Float): Rotation angle in radians.
+            theta: Rotation angle in radians.
 
         Returns:
             jtp.Matrix: 3D rotation matrix.
@@ -43,7 +43,7 @@ class Rotation:
         Generate a 3D rotation matrix around the Z-axis.
 
         Args:
-            theta (jtp.Float): Rotation angle in radians.
+            theta: Rotation angle in radians.
 
         Returns:
             jtp.Matrix: 3D rotation matrix.

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -8,6 +8,9 @@ from .utils import safe_norm
 
 
 class Rotation:
+    """
+    A utility class for rotation matrix operations.
+    """
 
     @staticmethod
     def x(theta: jtp.Float) -> jtp.Matrix:

--- a/src/jaxsim/math/skew.py
+++ b/src/jaxsim/math/skew.py
@@ -14,7 +14,7 @@ class Skew:
         Compute the skew-symmetric matrix (wedge operator) of a 3D vector.
 
         Args:
-            vector (jtp.Vector): A 3D vector.
+            vector: A 3D vector.
 
         Returns:
             jtp.Matrix: The skew-symmetric matrix corresponding to the input vector.
@@ -31,7 +31,7 @@ class Skew:
         Extract the 3D vector from a skew-symmetric matrix (vee operator).
 
         Args:
-            matrix (jtp.Matrix): A 3x3 skew-symmetric matrix.
+            matrix: A 3x3 skew-symmetric matrix.
 
         Returns:
             jtp.Vector: The 3D vector extracted from the input matrix.

--- a/src/jaxsim/math/transform.py
+++ b/src/jaxsim/math/transform.py
@@ -5,6 +5,9 @@ import jaxsim.typing as jtp
 
 
 class Transform:
+    """
+    A utility class for transformation matrix operations.
+    """
 
     @staticmethod
     def from_quaternion_and_translation(

--- a/src/jaxsim/math/utils.py
+++ b/src/jaxsim/math/utils.py
@@ -5,8 +5,8 @@ import jaxsim.typing as jtp
 
 def safe_norm(array: jtp.ArrayLike, axis=None) -> jtp.Array:
     """
-    Provides a calculation for an array norm so that it is safe
-    to compute the gradient and handle NaNs.
+    Compute an array norm handling NaNs and making sure that
+    it is safe to get the gradient.
 
     Args:
         array: The array for which to compute the norm.

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -62,7 +62,9 @@ def load_rod_model(
 
 
 class RodModelToMjcf:
-    """"""
+    """
+    Class to convert a ROD model to a Mujoco MJCF string.
+    """
 
     @staticmethod
     def assets_from_rod_model(
@@ -522,6 +524,10 @@ class RodModelToMjcf:
 
 
 class UrdfToMjcf:
+    """
+    Class to convert a URDF file to a Mujoco MJCF string.
+    """
+
     @staticmethod
     def convert(
         urdf: str | pathlib.Path,
@@ -564,6 +570,10 @@ class UrdfToMjcf:
 
 
 class SdfToMjcf:
+    """
+    Class to convert a SDF file to a Mujoco MJCF string.
+    """
+
     @staticmethod
     def convert(
         sdf: str | pathlib.Path,

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -22,7 +22,7 @@ def load_rod_model(
     model_name: str | None = None,
 ) -> rod.Model:
     """
-    Loads a ROD model from a URDF/SDF file or a ROD model.
+    Load a ROD model from a URDF/SDF file or a ROD model.
 
     Args:
         model_description: The URDF/SDF file or ROD model to load.
@@ -69,7 +69,7 @@ class RodModelToMjcf:
         rod_model: rod.Model,
     ) -> dict[str, bytes]:
         """
-        Generates a dictionary of assets from a ROD model.
+        Generate a dictionary of assets from a ROD model.
 
         Args:
             rod_model: The ROD model to extract the assets from.
@@ -112,7 +112,7 @@ class RodModelToMjcf:
         floating_joint_name: str = "world_to_base",
     ) -> str:
         """
-        Adds a floating joint to a URDF string.
+        Add a floating joint to a URDF string.
 
         Args:
             urdf_string: The URDF string to modify.
@@ -171,7 +171,7 @@ class RodModelToMjcf:
         cameras: MujocoCameraType = (),
     ) -> tuple[str, dict[str, Any]]:
         """
-        Converts a ROD model to a Mujoco MJCF string.
+        Convert a ROD model to a Mujoco MJCF string.
 
         Args:
             rod_model: The ROD model to convert.
@@ -532,7 +532,7 @@ class UrdfToMjcf:
         cameras: MujocoCameraType = (),
     ) -> tuple[str, dict[str, Any]]:
         """
-        Converts a URDF file to a Mujoco MJCF string.
+        Convert a URDF file to a Mujoco MJCF string.
 
         Args:
             urdf: The URDF file to convert.
@@ -574,7 +574,7 @@ class SdfToMjcf:
         cameras: MujocoCameraType = (),
     ) -> tuple[str, dict[str, Any]]:
         """
-        Converts a SDF file to a Mujoco MJCF string.
+        Convert a SDF file to a Mujoco MJCF string.
 
         Args:
             sdf: The SDF file to convert.

--- a/src/jaxsim/mujoco/model.py
+++ b/src/jaxsim/mujoco/model.py
@@ -254,17 +254,17 @@ class MujocoModelHelper:
     # ==================
 
     def number_of_joints(self) -> int:
-        """Returns the number of joints in the model."""
+        """Return the number of joints in the model."""
 
         return self.model.njnt
 
     def number_of_dofs(self) -> int:
-        """Returns the number of DoFs in the model."""
+        """Return the number of DoFs in the model."""
 
         return self.model.nq
 
     def joint_names(self) -> list[str]:
-        """Returns the names of the joints in the model."""
+        """Return the names of the joints in the model."""
 
         return [
             mj.mj_id2name(self.model, mj.mjtObj.mjOBJ_JOINT, idx)
@@ -272,7 +272,7 @@ class MujocoModelHelper:
         ]
 
     def joint_dofs(self, joint_name: str) -> int:
-        """Returns the number of DoFs of a joint."""
+        """Return the number of DoFs of a joint."""
 
         if joint_name not in self.joint_names():
             raise ValueError(f"Joint '{joint_name}' not found")
@@ -280,7 +280,7 @@ class MujocoModelHelper:
         return self.data.joint(joint_name).qpos.size
 
     def joint_position(self, joint_name: str) -> npt.NDArray:
-        """Returns the position of a joint."""
+        """Return the position of a joint."""
 
         if joint_name not in self.joint_names():
             raise ValueError(f"Joint '{joint_name}' not found")
@@ -288,7 +288,7 @@ class MujocoModelHelper:
         return self.data.joint(joint_name).qpos
 
     def joint_positions(self, joint_names: list[str] | None = None) -> npt.NDArray:
-        """Returns the positions of the joints."""
+        """Return the positions of the joints."""
 
         joint_names = joint_names if joint_names is not None else self.joint_names()
 
@@ -299,7 +299,7 @@ class MujocoModelHelper:
     def set_joint_position(
         self, joint_name: str, position: npt.NDArray | float
     ) -> None:
-        """Sets the position of a joint."""
+        """Set the position of a joint."""
 
         position = np.atleast_1d(np.array(position).squeeze())
 
@@ -328,12 +328,12 @@ class MujocoModelHelper:
     # ==================
 
     def number_of_bodies(self) -> int:
-        """Returns the number of bodies in the model."""
+        """Return the number of bodies in the model."""
 
         return self.model.nbody
 
     def body_names(self) -> list[str]:
-        """Returns the names of the bodies in the model."""
+        """Return the names of the bodies in the model."""
 
         return [
             mj.mj_id2name(self.model, mj.mjtObj.mjOBJ_BODY, idx)
@@ -341,7 +341,7 @@ class MujocoModelHelper:
         ]
 
     def body_position(self, body_name: str) -> npt.NDArray:
-        """Returns the position of a body."""
+        """Return the position of a body."""
 
         if body_name not in self.body_names():
             raise ValueError(f"Body '{body_name}' not found")
@@ -349,7 +349,7 @@ class MujocoModelHelper:
         return self.data.body(body_name).xpos
 
     def body_orientation(self, body_name: str, dcm: bool = False) -> npt.NDArray:
-        """Returns the orientation of a body."""
+        """Return the orientation of a body."""
 
         if body_name not in self.body_names():
             raise ValueError(f"Body '{body_name}' not found")
@@ -363,12 +363,12 @@ class MujocoModelHelper:
     # ======================
 
     def number_of_geometries(self) -> int:
-        """Returns the number of geometries in the model."""
+        """Return the number of geometries in the model."""
 
         return self.model.ngeom
 
     def geometry_names(self) -> list[str]:
-        """Returns the names of the geometries in the model."""
+        """Return the names of the geometries in the model."""
 
         return [
             mj.mj_id2name(self.model, mj.mjtObj.mjOBJ_GEOM, idx)
@@ -376,7 +376,7 @@ class MujocoModelHelper:
         ]
 
     def geometry_position(self, geometry_name: str) -> npt.NDArray:
-        """Returns the position of a geometry."""
+        """Return the position of a geometry."""
 
         if geometry_name not in self.geometry_names():
             raise ValueError(f"Geometry '{geometry_name}' not found")
@@ -386,7 +386,7 @@ class MujocoModelHelper:
     def geometry_orientation(
         self, geometry_name: str, dcm: bool = False
     ) -> npt.NDArray:
-        """Returns the orientation of a geometry."""
+        """Return the orientation of a geometry."""
 
         if geometry_name not in self.geometry_names():
             raise ValueError(f"Geometry '{geometry_name}' not found")

--- a/src/jaxsim/mujoco/utils.py
+++ b/src/jaxsim/mujoco/utils.py
@@ -133,6 +133,9 @@ class MujocoCamera:
 
     @classmethod
     def build(cls, **kwargs) -> MujocoCamera:
+        """
+        Build a Mujoco camera from a dictionary.
+        """
 
         if not all(isinstance(value, str) for value in kwargs.values()):
             raise ValueError(f"Values must be strings: {kwargs}")
@@ -219,5 +222,7 @@ class MujocoCamera:
         )
 
     def asdict(self) -> dict[str, str]:
-
+        """
+        Convert the camera to a dictionary.
+        """
         return {k: v for k, v in dataclasses.asdict(self).items() if v is not None}

--- a/src/jaxsim/mujoco/visualizer.py
+++ b/src/jaxsim/mujoco/visualizer.py
@@ -10,7 +10,9 @@ import numpy.typing as npt
 
 
 class MujocoVideoRecorder:
-    """"""
+    """
+    Video recorder for the MuJoCo passive viewer.
+    """
 
     def __init__(
         self,
@@ -117,7 +119,9 @@ class MujocoVideoRecorder:
 
 
 class MujocoVisualizer:
-    """"""
+    """
+    Visualizer for the MuJoCo passive viewer.
+    """
 
     def __init__(
         self, model: mj.MjModel | None = None, data: mj.MjData | None = None

--- a/src/jaxsim/mujoco/visualizer.py
+++ b/src/jaxsim/mujoco/visualizer.py
@@ -64,7 +64,7 @@ class MujocoVideoRecorder:
         self.model = model if model is not None else self.model
 
     def render_frame(self, camera_name: str = "track") -> npt.NDArray:
-        """Renders a frame."""
+        """Render a frame."""
 
         mujoco.mj_forward(self.model, self.data)
         self.renderer.update_scene(data=self.data, camera=camera_name)
@@ -72,13 +72,13 @@ class MujocoVideoRecorder:
         return self.renderer.render()
 
     def record_frame(self, camera_name: str = "track") -> None:
-        """Stores a frame in the buffer."""
+        """Store a frame in the buffer."""
 
         frame = self.render_frame(camera_name=camera_name)
         self.frames.append(frame)
 
     def write_video(self, path: pathlib.Path, exist_ok: bool = False) -> None:
-        """Writes the video to a file."""
+        """Write the video to a file."""
 
         # Resolve the path to the video.
         path = path.expanduser().resolve()
@@ -139,7 +139,7 @@ class MujocoVisualizer:
         model: mj.MjModel | None = None,
         data: mj.MjData | None = None,
     ) -> None:
-        """Updates the viewer with the current model and data."""
+        """Update the viewer with the current model and data."""
 
         data = data if data is not None else self.data
         model = model if model is not None else self.model
@@ -150,7 +150,7 @@ class MujocoVisualizer:
     def open_viewer(
         self, model: mj.MjModel | None = None, data: mj.MjData | None = None
     ) -> mj.viewer.Handle:
-        """Opens a viewer."""
+        """Open a viewer."""
 
         data = data if data is not None else self.data
         model = model if model is not None else self.model

--- a/src/jaxsim/parsers/descriptions/collision.py
+++ b/src/jaxsim/parsers/descriptions/collision.py
@@ -158,6 +158,13 @@ class SphereCollision(CollisionShape):
 
 @dataclasses.dataclass
 class MeshCollision(CollisionShape):
+    """
+    Represents a mesh-shaped collision shape.
+
+    Attributes:
+        center: The center of the mesh in the local frame of the collision shape.
+    """
+
     center: jtp.VectorLike
 
     def __hash__(self) -> int:

--- a/src/jaxsim/parsers/descriptions/collision.py
+++ b/src/jaxsim/parsers/descriptions/collision.py
@@ -22,7 +22,6 @@ class CollidablePoint:
         parent_link: The parent link to which the collidable point is attached.
         position: The position of the collidable point relative to the parent link.
         enabled: A flag indicating whether the collidable point is enabled for collision detection.
-
     """
 
     parent_link: LinkDescription
@@ -86,7 +85,6 @@ class CollisionShape(abc.ABC):
 
     Attributes:
         collidable_points: A list of collidable points associated with the collision shape.
-
     """
 
     collidable_points: tuple[CollidablePoint]
@@ -107,7 +105,6 @@ class BoxCollision(CollisionShape):
 
     Attributes:
         center: The center of the box in the local frame of the collision shape.
-
     """
 
     center: jtp.VectorLike
@@ -135,7 +132,6 @@ class SphereCollision(CollisionShape):
 
     Attributes:
         center: The center of the sphere in the local frame of the collision shape.
-
     """
 
     center: jtp.VectorLike

--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -47,20 +47,19 @@ class JointDescription(JaxsimDataclass):
     In-memory description of a robot link.
 
     Attributes:
-        name (str): The name of the joint.
-        axis (npt.NDArray): The axis of rotation or translation for the joint.
-        pose (npt.NDArray): The pose transformation matrix of the joint.
-        jtype (JointType): The type of the joint.
-        child (LinkDescription): The child link attached to the joint.
-        parent (LinkDescription): The parent link attached to the joint.
-        index (Optional[int]): An optional index for the joint.
-        friction_static (float): The static friction coefficient for the joint.
-        friction_viscous (float): The viscous friction coefficient for the joint.
-        position_limit_damper (float): The damper coefficient for position limits.
-        position_limit_spring (float): The spring coefficient for position limits.
-        position_limit (Tuple[float, float]): The position limits for the joint.
-        initial_position (Union[float, npt.NDArray]): The initial position of the joint.
-
+        name: The name of the joint.
+        axis: The axis of rotation or translation for the joint.
+        pose: The pose transformation matrix of the joint.
+        jtype: The type of the joint.
+        child: The child link attached to the joint.
+        parent: The parent link attached to the joint.
+        index: An optional index for the joint.
+        friction_static: The static friction coefficient for the joint.
+        friction_viscous: The viscous friction coefficient for the joint.
+        position_limit_damper: The damper coefficient for position limits.
+        position_limit_spring: The spring coefficient for position limits.
+        position_limit: The position limits for the joint.
+        initial_position: The initial position of the joint.
     """
 
     name: jax_dataclasses.Static[str]

--- a/src/jaxsim/parsers/descriptions/joint.py
+++ b/src/jaxsim/parsers/descriptions/joint.py
@@ -14,6 +14,9 @@ from .link import LinkDescription
 
 @dataclasses.dataclass(frozen=True)
 class JointType:
+    """
+    Enumeration of joint types.
+    """
 
     Fixed: ClassVar[int] = 0
     Revolute: ClassVar[int] = 1

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -158,7 +158,7 @@ class ModelDescription(KinematicGraph):
         Reduce the model by removing specified joints.
 
         Args:
-            The joint names to consider.
+            considered_joints: Sequence of joint names to consider.
 
         Returns:
             A `ModelDescription` instance that only includes the considered joints.

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -97,20 +97,32 @@ class KinematicGraph(Sequence[LinkDescription]):
 
     @functools.cached_property
     def links_dict(self) -> dict[str, LinkDescription]:
+        """
+        Get a dictionary of links indexed by their name.
+        """
         return {l.name: l for l in iter(self)}
 
     @functools.cached_property
     def frames_dict(self) -> dict[str, LinkDescription]:
+        """
+        Get a dictionary of frames indexed by their name.
+        """
         return {f.name: f for f in self.frames}
 
     @functools.cached_property
     def joints_dict(self) -> dict[str, JointDescription]:
+        """
+        Get a dictionary of joints indexed by their name.
+        """
         return {j.name: j for j in self.joints}
 
     @functools.cached_property
     def joints_connection_dict(
         self,
     ) -> dict[tuple[str, str], JointDescription]:
+        """
+        Get a dictionary of joints indexed by the tuple (parent, child) link names.
+        """
         return {(j.parent.name, j.child.name): j for j in self.joints}
 
     def __post_init__(self) -> None:
@@ -734,9 +746,15 @@ class KinematicGraph(Sequence[LinkDescription]):
         raise TypeError(type(key).__name__)
 
     def count(self, value: LinkDescription) -> int:
+        """
+        Count the occurrences of a link in the kinematic graph.
+        """
         return list(iter(self)).count(value)
 
     def index(self, value: LinkDescription, start: int = 0, stop: int = -1) -> int:
+        """
+        Find the index of a link in the kinematic graph.
+        """
         return list(iter(self)).index(value, start, stop)
 
 
@@ -747,6 +765,12 @@ class KinematicGraph(Sequence[LinkDescription]):
 
 @dataclasses.dataclass(frozen=True)
 class KinematicGraphTransforms:
+    """
+    Class to compute forward kinematics on a kinematic graph.
+
+    Attributes:
+        graph: The kinematic graph on which to compute forward kinematics.
+    """
 
     graph: KinematicGraph
 
@@ -767,6 +791,9 @@ class KinematicGraphTransforms:
 
     @property
     def initial_joint_positions(self) -> npt.NDArray:
+        """
+        Get the initial joint positions of the kinematic graph.
+        """
 
         return np.atleast_1d(
             np.array(list(self._initial_joint_positions.values()))
@@ -910,6 +937,17 @@ class KinematicGraphTransforms:
         joint_axis: npt.NDArray,
         joint_position: float | None = None,
     ) -> npt.NDArray:
+        """
+        Compute the SE(3) transform from the predecessor to the successor frame.
+
+        Args:
+            joint_type: The type of the joint.
+            joint_axis: The axis of the joint.
+            joint_position: The position of the joint.
+
+        Returns:
+            The 4x4 transform matrix from the predecessor to the successor frame.
+        """
 
         import jaxsim.math
 

--- a/src/jaxsim/parsers/rod/meshes.py
+++ b/src/jaxsim/parsers/rod/meshes.py
@@ -6,14 +6,14 @@ VALID_AXIS = {"x": 0, "y": 1, "z": 2}
 
 def extract_points_vertices(mesh: trimesh.Trimesh) -> np.ndarray:
     """
-    Extracts the vertices of a mesh as points.
+    Extract the vertices of a mesh as points.
     """
     return mesh.vertices
 
 
 def extract_points_random_surface_sampling(mesh: trimesh.Trimesh, n) -> np.ndarray:
     """
-    Extracts N random points from the surface of a mesh.
+    Extract N random points from the surface of a mesh.
 
     Args:
         mesh: The mesh from which to extract points.
@@ -30,7 +30,7 @@ def extract_points_uniform_surface_sampling(
     mesh: trimesh.Trimesh, n: int
 ) -> np.ndarray:
     """
-    Extracts N uniformly sampled points from the surface of a mesh.
+    Extract N uniformly sampled points from the surface of a mesh.
 
     Args:
         mesh: The mesh from which to extract points.
@@ -47,7 +47,7 @@ def extract_points_select_points_over_axis(
     mesh: trimesh.Trimesh, axis: str, direction: str, n: int
 ) -> np.ndarray:
     """
-    Extracts N points from a mesh along a specified axis. The points are selected based on their position along the axis.
+    Extract N points from a mesh along a specified axis. The points are selected based on their position along the axis.
 
     Args:
         mesh: The mesh from which to extract points.
@@ -75,7 +75,7 @@ def extract_points_aap(
     lower: float | None = None,
 ) -> np.ndarray:
     """
-    Extracts points from a mesh along a specified axis within a specified range. The points are selected based on their position along the axis.
+    Extract points from a mesh along a specified axis within a specified range. The points are selected based on their position along the axis.
 
     Args:
         mesh: The mesh from which to extract points.

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -364,7 +364,7 @@ def build_model_description(
     is_urdf: bool | None = None,
 ) -> descriptions.ModelDescription:
     """
-    Builds a model description from an SDF/URDF resource.
+    Build a model description from an SDF/URDF resource.
 
     Args:
         model_description: A path to an SDF/URDF file, a string containing its content,

--- a/src/jaxsim/parsers/rod/utils.py
+++ b/src/jaxsim/parsers/rod/utils.py
@@ -223,6 +223,17 @@ def create_mesh_collision(
     link_description: descriptions.LinkDescription,
     method: MeshMappingMethod = None,
 ) -> descriptions.MeshCollision:
+    """
+    Create a mesh collision from an SDF collision element.
+
+    Args:
+        collision: The SDF collision element.
+        link_description: The link description.
+        method: The method to use for mesh wrapping.
+
+    Returns:
+        The mesh collision description.
+    """
 
     file = pathlib.Path(resolve_local_uri(uri=collision.geometry.mesh.uri))
     file_type = file.suffix.replace(".", "")

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -125,6 +125,7 @@ class ContactModel(JaxsimDataclass):
         Args:
             model: The robot model considered by the contact model.
             data: The data of the considered model.
+            **kwargs: Optional additional arguments, specific to the contact model.
 
         Returns:
             A tuple containing as first element the computed 6D contact force applied to
@@ -146,6 +147,7 @@ class ContactModel(JaxsimDataclass):
         Args:
             model: The robot model considered by the contact model.
             data: The data of the considered model.
+            **kwargs: Optional additional arguments, specific to the contact model.
 
         Returns:
             A tuple containing as first element the 6D contact force applied to the

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -526,7 +526,7 @@ class RelaxedRigidContacts(common.ContactModel):
             vel: jtp.Vector,
         ) -> tuple[jtp.Vector, jtp.Vector, jtp.Vector, jtp.Vector]:
             """
-            Calculates impedance and offset acceleration in constraint frame.
+            Calculate impedance and offset acceleration in constraint frame.
 
             Args:
                 pos: position in constraint frame.

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -112,7 +112,7 @@ class RelaxedRigidContactsParams(common.ContactsParams):
         damping: jtp.FloatLike | None = None,
         mu: jtp.FloatLike | None = None,
     ) -> Self:
-        """Create a `RelaxedRigidContactsParams` instance"""
+        """Create a `RelaxedRigidContactsParams` instance."""
 
         def default(name: str):
             return cls.__dataclass_fields__[name].default_factory()

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -160,6 +160,7 @@ class RelaxedRigidContactsParams(common.ContactsParams):
         )
 
     def valid(self) -> jtp.BoolLike:
+        """Check if the parameters are valid."""
 
         return bool(
             jnp.all(self.time_constant >= 0.0)
@@ -187,6 +188,7 @@ class RelaxedRigidContacts(common.ContactModel):
 
     @property
     def solver_options(self) -> dict[str, Any]:
+        """Get the solver options."""
 
         return dict(
             zip(
@@ -207,6 +209,7 @@ class RelaxedRigidContacts(common.ContactModel):
 
         Args:
             solver_options: The options to pass to the L-BFGS solver.
+            **kwargs: The parameters of the relaxed rigid contacts model.
 
         Returns:
             The `RelaxedRigidContacts` instance.
@@ -483,8 +486,8 @@ class RelaxedRigidContacts(common.ContactModel):
 
         Args:
             model: The jaxsim model.
-            penetration: The point position in the constraint frame.
-            velocity: The point velocity in the constraint frame.
+            position_constraint: The position of the collidable points in the constraint frame.
+            velocity_constraint: The velocity of the collidable points in the constraint frame.
             parameters: The parameters of the relaxed rigid contacts model.
 
         Returns:

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -79,7 +79,7 @@ class RigidContactsParams(ContactsParams):
         )
 
     def valid(self) -> jtp.BoolLike:
-
+        """Check if the parameters are valid."""
         return bool(
             jnp.all(self.mu >= 0.0)
             and jnp.all(self.K >= 0.0)
@@ -104,6 +104,7 @@ class RigidContacts(ContactModel):
 
     @property
     def solver_options(self) -> dict[str, Any]:
+        """Get the solver options as a dictionary."""
 
         return dict(
             zip(
@@ -127,6 +128,7 @@ class RigidContacts(ContactModel):
             regularization_delassus:
                 The regularization term to add to the diagonal of the Delassus matrix.
             solver_options: The options to pass to the QP solver.
+            **kwargs: Extra arguments which are ignored.
 
         Returns:
             The `RigidContacts` instance.

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -173,7 +173,8 @@ class RigidContacts(ContactModel):
         J_WC: jtp.MatrixLike,
         data: js.data.JaxSimModelData,
     ) -> jtp.Vector:
-        """Returns the new velocity of the system after a potential impact.
+        """
+        Return the new velocity of the system after a potential impact.
 
         Args:
             inactive_collidable_points: The activation state of the collidable points.

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -62,7 +62,7 @@ class RigidContactsParams(ContactsParams):
         K: jtp.FloatLike | None = None,
         D: jtp.FloatLike | None = None,
     ) -> Self:
-        """Create a `RigidContactParams` instance"""
+        """Create a `RigidContactParams` instance."""
 
         return cls(
             mu=jnp.array(
@@ -416,7 +416,8 @@ class RigidContacts(ContactModel):
         inactive_collidable_points: jtp.Vector, mu: jtp.FloatLike
     ) -> jtp.Matrix:
         """
-        Compute the inequality constraint matrix for a single collidable point
+        Compute the inequality constraint matrix for a single collidable point.
+
         Rows 0-3: enforce the friction pyramid constraint,
         Row 4: last one is for the non negativity of the vertical force
         Row 5: contact complementarity condition

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -244,6 +244,28 @@ class SoftContacts(common.ContactModel):
         p: jtp.FloatLike = 0.5,
         q: jtp.FloatLike = 0.5,
     ) -> tuple[jtp.Vector, jtp.Vector]:
+        """
+        Compute the contact force using the Hunt/Crossley model.
+
+        Args:
+            position: The position of the collidable point.
+            velocity: The velocity of the collidable point.
+            tangential_deformation: The material deformation of the collidable point.
+            terrain: The terrain model.
+            K: The stiffness parameter.
+            D: The damping parameter of the soft contacts model.
+            mu: The static friction coefficient.
+            p:
+                The exponent p corresponding to the damping-related non-linearity
+                of the Hunt/Crossley model.
+            q:
+                The exponent q corresponding to the spring-related non-linearity
+                of the Hunt/Crossley model
+
+        Returns:
+            A tuple containing the computed contact force and the derivative of the
+            material deformation.
+        """
 
         # Convert the input vectors to arrays.
         W_p_C = jnp.array(position, dtype=float).squeeze()
@@ -364,6 +386,20 @@ class SoftContacts(common.ContactModel):
         parameters: SoftContactsParams,
         terrain: Terrain,
     ) -> tuple[jtp.Vector, jtp.Vector]:
+        """
+        Compute the contact force.
+
+        Args:
+            position: The position of the collidable point.
+            velocity: The velocity of the collidable point.
+            tangential_deformation: The material deformation of the collidable point.
+            parameters: The parameters of the soft contacts model.
+            terrain: The terrain model.
+
+        Returns:
+            A tuple containing the computed contact force and the derivative of the
+            material deformation.
+        """
 
         CW_fl, ṁ = SoftContacts.hunt_crossley_contact_model(
             position=position,

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -207,6 +207,7 @@ class SoftContacts(common.ContactModel):
             model:
                 The robot model considered by the contact model.
                 If passed, it is used to estimate good default parameters.
+            **kwargs: Additional parameters to pass to the contact model.
 
         Returns:
             The `SoftContacts` instance.

--- a/src/jaxsim/rbda/contacts/visco_elastic.py
+++ b/src/jaxsim/rbda/contacts/visco_elastic.py
@@ -206,6 +206,7 @@ class ViscoElasticContacts(common.ContactModel):
                 If passed, it is used to estimate good default parameters.
             max_squarings:
                 The maximum number of squarings performed in the matrix exponential.
+            **kwargs: Extra arguments to ignore.
 
         Returns:
             The `ViscoElasticContacts` instance.

--- a/src/jaxsim/terrain/terrain.py
+++ b/src/jaxsim/terrain/terrain.py
@@ -13,11 +13,28 @@ from jaxsim import exceptions
 
 
 class Terrain(abc.ABC):
+    """
+    Base class for terrain models.
+
+    Attributes:
+        delta: The delta value used for numerical differentiation.
+    """
 
     delta = 0.010
 
     @abc.abstractmethod
     def height(self, x: jtp.FloatLike, y: jtp.FloatLike) -> jtp.Float:
+        """
+        Compute the height of the terrain at a specific (x, y) location.
+
+        Args:
+            x: The x-coordinate of the location.
+            y: The y-coordinate of the location.
+
+        Returns:
+            The height of the terrain at the specified location.
+        """
+
         pass
 
     def normal(self, x: jtp.FloatLike, y: jtp.FloatLike) -> jtp.Vector:
@@ -47,19 +64,51 @@ class Terrain(abc.ABC):
 
 @jax_dataclasses.pytree_dataclass
 class FlatTerrain(Terrain):
+    """
+    Represents a terrain model with a flat surface and a constant height.
+    """
 
     _height: float = dataclasses.field(default=0.0, kw_only=True)
 
     @staticmethod
     def build(height: jtp.FloatLike = 0.0) -> FlatTerrain:
+        """
+        Create a FlatTerrain instance with a specified height.
+
+        Args:
+            height: The height of the flat terrain.
+
+        Returns:
+            FlatTerrain: A FlatTerrain instance.
+        """
 
         return FlatTerrain(_height=float(height))
 
     def height(self, x: jtp.FloatLike, y: jtp.FloatLike) -> jtp.Float:
+        """
+        Compute the height of the terrain at a specific (x, y) location.
+
+        Args:
+            x: The x-coordinate of the location.
+            y: The y-coordinate of the location.
+
+        Returns:
+            The height of the terrain at the specified location.
+        """
 
         return jnp.array(self._height, dtype=float)
 
     def normal(self, x: jtp.FloatLike, y: jtp.FloatLike) -> jtp.Vector:
+        """
+        Compute the normal vector of the terrain at a specific (x, y) location.
+
+        Args:
+            x: The x-coordinate of the location.
+            y: The y-coordinate of the location.
+
+        Returns:
+            The normal vector of the terrain surface at the specified location.
+        """
 
         return jnp.array([0.0, 0.0, 1.0], dtype=float)
 
@@ -77,6 +126,9 @@ class FlatTerrain(Terrain):
 
 @jax_dataclasses.pytree_dataclass
 class PlaneTerrain(FlatTerrain):
+    """
+    Represents a terrain model with a flat surface defined by a normal vector.
+    """
 
     _normal: tuple[float, float, float] = jax_dataclasses.field(
         default=(0.0, 0.0, 1.0), kw_only=True

--- a/src/jaxsim/utils/jaxsim_dataclass.py
+++ b/src/jaxsim/utils/jaxsim_dataclass.py
@@ -124,7 +124,7 @@ class JaxsimDataclass(abc.ABC):
     @staticmethod
     def get_leaf_shapes(tree: jtp.PyTree) -> tuple[tuple[int, ...] | None]:
         """
-        Helper method to get the leaf shapes of a PyTree.
+        Get the leaf shapes of a PyTree.
 
         Args:
             tree: The PyTree to consider.
@@ -144,7 +144,7 @@ class JaxsimDataclass(abc.ABC):
     @staticmethod
     def get_leaf_dtypes(tree: jtp.PyTree) -> tuple:
         """
-        Helper method to get the leaf dtypes of a PyTree.
+        Get the leaf dtypes of a PyTree.
 
         Args:
             tree: The PyTree to consider.
@@ -164,7 +164,7 @@ class JaxsimDataclass(abc.ABC):
     @staticmethod
     def get_leaf_weak_types(tree: jtp.PyTree) -> tuple[bool, ...]:
         """
-        Helper method to get the leaf weak types of a PyTree.
+        Get the leaf weak types of a PyTree.
 
         Args:
             tree: The PyTree to consider.

--- a/src/jaxsim/utils/tracing.py
+++ b/src/jaxsim/utils/tracing.py
@@ -6,7 +6,7 @@ import jax.interpreters.partial_eval
 
 
 def tracing(var: Any) -> bool | jax.Array:
-    """Returns True if the variable is being traced by JAX, False otherwise."""
+    """Return True if the variable is being traced by JAX, False otherwise."""
 
     return isinstance(
         var, jax._src.core.Tracer | jax.interpreters.partial_eval.DynamicJaxprTracer
@@ -14,6 +14,6 @@ def tracing(var: Any) -> bool | jax.Array:
 
 
 def not_tracing(var: Any) -> bool | jax.Array:
-    """Returns True if the variable is not being traced by JAX, False otherwise."""
+    """Return True if the variable is not being traced by JAX, False otherwise."""
 
     return True if tracing(var) is False else False

--- a/src/jaxsim/utils/wrappers.py
+++ b/src/jaxsim/utils/wrappers.py
@@ -25,6 +25,9 @@ class HashlessObject(Generic[T]):
     obj: T
 
     def get(self: HashlessObject[T]) -> T:
+        """
+        Get the wrapped object.
+        """
         return self.obj
 
     def __hash__(self) -> int:
@@ -52,6 +55,9 @@ class CustomHashedObject(Generic[T]):
     hash_function: Callable[[T], int] = hash
 
     def get(self: CustomHashedObject[T]) -> T:
+        """
+        Get the wrapped object.
+        """
         return self.obj
 
     def __hash__(self) -> int:
@@ -93,6 +99,9 @@ class HashedNumpyArray:
     )
 
     def get(self) -> jax.Array | npt.NDArray:
+        """
+        Get the wrapped array.
+        """
         return self.array
 
     def __hash__(self) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,6 +243,7 @@ def ergocub_model_description_path() -> pathlib.Path:
 
     Returns:
         The path to the URDF model description of the ErgoCub robot.
+
     """
 
     try:
@@ -271,6 +272,7 @@ def jaxsim_model_ergocub(
 
     Returns:
         The JaxSim model of the ErgoCub robot.
+
     """
 
     return build_jaxsim_model(model_description=ergocub_model_description_path)
@@ -283,6 +285,7 @@ def jaxsim_model_ergocub_reduced(jaxsim_model_ergocub) -> js.model.JaxSimModel:
 
     Returns:
         The JaxSim model of the ErgoCub robot with only locomotion joints.
+
     """
 
     model_full = jaxsim_model_ergocub
@@ -316,6 +319,7 @@ def jaxsim_model_ur10() -> js.model.JaxSimModel:
 
     Returns:
         The JaxSim model of the UR10 robot.
+
     """
 
     import robot_descriptions.ur10_description
@@ -329,6 +333,7 @@ def jaxsim_model_ur10() -> js.model.JaxSimModel:
 def jaxsim_model_single_pendulum() -> js.model.JaxSimModel:
     """
     Fixture providing the JaxSim model of a single pendulum.
+
     Returns:
         The JaxSim model of a single pendulum.
     """
@@ -452,6 +457,7 @@ def get_jaxsim_model_fixture(
 
     Returns:
         The JaxSim model of the robot.
+
     """
 
     match model_name:
@@ -507,6 +513,7 @@ def jaxsim_models_types(request) -> pathlib.Path | str:
         - A robot with no joints.
         - A fixed-base robot.
         - A floating-base robot.
+
     """
 
     model_name: str = request.param
@@ -580,6 +587,7 @@ def jaxsim_model_box_32bit(set_jax_32bit, request) -> js.model.JaxSimModel:
 
     Returns:
         The JaxSim model of a box with 32-bit precision.
+
     """
 
     return get_jaxsim_model_fixture(model_name="box", request=request)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def build_jaxsim_model(
     model_description: str | pathlib.Path | rod.Model,
 ) -> js.model.JaxSimModel:
     """
-    Helper to build a JaxSim model from a model description.
+    Build a JaxSim model from a model description.
 
     Args:
         model_description: A model description provided by any fixture provider.
@@ -444,7 +444,7 @@ def get_jaxsim_model_fixture(
     model_name: str, request: pytest.FixtureRequest
 ) -> str | pathlib.Path:
     """
-    Factory to get the fixture providing the JaxSim model of a robot.
+    Get the fixture providing the JaxSim model of a robot.
 
     Args:
         model_name: The name of the model.

--- a/tests/test_meshes.py
+++ b/tests/test_meshes.py
@@ -6,8 +6,9 @@ from jaxsim.parsers.rod import meshes
 def test_mesh_wrapping_vertex_extraction():
     """
     Test the vertex extraction method on different meshes.
-    1. A simple box
-    2. A sphere
+
+    1. A simple box.
+    2. A sphere.
     """
 
     # Test 1: A simple box.
@@ -29,6 +30,7 @@ def test_mesh_wrapping_vertex_extraction():
 def test_mesh_wrapping_aap():
     """
     Test the AAP wrapping method on different meshes.
+
     1. A simple box
         1.1: Remove all points above x=0.0
         1.2: Remove all points below y=0.0
@@ -64,6 +66,7 @@ def test_mesh_wrapping_aap():
 def test_mesh_wrapping_points_over_axis():
     """
     Test the points over axis method on different meshes.
+
     1. A simple box
         1.1: Select 10 points from the lower end of the x-axis
         1.2: Select 10 points from the higher end of the y-axis

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -15,7 +15,8 @@ def test_box_with_external_forces(
     velocity_representation: VelRepr,
 ):
     """
-    This test simulates a box falling due to gravity.
+    Simulate a box falling due to gravity.
+
     We apply to its CoM a 6D force that balances exactly the gravitational force.
     The box should not fall.
     """

--- a/tests/utils_idyntree.py
+++ b/tests/utils_idyntree.py
@@ -33,6 +33,7 @@ def build_kindyncomputations_from_jaxsim_model(
 
     Note:
         Only `JaxSimModel` built from URDF files are supported.
+
     """
 
     if (
@@ -98,6 +99,7 @@ def store_jaxsim_data_in_kindyncomputations(
 
     Returns:
         The updated `KinDynComputations` with the state of `JaxSimModelData`.
+
     """
 
     if kin_dyn.dofs() != data.joint_positions().size:


### PR DESCRIPTION
This PR enhances clarity and uniformity of docstrings across the codebase by removing unnecessary type hints, adopting imperative mood, and adding missing documentation where needed. This update also introduces a `pydocstyle` check in the `ruff` configuration to enforce these standards in the future.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--326.org.readthedocs.build//326/

<!-- readthedocs-preview jaxsim end -->