### PR TITLE
Add `ModelToMjcf` class for generic model to MJCF conversion

### DIFF
--- a/src/jaxsim/mujoco/__init__.py
+++ b/src/jaxsim/mujoco/__init__.py
@@ -1,4 +1,4 @@
-from .loaders import RodModelToMjcf, SdfToMjcf, UrdfToMjcf
+from .loaders import ModelToMjcf, RodModelToMjcf, SdfToMjcf, UrdfToMjcf
 from .model import MujocoModelHelper
 from .utils import mujoco_data_from_jaxsim
 from .visualizer import MujocoVideoRecorder, MujocoVisualizer


### PR DESCRIPTION
This PR introduces a new class for converting URDF/SDF files and ROD models to Mujoco MJCF format, while marking the previous conversion methods as deprecated. 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--335.org.readthedocs.build//335/

<!-- readthedocs-preview jaxsim end -->