### PR TITLE
[Sprint] Set mixed as default representation in `data.build`

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1989,7 +1989,7 @@ def step(
     model: JaxSimModel,
     data: js.data.JaxSimModelData,
     *,
-    link_forces_inertial: jtp.MatrixLike | None = None,
+    link_forces: jtp.MatrixLike | None = None,
     joint_force_references: jtp.VectorLike | None = None,
 ) -> js.data.JaxSimModelData:
     """
@@ -1999,8 +1999,8 @@ def step(
         model: The model to consider.
         data: The data of the considered model.
         dt: The time step to consider. If not specified, it is read from the model.
-        link_forces_inertial:
-            The 6D forces to apply to the links expressed in inertial-representation.
+        link_forces:
+            The 6D forces to apply to the links expressed in same representation of data.
         joint_force_references: The joint force references to consider.
 
     Returns:
@@ -2016,11 +2016,22 @@ def step(
     # the enabled collidable points
 
     # Extract the inputs
-    W_f_L_external = jnp.atleast_2d(
-        jnp.array(link_forces_inertial, dtype=float).squeeze()
-        if link_forces_inertial is not None
+    O_f_L_external = jnp.atleast_2d(
+        jnp.array(link_forces, dtype=float).squeeze()
+        if link_forces is not None
         else jnp.zeros((model.number_of_links(), 6))
     )
+
+    # Get the external forces in inertial-fixed representation.
+    W_f_L_external = jax.vmap(
+        lambda f_L, W_H_L: js.data.JaxSimModelData.other_representation_to_inertial(
+            f_L,
+            other_representation=data.velocity_representation,
+            transform=W_H_L,
+            is_force=True,
+        )
+    )(O_f_L_external, data.link_transforms)
+
     τ_references = jnp.atleast_1d(
         jnp.array(joint_force_references, dtype=float).squeeze()
         if joint_force_references is not None

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -2074,7 +2074,7 @@ def step(
     # ===============================
 
     with data.switch_velocity_representation(jaxsim.VelRepr.Inertial):
-        W_v̇_WB, s̈ = js.ode.system_velocity_dynamics(
+        W_v̇_WB, s̈ = js.ode.system_acceleration(
             model=model,
             data=data,
             link_forces=W_f_L_total,

--- a/src/jaxsim/rbda/forward_kinematics.py
+++ b/src/jaxsim/rbda/forward_kinematics.py
@@ -15,8 +15,8 @@ def forward_kinematics_model(
     base_position: jtp.VectorLike,
     base_quaternion: jtp.VectorLike,
     joint_positions: jtp.VectorLike,
-    base_linear_velocity: jtp.VectorLike,
-    base_angular_velocity: jtp.VectorLike,
+    base_linear_velocity_inertial: jtp.VectorLike,
+    base_angular_velocity_inertial: jtp.VectorLike,
     joint_velocities: jtp.VectorLike,
 ) -> jtp.Array:
     """
@@ -27,8 +27,8 @@ def forward_kinematics_model(
         base_position: The position of the base link.
         base_quaternion: The quaternion of the base link.
         joint_positions: The positions of the joints.
-        base_linear_velocity: The linear velocity of the base link.
-        base_angular_velocity: The angular velocity of the base link.
+        base_linear_velocity_inertial: The linear velocity of the base link in inertial-fixed representation.
+        base_angular_velocity_inertial: The angular velocity of the base link in inertial-fixed representation.
         joint_velocities: The velocities of the joints.
 
     Returns:
@@ -40,8 +40,8 @@ def forward_kinematics_model(
         base_position=base_position,
         base_quaternion=base_quaternion,
         joint_positions=joint_positions,
-        base_linear_velocity=base_linear_velocity,
-        base_angular_velocity=base_angular_velocity,
+        base_linear_velocity=base_linear_velocity_inertial,
+        base_angular_velocity=base_angular_velocity_inertial,
         joint_velocities=joint_velocities,
     )
 

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -229,21 +229,14 @@ def test_ad_fk(
     # ====
 
     # Get a closure exposing only the parameters to be differentiated.
-    fk = (
-        lambda W_p_B,
-        W_Q_B,
-        s,
-        W_v_lin,
-        W_v_ang,
-        ṡ: jaxsim.rbda.forward_kinematics_model(
-            model=model,
-            base_position=W_p_B,
-            base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
-            joint_positions=s,
-            base_linear_velocity_inertial=W_v_lin,
-            base_angular_velocity_inertial=W_v_ang,
-            joint_velocities=ṡ,
-        )
+    fk = lambda W_p_B, W_Q_B, s, W_v_lin, W_v_ang, ṡ: jaxsim.rbda.forward_kinematics_model(
+        model=model,
+        base_position=W_p_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+        joint_positions=s,
+        base_linear_velocity_inertial=W_v_lin,
+        base_angular_velocity_inertial=W_v_ang,
+        joint_velocities=ṡ,
     )
 
     # Check derivatives against finite differences.

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -229,14 +229,21 @@ def test_ad_fk(
     # ====
 
     # Get a closure exposing only the parameters to be differentiated.
-    fk = lambda W_p_B, W_Q_B, s, W_v_lin, W_v_ang, ṡ: jaxsim.rbda.forward_kinematics_model(
-        model=model,
-        base_position=W_p_B,
-        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
-        joint_positions=s,
-        base_linear_velocity=W_v_lin,
-        base_angular_velocity=W_v_ang,
-        joint_velocities=ṡ,
+    fk = (
+        lambda W_p_B,
+        W_Q_B,
+        s,
+        W_v_lin,
+        W_v_ang,
+        ṡ: jaxsim.rbda.forward_kinematics_model(
+            model=model,
+            base_position=W_p_B,
+            base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+            joint_positions=s,
+            base_linear_velocity_inertial=W_v_lin,
+            base_angular_velocity_inertial=W_v_ang,
+            joint_velocities=ṡ,
+        )
     )
 
     # Check derivatives against finite differences.
@@ -344,7 +351,7 @@ def test_ad_integration(
             model=model,
             data=data_x0,
             joint_force_references=τ,
-            link_forces_inertial=W_f_L,
+            link_forces=W_f_L,
         )
 
         xf_W_p_B = data_xf.base_position


### PR DESCRIPTION
This PR introduced the following changes:
- Refactors `data.build` method to use the mixed representation if not specified
- Refactor `model.step` to accept link forces in any representation (as done in main)
- Remove `ode.system_velocity_dynamics` since its job has been extracted in other functions and now is a duplicated of `system_acceleration`

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--361.org.readthedocs.build//361/

<!-- readthedocs-preview jaxsim end -->