### PR TITLE
[Sprint] Fix missing switch in RelaxedRigidContacts `compute_contact_forces`

### DIFF
--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -336,13 +336,13 @@ class RelaxedRigidContacts(common.ContactModel):
                 ),
             )
 
-            # Compute the regularization terms.
-            a_ref, R, *_ = self._regularizers(
-                model=model,
-                position_constraint=position_constraint,
-                velocity_constraint=velocity,
-                parameters=model.contacts_params,
-            )
+        # Compute the regularization terms.
+        a_ref, R, *_ = self._regularizers(
+            model=model,
+            position_constraint=position_constraint,
+            velocity_constraint=velocity,
+            parameters=model.contacts_params,
+        )
 
         # Compute the Delassus matrix and the free mixed linear acceleration of
         # the collidable points.


### PR DESCRIPTION
This PR fixes a missing switch of velocity representation inside the relaxed contact model, probably removed during the sprint.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--356.org.readthedocs.build//356/

<!-- readthedocs-preview jaxsim end -->