### PR TITLE
Fix displayed version on Read The Docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,8 +2,6 @@
 import os
 import sys
 
-from pkg_resources import get_distribution
-
 if os.environ.get("READTHEDOCS"):
     checkout_name = os.path.basename(os.path.dirname(os.path.realpath(__file__)))
     os.environ["CONDA_PREFIX"] = os.path.realpath(
@@ -21,7 +19,7 @@ sys.path.insert(0, os.path.abspath("../../"))
 module_path = os.path.abspath("../src/")
 sys.path.insert(0, module_path)
 
-__version__ = get_distribution("jaxsim").version
+__version__ = jaxsim._version.__version__
 
 # -- Project information
 
@@ -29,8 +27,7 @@ project = "JAXsim"
 copyright = "2022, Artificial and Mechanical Intelligence"
 author = "Artificial and Mechanical Intelligence"
 
-release = f"{__version__}"
-version = f"main ({__version__})"
+release = version = __version__
 
 # -- General configuration
 


### PR DESCRIPTION
This PR corrects the version information shown on the Read the Docs page. For some reason, the version provided by `setuptools_scm` was not used by Sphinx during the build

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--338.org.readthedocs.build//338/

<!-- readthedocs-preview jaxsim end -->