### PR TITLE
Remove unnecessary typehints and duplicated returntypes in `jaxsim.math` module

### DIFF
--- a/src/jaxsim/math/adjoint.py
+++ b/src/jaxsim/math/adjoint.py
@@ -28,7 +28,7 @@ class Adjoint:
             normalize_quaternion: Whether to normalize the quaternion before creating the adjoint.
 
         Returns:
-            jtp.Matrix: The adjoint matrix.
+            The adjoint matrix.
         """
         quaternion = quaternion if quaternion is not None else jnp.array([1.0, 0, 0, 0])
         translation = translation if translation is not None else jnp.zeros(3)
@@ -78,7 +78,7 @@ class Adjoint:
             inverse: Whether to compute the inverse adjoint. Default is False.
 
         Returns:
-            jtp.Matrix: The adjoint matrix.
+            The adjoint matrix.
         """
         rotation = rotation if rotation is not None else jnp.eye(3)
         translation = translation if translation is not None else jnp.zeros(3)
@@ -115,7 +115,7 @@ class Adjoint:
             adjoint: The adjoint matrix (6x6).
 
         Returns:
-            jtp.Matrix: The transformation matrix (4x4).
+            The transformation matrix (4x4).
         """
         X = adjoint.squeeze()
         assert X.shape == (6, 6)
@@ -141,7 +141,7 @@ class Adjoint:
             adjoint: The adjoint matrix.
 
         Returns:
-            jtp.Matrix: The inverse adjoint matrix.
+            The inverse adjoint matrix.
         """
         A_X_B = adjoint.reshape(-1, 6, 6)
 

--- a/src/jaxsim/math/adjoint.py
+++ b/src/jaxsim/math/adjoint.py
@@ -22,11 +22,10 @@ class Adjoint:
         Create an adjoint matrix from a quaternion and a translation.
 
         Args:
-            quaternion (jtp.Vector): A quaternion vector (4D) representing orientation. Default is [1, 0, 0, 0].
-            translation (jtp.Vector): A translation vector (3D). Default is [0, 0, 0].
-            inverse (bool): Whether to compute the inverse adjoint. Default is False.
-            normalize_quaternion (bool): Whether to normalize the quaternion before creating the adjoint.
-                                         Default is False.
+            quaternion: A quaternion vector (4D) representing orientation.
+            translation: A translation vector (3D).
+            inverse: Whether to compute the inverse adjoint.
+            normalize_quaternion: Whether to normalize the quaternion before creating the adjoint.
 
         Returns:
             jtp.Matrix: The adjoint matrix.
@@ -74,9 +73,9 @@ class Adjoint:
         Create an adjoint matrix from a rotation matrix and a translation vector.
 
         Args:
-            rotation (jtp.Matrix): A 3x3 rotation matrix. Default is identity.
-            translation (jtp.Vector): A translation vector (3D). Default is [0, 0, 0].
-            inverse (bool): Whether to compute the inverse adjoint. Default is False.
+            rotation: A 3x3 rotation matrix.
+            translation: A translation vector (3D).
+            inverse: Whether to compute the inverse adjoint. Default is False.
 
         Returns:
             jtp.Matrix: The adjoint matrix.

--- a/src/jaxsim/math/cross.py
+++ b/src/jaxsim/math/cross.py
@@ -19,7 +19,7 @@ class Cross:
             velocity_sixd: A 6D velocity vector [v, ω].
 
         Returns:
-            jtp.Matrix: The cross product matrix (6x6).
+            The cross product matrix (6x6).
 
         Raises:
             ValueError: If the input vector does not have a size of 6.
@@ -49,7 +49,7 @@ class Cross:
             velocity_sixd: A 6D velocity vector [v, ω].
 
         Returns:
-            jtp.Matrix: The negative transpose of the cross product matrix (6x6).
+            The negative transpose of the cross product matrix (6x6).
 
         Raises:
             ValueError: If the input vector does not have a size of 6.

--- a/src/jaxsim/math/inertia.py
+++ b/src/jaxsim/math/inertia.py
@@ -21,7 +21,7 @@ class Inertia:
             I: The 3x3 inertia matrix.
 
         Returns:
