### PR TITLE
Implement Runge-Kutta 4 integrator

### DIFF
--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -1,4 +1,5 @@
 import dataclasses
+from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
@@ -143,3 +144,9 @@ def rk4_integration(
     data_tf = dataclasses.replace(data, **{"_" + k: v for k, v in x_tf.items()})
 
     return data_tf.replace(model=model)
+
+
+_INTEGRATORS_MAP: dict[js.model.Integrator, Callable[..., js.data.JaxSimModelData]] = {
+    js.model.Integrator.SemiImplicitEuler: semi_implicit_euler_integration,
+    js.model.Integrator.RungeKutta4: rk4_integration,
+}

--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -145,7 +145,9 @@ def rk4_integration(
     return data_tf.replace(model=model)
 
 
-_INTEGRATORS_MAP: dict[js.model.Integrator, Callable[..., js.data.JaxSimModelData]] = {
-    js.model.Integrator.SemiImplicitEuler: semi_implicit_euler_integration,
-    js.model.Integrator.RungeKutta4: rk4_integration,
+_INTEGRATORS_MAP: dict[
+    js.model.IntegratorType, Callable[..., js.data.JaxSimModelData]
+] = {
+    js.model.IntegratorType.SemiImplicitEuler: semi_implicit_euler_integration,
+    js.model.IntegratorType.RungeKutta4: rk4_integration,
 }

--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -93,18 +93,18 @@ def rk4_integration(
     def get_state_derivative(data_ode: JaxSimModelData) -> dict:
 
         # Safe normalize the quaternion.
-        base_quaternion_norm = jaxsim.math.safe_norm(data_ode.base_quaternion)
-        base_quaternion = data_ode.base_quaternion / jnp.where(
+        base_quaternion_norm = jaxsim.math.safe_norm(data_ode._base_quaternion)
+        base_quaternion = data_ode._base_quaternion / jnp.where(
             base_quaternion_norm == 0, 1.0, base_quaternion_norm
         )
 
         return dict(
-            base_position=data_ode.base_position,
+            base_position=data_ode._base_position,
             base_quaternion=base_quaternion,
-            joint_positions=data_ode.joint_positions,
-            base_linear_velocity=data_ode.base_velocity[0:3],
-            base_angular_velocity=data_ode.base_velocity[3:6],
-            joint_velocities=data_ode.joint_velocities,
+            joint_positions=data_ode._joint_positions,
+            base_linear_velocity=data_ode._base_linear_velocity,
+            base_angular_velocity=data_ode._base_angular_velocity,
+            joint_velocities=data_ode._joint_velocities,
         )
 
     def f(x) -> dict[str, jtp.Matrix]:
@@ -122,8 +122,7 @@ def rk4_integration(
                 joint_torques=joint_torques,
             )
 
-    with data.switch_velocity_representation(jaxsim.VelRepr.Inertial):
-        x_t0 = get_state_derivative(data)
+    x_t0 = get_state_derivative(data)
 
     euler_mid = lambda x, dxdt: x + (0.5 * dt) * dxdt
     euler_fin = lambda x, dxdt: x + dt * dxdt

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -2113,7 +2113,7 @@ def step(
         # Pass link_forces and joint_torques if the integrator is rk4
         **(
             {"link_forces": W_f_L_total, "joint_torques": τ_total}
-            if model.integrator == js.integrators.rk4_integration
+            if model.integrator == IntegratorType.RungeKutta4
             else {}
         ),
     )

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import enum
 import functools
 import pathlib
 from collections.abc import Sequence
@@ -21,6 +22,13 @@ from jaxsim.parsers.descriptions import ModelDescription
 from jaxsim.utils import JaxsimDataclass, Mutability, wrappers
 
 from .common import VelRepr
+
+
+class Integrator(enum.IntEnum):
+    """The integrators available for the simulation."""
+
+    SemiImplicitEuler = enum.auto()
+    RungeKutta4 = enum.auto()
 
 
 @jax_dataclasses.pytree_dataclass(eq=False, unsafe_hash=False)
@@ -53,6 +61,10 @@ class JaxSimModel(JaxsimDataclass):
 
     kin_dyn_parameters: js.kin_dyn_parameters.KinDynParameters | None = (
         dataclasses.field(default=None, repr=False)
+    )
+
+    integrator: Static[Integrator] = dataclasses.field(
+        default=Integrator.SemiImplicitEuler, repr=False
     )
 
     built_from: Static[str | pathlib.Path | rod.Model | None] = dataclasses.field(
@@ -111,6 +123,7 @@ class JaxSimModel(JaxsimDataclass):
         terrain: jaxsim.terrain.Terrain | None = None,
         contact_model: jaxsim.rbda.contacts.ContactModel | None = None,
         contact_params: jaxsim.rbda.contacts.ContactsParams | None = None,
+        integrator: Integrator | None = None,
         is_urdf: bool | None = None,
         considered_joints: Sequence[str] | None = None,
     ) -> JaxSimModel:
@@ -131,6 +144,7 @@ class JaxSimModel(JaxsimDataclass):
                 The contact model to consider.
                 If not specified, a soft contacts model is used.
             contact_params: The parameters of the contact model.
+            integrator: The integrator to use for the simulation.
             is_urdf:
                 The optional flag to force the model description to be parsed as a URDF.
                 This is usually automatically inferred.
@@ -164,6 +178,7 @@ class JaxSimModel(JaxsimDataclass):
             terrain=terrain,
             contact_model=contact_model,
             contacts_params=contact_params,
+            integrator=integrator,
         )
 
         # Store the origin of the model, in case downstream logic needs it.
@@ -182,6 +197,7 @@ class JaxSimModel(JaxsimDataclass):
         terrain: jaxsim.terrain.Terrain | None = None,
         contact_model: jaxsim.rbda.contacts.ContactModel | None = None,
         contacts_params: jaxsim.rbda.contacts.ContactsParams | None = None,
+        integrator: Integrator | None = None,
         gravity: jtp.FloatLike = jaxsim.math.STANDARD_GRAVITY,
     ) -> JaxSimModel:
         """
@@ -202,6 +218,7 @@ class JaxSimModel(JaxsimDataclass):
                 The contact model to consider.
                 If not specified, a soft contacts model is used.
             contacts_params: The parameters of the soft contacts.
+            integrator: The integrator to use for the simulation.
             gravity: The gravity constant.
 
         Returns:
@@ -237,6 +254,13 @@ class JaxSimModel(JaxsimDataclass):
         if contacts_params is None:
             contacts_params = contact_model._parameters_class()
 
+        # Consider the default integrator if not specified.
+        integrator = (
+            integrator
+            if integrator is not None
+            else JaxSimModel.__dataclass_fields__["integrator"].default
+        )
+
         # Build the model.
         model = cls(
             model_name=model_name,
@@ -247,6 +271,7 @@ class JaxSimModel(JaxsimDataclass):
             terrain=terrain,
             contact_model=contact_model,
             contacts_params=contacts_params,
+            integrator=integrator,
             gravity=gravity,
             # The following is wrapped as hashless since it's a static argument, and we
             # don't want to trigger recompilation if it changes. All relevant parameters
@@ -449,6 +474,7 @@ def reduce(
         contact_model=model.contact_model,
         contacts_params=model.contacts_params,
         gravity=model.gravity,
+        integrator=model.integrator,
     )
 
     # Store the origin of the model, in case downstream logic needs it.
@@ -2075,12 +2101,21 @@ def step(
     # =============================
     # Advance the simulation state
     # =============================
+    from .integrators import _INTEGRATORS_MAP
 
-    data_tf = js.integrators.semi_implicit_euler_integration(
+    integrator_fn = _INTEGRATORS_MAP[model.integrator]
+
+    data_tf = integrator_fn(
         model=model,
         data=data,
         base_acceleration_inertial=W_v̇_WB,
         joint_accelerations=s̈,
+        # Pass link_forces and joint_torques if the integrator is rk4
+        **(
+            {"link_forces": W_f_L_total, "joint_torques": τ_total}
+            if model.integrator == js.integrators.rk4_integration
+            else {}
+        ),
     )
 
     return data_tf

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -24,7 +24,7 @@ from jaxsim.utils import JaxsimDataclass, Mutability, wrappers
 from .common import VelRepr
 
 
-class Integrator(enum.IntEnum):
+class IntegratorType(enum.IntEnum):
     """The integrators available for the simulation."""
 
     SemiImplicitEuler = enum.auto()
@@ -63,8 +63,8 @@ class JaxSimModel(JaxsimDataclass):
         dataclasses.field(default=None, repr=False)
     )
 
-    integrator: Static[Integrator] = dataclasses.field(
-        default=Integrator.SemiImplicitEuler, repr=False
+    integrator: Static[IntegratorType] = dataclasses.field(
+        default=IntegratorType.SemiImplicitEuler, repr=False
     )
 
     built_from: Static[str | pathlib.Path | rod.Model | None] = dataclasses.field(
@@ -123,7 +123,7 @@ class JaxSimModel(JaxsimDataclass):
         terrain: jaxsim.terrain.Terrain | None = None,
         contact_model: jaxsim.rbda.contacts.ContactModel | None = None,
         contact_params: jaxsim.rbda.contacts.ContactsParams | None = None,
-        integrator: Integrator | None = None,
+        integrator: IntegratorType | None = None,
         is_urdf: bool | None = None,
         considered_joints: Sequence[str] | None = None,
     ) -> JaxSimModel:
@@ -197,7 +197,7 @@ class JaxSimModel(JaxsimDataclass):
         terrain: jaxsim.terrain.Terrain | None = None,
         contact_model: jaxsim.rbda.contacts.ContactModel | None = None,
         contacts_params: jaxsim.rbda.contacts.ContactsParams | None = None,
-        integrator: Integrator | None = None,
+        integrator: IntegratorType | None = None,
         gravity: jtp.FloatLike = jaxsim.math.STANDARD_GRAVITY,
     ) -> JaxSimModel:
         """

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -3,7 +3,6 @@ import jax.numpy as jnp
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.api.data import JaxSimModelData
 from jaxsim.math import Quaternion, Skew
 
 from .common import VelRepr
@@ -123,7 +122,7 @@ def system_dynamics(
     link_forces: jtp.Vector | None = None,
     joint_torques: jtp.Vector | None = None,
     baumgarte_quaternion_regularization: jtp.FloatLike = 1.0,
-) -> JaxSimModelData:
+) -> dict[str, jtp.Vector]:
     """
     Compute the dynamics of the system.
 
@@ -139,9 +138,9 @@ def system_dynamics(
             quaternion (only used in integrators not operating on the SO(3) manifold).
 
     Returns:
-        A tuple with an `JaxSimModelData` object storing in each of its attributes the
-        corresponding derivative, and the dictionary of auxiliary data returned
-        by the system dynamics evaluation.
+        A dictionary containing the derivatives of the base position, the base quaternion,
+        the joint positions, the base linear velocity, the base angular velocity, and the
+        joint velocities.
     """
 
     with data.switch_velocity_representation(velocity_representation=VelRepr.Inertial):

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -158,8 +158,7 @@ def system_dynamics(
             baumgarte_quaternion_regularization=baumgarte_quaternion_regularization,
         )
 
-    ode_state_derivative = JaxSimModelData.build(
-        model=model,
+    return dict(
         base_position=W_ṗ_B,
         base_quaternion=W_Q̇_B,
         joint_positions=ṡ,
@@ -167,5 +166,3 @@ def system_dynamics(
         base_angular_velocity=W_v̇_WB[3:6],
         joint_velocities=s̈,
     )
-
-    return ode_state_derivative

--- a/src/jaxsim/rbda/utils.py
+++ b/src/jaxsim/rbda/utils.py
@@ -132,6 +132,12 @@ def process_inputs(
     if W_Q_B.shape != (4,):
         raise ValueError(W_Q_B.shape, (4,))
 
+    # Check that the quaternion does not contain NaNs.
+    exceptions.raise_value_error_if(
+        condition=jnp.isnan(W_Q_B).any(),
+        msg="A RBDA received a quaternion that contains NaNs.",
+    )
+
     # Check that the quaternion is unary since our RBDAs make this assumption in order
     # to prevent introducing additional normalizations that would affect AD.
     exceptions.raise_value_error_if(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import rod.urdf.exporter
 
 import jaxsim
 import jaxsim.api as js
-from jaxsim.api.model import Integrator
+from jaxsim.api.model import IntegratorType
 
 
 def pytest_addoption(parser):
@@ -131,8 +131,8 @@ def velocity_representation(request) -> jaxsim.VelRepr:
 @pytest.fixture(
     scope="function",
     params=[
-        pytest.param(Integrator.SemiImplicitEuler, id="semi_implicit_euler"),
-        pytest.param(Integrator.RungeKutta4, id="runge_kutta_4"),
+        pytest.param(IntegratorType.SemiImplicitEuler, id="semi_implicit_euler"),
+        pytest.param(IntegratorType.RungeKutta4, id="runge_kutta_4"),
     ],
 )
 def integrator(request) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import rod.urdf.exporter
 
 import jaxsim
 import jaxsim.api as js
+from jaxsim.api.model import Integrator
 
 
 def pytest_addoption(parser):
@@ -122,6 +123,24 @@ def velocity_representation(request) -> jaxsim.VelRepr:
 
     Returns:
         A velocity representation.
+    """
+
+    return request.param
+
+
+@pytest.fixture(
+    scope="function",
+    params=[
+        pytest.param(Integrator.SemiImplicitEuler, id="semi_implicit_euler"),
+        pytest.param(Integrator.RungeKutta4, id="runge_kutta_4"),
+    ],
+)
+def integrator(request) -> str:
+    """
+    Fixture providing the integrator to use in the simulation.
+
+    Returns:
+        The integrator to use in the simulation.
     """
 
     return request.param

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -188,7 +188,7 @@ def run_simulation(
 
 
 def test_simulation_with_relaxed_rigid_contacts(
-    jaxsim_model_box: js.model.JaxSimModel,
+    jaxsim_model_box: js.model.JaxSimModel, integrator
 ):
 
     model = jaxsim_model_box
@@ -206,6 +206,7 @@ def test_simulation_with_relaxed_rigid_contacts(
         model.kin_dyn_parameters.contact_parameters.enabled = tuple(
             enabled_collidable_points_mask.tolist()
         )
+        model.integrator = integrator
 
     assert np.sum(model.kin_dyn_parameters.contact_parameters.enabled) == 4
 


### PR DESCRIPTION
This PR introduces a new Runge-Kutta 4 integration method and an `Integrator` enum to select between available simulation integrators. Moreover, it adds NaN checks for quaternions and add a `pytest` fixture for testing different integrators and updates the `JaxSimModel` to support integrator selection.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--373.org.readthedocs.build//373/

<!-- readthedocs-preview jaxsim end -->