### PR TITLE
Avoid device-to-host data transfers and disable runtime exception handling

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -61,9 +61,9 @@ The logging and exceptions configurations is controlled by the following environ
 
   *Default:* ``DEBUG`` for development, ``WARNING`` for production.
 
-- ``JAXSIM_DISABLE_EXCEPTIONS``: Disables the runtime checks and exceptions. Note that enabling exceptions might lead to device-to-host transfer of data, increasing the computational time required.
+- ``JAXSIM_ENABLE_EXCEPTIONS``: Enables the runtime checks and exceptions. Note that enabling exceptions might lead to device-to-host transfer of data, increasing the computational time required.
 
-  *Default:* ``True``.
+  *Default:* ``False``.
 
 .. note::
     Runtime exceptions are disabled by default on TPU.

--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -61,9 +61,9 @@ The logging and exceptions configurations is controlled by the following environ
 
   *Default:* ``DEBUG`` for development, ``WARNING`` for production.
 
-- ``JAXSIM_DISABLE_EXCEPTIONS``: Disables the runtime checks and exceptions.
+- ``JAXSIM_DISABLE_EXCEPTIONS``: Disables the runtime checks and exceptions. Note that enabling exceptions might lead to device-to-host transfer of data, increasing the computational time required.
 
-  *Default:* ``False``.
+  *Default:* ``True``.
 
 .. note::
     Runtime exceptions are disabled by default on TPU.

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -89,7 +89,7 @@ class JaxSimModel(JaxsimDataclass):
         return hash(
             (
                 hash(self.model_name),
-                hash(float(self.time_step)),
+                hash(self.time_step),
                 hash(self.kin_dyn_parameters),
                 hash(self.contact_model),
             )
@@ -350,7 +350,7 @@ class JaxSimModel(JaxsimDataclass):
             True if the model is floating-base, False otherwise.
         """
 
-        return bool(self.kin_dyn_parameters.joint_model.joint_dofs[0] == 6)
+        return self.kin_dyn_parameters.joint_model.joint_dofs[0] == 6
 
     def base_link(self) -> str:
         """
@@ -381,7 +381,7 @@ class JaxSimModel(JaxsimDataclass):
             the number of joints. In the future, this could be different.
         """
 
-        return int(sum(self.kin_dyn_parameters.joint_model.joint_dofs[1:]))
+        return sum(self.kin_dyn_parameters.joint_model.joint_dofs[1:])
 
     def joint_names(self) -> tuple[str, ...]:
         """
@@ -464,7 +464,7 @@ def reduce(
     for joint_name in set(model.joint_names()) - set(considered_joints):
         j = intermediate_description.joints_dict[joint_name]
         with j.mutable_context():
-            j.initial_position = float(locked_joint_positions.get(joint_name, 0.0))
+            j.initial_position = locked_joint_positions.get(joint_name, 0.0)
 
     # Reduce the model description.
     # If `considered_joints` contains joints not existing in the model,

--- a/src/jaxsim/exceptions.py
+++ b/src/jaxsim/exceptions.py
@@ -24,7 +24,7 @@ def raise_if(
     # Disable host callback if running on unsupported hardware or if the user
     # explicitly disabled it.
     if jax.devices()[0].platform in {"tpu", "METAL"} or os.environ.get(
-        "JAXSIM_DISABLE_EXCEPTIONS", 0
+        "JAXSIM_DISABLE_EXCEPTIONS", 1
     ):
         return
 

--- a/src/jaxsim/exceptions.py
+++ b/src/jaxsim/exceptions.py
@@ -23,8 +23,8 @@ def raise_if(
 
     # Disable host callback if running on unsupported hardware or if the user
     # explicitly disabled it.
-    if jax.devices()[0].platform in {"tpu", "METAL"} or os.environ.get(
-        "JAXSIM_DISABLE_EXCEPTIONS", 1
+    if jax.devices()[0].platform in {"tpu", "METAL"} or not os.environ.get(
+        "JAXSIM_ENABLE_EXCEPTIONS", 0
     ):
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 import os
+
+os.environ["JAXSIM_ENABLE_EXCEPTIONS"] = "1"
+
 import pathlib
 import subprocess
 


### PR DESCRIPTION
This PR removes device-to-host data transfers caused by accessing `JaxSimModel` properties and disables runtime exceptions by default. Moreover, it updates the relevant documentation section 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--355.org.readthedocs.build//355/

<!-- readthedocs-preview jaxsim end -->