### PR TITLE
Inherit model contact parameters and gravity in `js.model.reduce`

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -447,6 +447,8 @@ def reduce(
         time_step=model.time_step,
         terrain=model.terrain,
         contact_model=model.contact_model,
+        contacts_params=model.contacts_params,
+        gravity=model.gravity,
     )
 
     # Store the origin of the model, in case downstream logic needs it.


### PR DESCRIPTION
 This PR fixes the `js.model.reduce` function to inherit model contact parameters and gravity, improving consistency and functionality.