### PR TITLE
JAX Jacobian of from_axis_angle producing NaNs

### DIFF
--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -81,5 +81,4 @@ class Rotation:
 
         R = c * jnp.eye(3) - s * Skew.wedge(u) + c1 * u @ u.T
         
-
         return R.transpose()

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -78,7 +78,8 @@ class Rotation:
 
             c1 = 2 * jnp.sin(theta / 2.0) ** 2
 
-            u = v / theta
+            safe_theta = jnp.where(theta == 0, 1.0, theta)
+            u = v / safe_theta
             u = jnp.vstack(u.squeeze())
 
             R = c * jnp.eye(3) - s * Skew.wedge(u) + c1 * u @ u.T

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -68,27 +68,18 @@ class Rotation:
 
         vector = vector.squeeze()
 
-        def theta_is_not_zero(axis: jtp.Vector) -> jtp.Matrix:
+        theta = safe_norm(vector)
 
-            v = axis
-            theta = safe_norm(v)
+        s = jnp.sin(theta)
+        c = jnp.cos(theta)
 
-            s = jnp.sin(theta)
-            c = jnp.cos(theta)
+        c1 = 2 * jnp.sin(theta / 2.0) ** 2
 
-            c1 = 2 * jnp.sin(theta / 2.0) ** 2
+        safe_theta = jnp.where(theta == 0, 1.0, theta)
+        u = vector / safe_theta
+        u = jnp.vstack(u.squeeze())
 
-            safe_theta = jnp.where(theta == 0, 1.0, theta)
-            u = v / safe_theta
-            u = jnp.vstack(u.squeeze())
+        R = c * jnp.eye(3) - s * Skew.wedge(u) + c1 * u @ u.T
+        
 
-            R = c * jnp.eye(3) - s * Skew.wedge(u) + c1 * u @ u.T
-
-            return R.transpose()
-
-        return jnp.where(
-            jnp.allclose(vector, 0.0),
-            # Return an identity rotation matrix when the input vector is zero.
-            jnp.eye(3),
-            theta_is_not_zero(axis=vector),
-        )
+        return R.transpose()

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -80,5 +80,5 @@ class Rotation:
         u = jnp.vstack(u.squeeze())
 
         R = c * jnp.eye(3) - s * Skew.wedge(u) + c1 * u @ u.T
-        
+
         return R.transpose()


### PR DESCRIPTION
Taking the JAX Jacobian of the `from_axis_angle` function was producing NaNs when `vector = [0,0,0]`

I found this: https://jax.readthedocs.io/en/latest/faq.html#gradients-contain-nan-where-using-where
which lays out how to fix this issue by making the internal function safe when the input is 0.

I just added an extra jnp.where() to check before dividing.


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--339.org.readthedocs.build//339/

<!-- readthedocs-preview jaxsim end -->