### PR TITLE
Run CI/CD workflows on `ubuntu-latest`

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -16,7 +16,7 @@ jobs:
 
   package:
     name: Package the project
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
 


### PR DESCRIPTION
This PR modifies the runner OS to run CI/CD tests on Ubuntu latest (24.04)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--363.org.readthedocs.build//363/

<!-- readthedocs-preview jaxsim end -->