### PR TITLE
Remove object references cycle in LinkDescription

### DIFF
--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -177,9 +177,9 @@ class KinDynParameters(JaxsimDataclass):
         # Build the parent array λ(i) of the model.
         # Note: the parent of the base link is not set since it's not defined.
         parent_array_dict = {
-            link.index: link.parent.index
+            link.index: model_description.links_dict[link.parent_name].index
             for link in ordered_links
-            if link.parent is not None
+            if link.parent_name is not None
         }
         parent_array = jnp.array([-1, *list(parent_array_dict.values())], dtype=int)
 
@@ -862,7 +862,7 @@ class FrameParameters(JaxsimDataclass):
 
         # For each frame, extract the index of the link to which it is attached to.
         parent_link_index_of_frames = tuple(
-            model_description.links_dict[frame.parent.name].index
+            model_description.links_dict[frame.parent_name].index
             for frame in model_description.frames
         )
 

--- a/src/jaxsim/parsers/descriptions/link.py
+++ b/src/jaxsim/parsers/descriptions/link.py
@@ -31,7 +31,7 @@ class LinkDescription(JaxsimDataclass):
     mass: float = dataclasses.field(repr=False)
     inertia: jtp.Matrix = dataclasses.field(repr=False)
     index: int | None = None
-    parent: LinkDescription | None = dataclasses.field(default=None, repr=False)
+    parent_name: str | None = dataclasses.field(default=None, repr=False)
     pose: jtp.Matrix = dataclasses.field(default_factory=lambda: jnp.eye(4), repr=False)
 
     children: Static[tuple[LinkDescription]] = dataclasses.field(
@@ -50,8 +50,7 @@ class LinkDescription(JaxsimDataclass):
                 hash(int(self.index)) if self.index is not None else 0,
                 HashedNumpyArray.hash_of_array(self.pose),
                 hash(tuple(self.children)),
-                # Here only using the name to prevent circular recursion:
-                hash(self.parent.name) if self.parent is not None else 0,
+                hash(self.parent_name) if self.parent_name is not None else 0,
             )
         )
 
@@ -67,11 +66,7 @@ class LinkDescription(JaxsimDataclass):
             and self.index == other.index
             and np.allclose(self.pose, other.pose)
             and self.children == other.children
-            and (
-                (self.parent is not None and self.parent.name == other.parent.name)
-                if self.parent is not None
-                else other.parent is None
-            ),
+            and self.parent_name == other.parent_name
         ):
             return False
 

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -119,16 +119,16 @@ class ModelDescription(KinematicGraph):
             for cp in collision_shape.collidable_points:
                 # Find the link that is part of the (reduced) model in which the
                 # collision shape's parent was lumped into
-                real_parent_link_of_shape = kinematic_graph.frames_dict[
+                real_parent_link_name = kinematic_graph.frames_dict[
                     parent_link_of_shape.name
-                ].parent
+                ].parent_name
 
                 # Change the link associated to the collidable point, updating their
                 # relative pose
                 moved_cp = cp.change_link(
-                    new_link=real_parent_link_of_shape,
+                    new_link=kinematic_graph.links_dict[real_parent_link_name],
                     new_H_old=fk.relative_transform(
-                        relative_to=real_parent_link_of_shape.name,
+                        relative_to=real_parent_link_name,
                         name=cp.parent_link.name,
                     ),
                 )

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -131,7 +131,7 @@ def extract_model_data(
             name=f.name,
             mass=jnp.array(0.0, dtype=float),
             inertia=jnp.zeros(shape=(3, 3)),
-            parent=links_dict[f.attached_to],
+            parent_name=f.attached_to,
             pose=f.pose.transform() if f.pose is not None else jnp.eye(4),
         )
         for f in sdf_model.frames()


### PR DESCRIPTION
Currently, `LinkDescription` has the attributes parent and children that are LinkDescription. This creates a reference where a `LinkDescription` references its parent, which references back to the `LinkDescription`.

This can create infinite recursion in case we call a function recursively on the attributes of `LinkDescription recursively`, for example in `__repr__`, `__has__` or `dataclasses.asdict`.

The last one is needed to implement a [Gymnax](https://github.com/RobertTLange/gymnax) environment, which I believe is a common use case.

In this PR, I changed the parent attribute to be the parent's name, instead of the object itself. This doesn't create a problem since most of the time we only need the name (and there is a dictionary mapping names to LinkDescription).


To reproduce the issue:
```python
from dataclasses import asdict
import jaxsim.api as js
import jaxsim

model = js.model.JaxSimModel.build_from_model_description(
    model_description=...,
    is_urdf=True,
    contact_model=jaxsim.rbda.contacts.RelaxedRigidContacts.build(),
)
asdict(model)
```