### PR TITLE
Add experimental JAX Metal support

### DIFF
--- a/src/jaxsim/__init__.py
+++ b/src/jaxsim/__init__.py
@@ -24,6 +24,11 @@ def _jnp_options() -> None:
         logging.warning(msg)
         use_x64 = False
 
+        if is_metal:
+            logging.warning(
+                "JAX Metal backend is experimental. Some functionalities may not be available."
+            )
+
     # Enable 64-bit precision in JAX.
     if use_x64:
         logging.info("Enabling JAX to use 64-bit precision")

--- a/src/jaxsim/__init__.py
+++ b/src/jaxsim/__init__.py
@@ -8,16 +8,19 @@ def _jnp_options() -> None:
 
     import jax
 
-    # Check if running on TPU
+    # Check if running on TPU.
     is_tpu = jax.devices()[0].platform == "tpu"
+
+    # Check if running on Metal.
+    is_metal = jax.devices()[0].platform == "METAL"
 
     # Enable by default 64-bit precision to get accurate physics.
     # Users can enforce 32-bit precision by setting the following variable to 0.
     use_x64 = os.environ.get("JAX_ENABLE_X64", "1") != "0"
 
     # Notify the user if unsupported 64-bit precision was enforced on TPU.
-    if is_tpu and use_x64:
-        msg = "64-bit precision is not allowed on TPU. Enforcing 32bit precision."
+    if (is_tpu or is_metal) and use_x64:
+        msg = f"64-bit precision is not allowed on {jax.devices()[0].platform.upper}. Enforcing 32bit precision."
         logging.warning(msg)
         use_x64 = False
 

--- a/src/jaxsim/exceptions.py
+++ b/src/jaxsim/exceptions.py
@@ -19,8 +19,9 @@ def raise_if(
             format string (fmt), whose fields are filled with the args and kwargs.
     """
 
-    # Disable host callback if running on TPU.
-    if jax.devices()[0].platform == "tpu" or os.environ.get(
+    # Disable host callback if running on unsupported hardware or if the user
+    # explicitly disabled it.
+    if jax.devices()[0].platform in {"tpu", "METAL"} or os.environ.get(
         "JAXSIM_DISABLE_EXCEPTIONS", 0
     ):
         return


### PR DESCRIPTION
This PR adds an experimental support for JAX Metal by enforcing 32-bit precision and disabling host callbacks on Apple Metal GPU platforms.

Note that some functions are still unsupported by JAX as they have no MLIR translation rule, e.g. `jnp.linalg.lstsq` and `jnp.linalg.solve`

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--327.org.readthedocs.build//327/

<!-- readthedocs-preview jaxsim end -->