### PR TITLE
Add unit tests for `ModelToMjcf` conversion and fix typo in `MujocoCamera`

### DIFF
--- a/examples/jaxsim_for_robot_controllers.ipynb
+++ b/examples/jaxsim_for_robot_controllers.ipynb
@@ -187,7 +187,7 @@
     "            in_link_frame=False,\n",
     "        ),\n",
     "        distance=3,\n",
-    "        azimut=150,\n",
+    "        azimuth=150,\n",
     "        elevation=-10,\n",
     "    ),\n",
     ")\n",

--- a/src/jaxsim/mujoco/utils.py
+++ b/src/jaxsim/mujoco/utils.py
@@ -147,7 +147,7 @@ class MujocoCamera:
         camera_name: str,
         lookat: Sequence[float | int] | npt.NDArray = (0, 0, 0),
         distance: float | int | npt.NDArray = 3,
-        azimut: float | int | npt.NDArray = 90,
+        azimuth: float | int | npt.NDArray = 90,
         elevation: float | int | npt.NDArray = -45,
         fovy: float | int | npt.NDArray = 45,
         degrees: bool = True,
@@ -170,7 +170,7 @@ class MujocoCamera:
             distance:
                 The distance from the target point (displacement between the origins
                 of `T` and `C`).
-            azimut:
+            azimuth:
                 The rotation around z of the camera. With an angle of 0, the camera
                 would loot at the target point towards the positive x-axis of `T`.
             elevation:
@@ -193,8 +193,8 @@ class MujocoCamera:
             seq="ZX", angles=[-90, 90], degrees=True
         ).as_matrix()
 
-        # Process the azimut.
-        R_az = Rotation.from_euler(seq="Y", angles=azimut, degrees=degrees).as_matrix()
+        # Process the azimuth.
+        R_az = Rotation.from_euler(seq="Y", angles=azimuth, degrees=degrees).as_matrix()
         W_H_C[0:3, 0:3] = W_H_C[0:3, 0:3] @ R_az
 
         # Process elevation.

--- a/src/jaxsim/mujoco/visualizer.py
+++ b/src/jaxsim/mujoco/visualizer.py
@@ -178,7 +178,7 @@ class MujocoVisualizer:
         close_on_exit: bool = True,
         lookat: Sequence[float | int] | npt.NDArray | None = None,
         distance: float | int | npt.NDArray | None = None,
-        azimut: float | int | npt.NDArray | None = None,
+        azimuth: float | int | npt.NDArray | None = None,
         elevation: float | int | npt.NDArray | None = None,
     ) -> contextlib.AbstractContextManager[mujoco.viewer.Handle]:
         """
@@ -195,7 +195,7 @@ class MujocoVisualizer:
             viewer=handle,
             lookat=lookat,
             distance=distance,
-            azimut=azimut,
+            azimuth=azimuth,
             elevation=elevation,
         )
 
@@ -210,7 +210,7 @@ class MujocoVisualizer:
         *,
         lookat: Sequence[float | int] | npt.NDArray | None,
         distance: float | int | npt.NDArray | None = None,
-        azimut: float | int | npt.NDArray | None = None,
+        azimuth: float | int | npt.NDArray | None = None,
         elevation: float | int | npt.NDArray | None = None,
     ) -> mj.viewer.Handle:
         """
@@ -236,8 +236,8 @@ class MujocoVisualizer:
         if distance is not None:
             viewer.cam.distance = float(distance)
 
-        if azimut is not None:
-            viewer.cam.azimuth = float(azimut) % 360
+        if azimuth is not None:
+            viewer.cam.azimuth = float(azimuth) % 360
 
         if elevation is not None:
             viewer.cam.elevation = float(elevation)

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,64 @@
+import pytest
+import rod
+
+from jaxsim.mujoco import ModelToMjcf
+from jaxsim.mujoco.loaders import MujocoCamera
+
+
+@pytest.fixture
+def mujoco_camera():
+
+    return MujocoCamera.build_from_target_view(
+        camera_name="test_camera",
+        lookat=(0, 0, 0),
+        distance=1,
+        azimuth=0,
+        elevation=0,
+        fovy=45,
+        degrees=True,
+    )
+
+
+def test_urdf_loading(jaxsim_model_single_pendulum, mujoco_camera):
+    model = jaxsim_model_single_pendulum.built_from
+
+    _ = ModelToMjcf.convert(model=model, cameras=mujoco_camera)
+
+
+def test_sdf_loading(jaxsim_model_single_pendulum, mujoco_camera):
+
+    model = rod.Sdf.load(sdf=jaxsim_model_single_pendulum.built_from).serialize(
+        pretty=True
+    )
+
+    _ = ModelToMjcf.convert(model=model, cameras=mujoco_camera)
+
+
+def test_rod_loading(jaxsim_model_single_pendulum, mujoco_camera):
+
+    model = rod.Sdf.load(sdf=jaxsim_model_single_pendulum.built_from).models()[0]
+
+    _ = ModelToMjcf.convert(model=model, cameras=mujoco_camera)
+
+
+def test_heightmap(jaxsim_model_single_pendulum, mujoco_camera):
+
+    model = rod.Sdf.load(sdf=jaxsim_model_single_pendulum.built_from).models()[0]
+
+    _ = ModelToMjcf.convert(
+        model=model,
+        cameras=mujoco_camera,
+        heightmap=True,
+        heightmap_samples_xy=(51, 51),
+    )
+
+
+def test_inclined_plane(jaxsim_model_single_pendulum, mujoco_camera):
+
+    model = rod.Sdf.load(sdf=jaxsim_model_single_pendulum.built_from).models()[0]
+
+    _ = ModelToMjcf.convert(
+        model=model,
+        cameras=mujoco_camera,
+        plane_normal=(0.3, 0.3, 0.3),
+    )


### PR DESCRIPTION
This PR corrects the parameter name from `azimut` to `azimuth` in `MujocoCamera` and introduces unit tests to validate the `ModelToMjcf` conversion functionality.

Needs #335 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--336.org.readthedocs.build//336/

<!-- readthedocs-preview jaxsim end -->