-            jtp.Matrix: The 6x6 inertia matrix.
+            The 6x6 inertia matrix.
 
         Raises:
             ValueError: If the shape of the inertia matrix I is not (3, 3).
@@ -49,7 +49,7 @@ class Inertia:
             M: The 6x6 inertia matrix.
 
         Returns:
-            tuple[jtp.Float, jtp.Vector, jtp.Matrix]: A tuple containing mass, center of mass (3D), and inertia matrix (3x3).
+            A tuple containing mass, center of mass (3D), and inertia matrix (3x3).
 
         Raises:
             ValueError: If the input matrix M has an unexpected shape.

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -21,7 +21,7 @@ class Quaternion:
             wxyz: Quaternion in WXYZ representation.
 
         Returns:
-            jtp.Vector: Quaternion in XYZW representation.
+            Quaternion in XYZW representation.
         """
         return wxyz.squeeze()[jnp.array([1, 2, 3, 0])]
 
@@ -34,7 +34,7 @@ class Quaternion:
             xyzw: Quaternion in XYZW representation.
 
         Returns:
-            jtp.Vector: Quaternion in WXYZ representation.
+            Quaternion in WXYZ representation.
         """
         return xyzw.squeeze()[jnp.array([3, 0, 1, 2])]
 
@@ -47,7 +47,7 @@ class Quaternion:
             quaternion: Quaternion in XYZW representation.
 
         Returns:
-            jtp.Matrix: Direction cosine matrix (DCM).
+            The Direction cosine matrix (DCM).
         """
         return jaxlie.SO3(wxyz=quaternion).as_matrix()
 
@@ -60,7 +60,7 @@ class Quaternion:
             dcm: Direction cosine matrix (DCM).
 
         Returns:
-            jtp.Vector: Quaternion in XYZW representation.
+            Quaternion in WXYZ representation.
         """
         return jaxlie.SO3.from_matrix(matrix=dcm).wxyz
 
@@ -81,7 +81,7 @@ class Quaternion:
             K (float): A scaling factor.
 
         Returns:
-            jtp.Vector: The derivative of the quaternion.
+            The derivative of the quaternion.
         """
         ω = omega.squeeze()
         quaternion = quaternion.squeeze()

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -21,7 +21,7 @@ class Rotation:
             theta: Rotation angle in radians.
 
         Returns:
-            jtp.Matrix: 3D rotation matrix.
+            The 3D rotation matrix.
         """
 
         return jaxlie.SO3.from_x_radians(theta=theta).as_matrix()
@@ -35,7 +35,7 @@ class Rotation:
             theta: Rotation angle in radians.
 
         Returns:
-            jtp.Matrix: 3D rotation matrix.
+            The 3D rotation matrix.
         """
 
         return jaxlie.SO3.from_y_radians(theta=theta).as_matrix()
@@ -49,7 +49,7 @@ class Rotation:
             theta: Rotation angle in radians.
 
         Returns:
-            jtp.Matrix: 3D rotation matrix.
+            The 3D rotation matrix.
         """
 
         return jaxlie.SO3.from_z_radians(theta=theta).as_matrix()

--- a/src/jaxsim/math/skew.py
+++ b/src/jaxsim/math/skew.py
@@ -17,7 +17,7 @@ class Skew:
             vector: A 3D vector.
 
         Returns:
-            jtp.Matrix: The skew-symmetric matrix corresponding to the input vector.
+            The skew-symmetric matrix corresponding to the input vector.
 
         """
 
@@ -45,7 +45,7 @@ class Skew:
             matrix: A 3x3 skew-symmetric matrix.
 
         Returns:
-            jtp.Vector: The 3D vector extracted from the input matrix.
+            The 3D vector extracted from the input matrix.
 
         """
         vector = 0.5 * jnp.vstack(


### PR DESCRIPTION
This PR simplifies the docstrings in the `jaxsim.math` module by removing redundant type hints and returntypes. 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--341.org.readthedocs.build//341/

<!-- readthedocs-preview jaxsim end -->