### PR TITLE
Add `pytest-benchmark` in environment YAML

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
   # [testing]
   - idyntree >= 12.2.1
   - pytest
+  - pytest-benchmark
   - pytest-icdiff
   - robot_descriptions
   - icub-models


### PR DESCRIPTION
This PR adds a missing dependency for `pytest` which made the tests fail if launched from a conda environment created with `conda create -f environment.yml` with:

```console
$ pytest                                                                                                                                                   
jaxsim[528135] INFO Enabling JAX to use 64-bit precision
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --benchmark-skip
  inifile: /home/fferretti-iit.local/git/jaxsim/pyproject.toml
  rootdir: /home/fferretti-iit.local/git/jaxsim
```

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--345.org.readthedocs.build//345/

<!-- readthedocs-preview jaxsim end -->