### PR TITLE
Refactor velocity representation handling in dynamics calculations

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -919,22 +919,17 @@ def forward_dynamics_aba(
         velocity_representation=data.velocity_representation,
     )
 
-    # Extract the link and joint serializations.
-    link_names = model.link_names()
-    joint_names = model.joint_names()
-
     # Extract the state in inertial-fixed representation.
     with data.switch_velocity_representation(VelRepr.Inertial):
         W_p_B = data.base_position()
         W_v_WB = data.base_velocity()
         W_Q_B = data.base_orientation(dcm=False)
-        s = data.joint_positions(model=model, joint_names=joint_names)
-        ṡ = data.joint_velocities(model=model, joint_names=joint_names)
+        s = data.joint_positions(model=model)
+        ṡ = data.joint_velocities(model=model)
 
     # Extract the inputs in inertial-fixed representation.
-    with references.switch_velocity_representation(VelRepr.Inertial):
-        W_f_L = references.link_forces(model=model, data=data, link_names=link_names)
-        τ = references.joint_force_references(model=model, joint_names=joint_names)
+    W_f_L = references._link_forces
+    τ = references._joint_force_references
 
     # ========================
     # Compute forward dynamics

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -307,37 +307,30 @@ class RelaxedRigidContacts(common.ContactModel):
         # collidable points.
         W_H_C = js.contact.transforms(model=model, data=data)
 
-        with (
-            references.switch_velocity_representation(VelRepr.Mixed),
-            data.switch_velocity_representation(VelRepr.Mixed),
-        ):
+        BW_ν = data.generalized_velocity()
 
-            BW_ν = data.generalized_velocity()
-
-            BW_ν̇_free = jnp.hstack(
-                js.ode.system_acceleration(
-                    model=model,
-                    data=data,
-                    link_forces=references.link_forces(model=model, data=data),
-                    joint_force_references=references.joint_force_references(
-                        model=model
-                    ),
-                )
+        BW_ν̇_free = jnp.hstack(
+            js.ode.system_acceleration(
+                model=model,
+                data=data,
+                link_forces=references.link_forces(model=model, data=data),
+                joint_force_references=references.joint_force_references(model=model),
             )
+        )
 
-            M = js.model.free_floating_mass_matrix(model=model, data=data)
+        M = js.model.free_floating_mass_matrix(model=model, data=data)
 
-            Jl_WC = jnp.vstack(
-                jax.vmap(lambda J, δ: J * (δ > 0))(
-                    js.contact.jacobian(model=model, data=data)[:, :3, :], δ
-                )
+        Jl_WC = jnp.vstack(
+            jax.vmap(lambda J, δ: J * (δ > 0))(
+                js.contact.jacobian(model=model, data=data)[:, :3, :], δ
             )
+        )
 
-            J̇_WC = jnp.vstack(
-                jax.vmap(lambda J̇, δ: J̇ * (δ > 0))(
-                    js.contact.jacobian_derivative(model=model, data=data)[:, :3], δ
-                ),
-            )
+        J̇_WC = jnp.vstack(
+            jax.vmap(lambda J̇, δ: J̇ * (δ > 0))(
+                js.contact.jacobian_derivative(model=model, data=data)[:, :3], δ
+            ),
+        )
 
         # Compute the regularization terms.
         a_ref, R, *_ = self._regularizers(


### PR DESCRIPTION
Streamline the code by removing unnecessary switches for velocity representation and adopting an inertial-fixed representation in various dynamics functions. This enhances clarity and efficiency in the calculations related to collidable points and contact forces.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--346.org.readthedocs.build//346/

<!-- readthedocs-preview jaxsim end -->