### PR TITLE
Create configuration for GPU benchmarks on local runner

### DIFF
--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -1,0 +1,53 @@
+name: GPU Benchmarks
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0  * * 1" # Run At 00:00 on Monday
+
+permissions:
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: [self-hosted, gpu]
+    container:
+      image: ghcr.io/nvidia/jax:jax
+      options: --gpus all
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up environment
+        run: |
+          pip install .[all]
+
+      - name: Run JaxSim benchmarks
+        id: benchmark
+        run: |
+          echo "### Benchmark Results" > results.txt
+          pytest --benchmark-only --gpu-only >> results.txt
+          # Output the results to GitHub Actions for use in the comment
+          echo "results=$(cat results.txt)" >> $GITHUB_ENV
+
+      - name: Debugging comment for benchmarks start
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Running GPU benchmarks for this PR :rocket:
+          comment-tag: to_delete_on_completion
+          mode: delete-on-completion
+
+      - name: Post results in PR comment
+        if: github.event_name == 'pull_request'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          pr-number: ${{ github.event.number }}
+          message: |
+            _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
+            ${{ env.results }}
+          comment-tag: execution
+          mode: upsert

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -25,6 +25,14 @@ jobs:
         run: |
           pip install .[all]
 
+      - name: Install Gazebo SDF
+        run: |
+            apt update && apt install -y lsb-release wget
+            sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+            wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -
+            apt-get update
+            apt install -y libsdformat14-dev libsdformat14
+
       - name: Performance regression check
         uses: actions/checkout@v4
 

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -57,6 +57,7 @@ jobs:
           alert-threshold: 150%
           auto-push: false
           gh-pages-branch: gh-pages
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push benchmark result
         if: github.event_name != 'pull_request'

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -37,7 +37,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run benchmark and store result
-        run: pytest tests/test_benchmark.py --benchmark-only --benchmark-json output.json
+        run: |
+            pytest tests/test_benchmark.py -k 'not test_rigid_contact_model and not test_soft_contact_model' --benchmark-only --benchmark-json output.json
 
       - name: Download previous benchmark data
         uses: actions/cache@v4

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -12,10 +12,10 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: [self-hosted, gpu]
+    runs-on: self-hosted
     container:
       image: ghcr.io/nvidia/jax:jax
-      options: --gpus all
+      options: --rm --gpus all
 
     steps:
       - name: Checkout repository
@@ -25,29 +25,30 @@ jobs:
         run: |
           pip install .[all]
 
-      - name: Run JaxSim benchmarks
-        id: benchmark
-        run: |
-          echo "### Benchmark Results" > results.txt
-          pytest --benchmark-only --gpu-only >> results.txt
-          # Output the results to GitHub Actions for use in the comment
-          echo "results=$(cat results.txt)" >> $GITHUB_ENV
+      - name: Performance regression check
+        uses: actions/checkout@v4
 
-      - name: Debugging comment for benchmarks start
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          message: |
-            Running GPU benchmarks for this PR :rocket:
-          comment-tag: to_delete_on_completion
-          mode: delete-on-completion
+      - name: Run benchmark and store result
+        run: pytest bench.py --benchmark-json output.json
 
-      - name: Post results in PR comment
-        if: github.event_name == 'pull_request'
-        uses: thollander/actions-comment-pull-request@v3
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
         with:
-          pr-number: ${{ github.event.number }}
-          message: |
-            _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
-            ${{ env.results }}
-          comment-tag: execution
-          mode: upsert
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          output-file-path: output.json
+          external-data-json-path: ./cache/benchmark-data.json
+          fail-on-alert: true
+          summary-always: true
+          alert-threshold: 150%
+          auto-push: false
+          gh-pages-branch: gh-pages
+
+      - name: Push benchmark result
+        if: github.event_name != 'pull_request'
+        run: git push 'https://ami-iit:${{ secrets.GITHUB_TOKEN }}@github.com/ami-iit/jaxsim.git' gh-pages:gh-pages

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run benchmark and store result
-        run: pytest bench.py --benchmark-json output.json
+        run: pytest tests/test_benchmark.py --benchmark-only --benchmark-json output.json
 
       - name: Download previous benchmark data
         uses: actions/cache@v4

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run benchmark and store result
         run: |
-            pytest tests/test_benchmark.py -k 'not test_rigid_contact_model and not test_soft_contact_model' --benchmark-only --benchmark-json output.json
+            pytest tests/test_benchmark.py -k 'not test_rigid_contact_model and not test_soft_contact_model' --gpu-only --batch-size 128 --benchmark-only --benchmark-json output.json
 
       - name: Download previous benchmark data
         uses: actions/cache@v4

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: self-hosted
     container:
       image: ghcr.io/nvidia/jax:jax
-      options: --rm --gpus all
+      options: --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   pull-requests: write
+  deployments: write
+  contents: write
 
 jobs:
   benchmark:
@@ -54,6 +56,7 @@ jobs:
           external-data-json-path: ./cache/benchmark-data.json
           fail-on-alert: true
           summary-always: true
+          comment-always: true
           alert-threshold: 150%
           auto-push: false
           gh-pages-branch: gh-pages

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1120,6 +1120,34 @@ def forward_dynamics_crb(
 
 @jax.jit
 @js.common.named_scope
+def forward_kinematics(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Matrix:
+    """
+    Compute the forward kinematics of the model.
+
+    Args:
+        model: The model to consider.
+        data: The data of the considered model.
+
+    Returns:
+        The nL x 4 x 4 array containing the stacked homogeneous transformations
+        of the links. The first axis is the link index.
+    """
+
+    W_H_LL, _ = jaxsim.rbda.forward_kinematics_model(
+        model=model,
+        base_position=data.base_position,
+        base_quaternion=data.base_quaternion,
+        joint_positions=data.joint_positions,
+        joint_velocities=data.joint_velocities,
+        base_linear_velocity_inertial=data._base_linear_velocity,
+        base_angular_velocity_inertial=data._base_angular_velocity,
+    )
+
+    return W_H_LL
+
+
+@jax.jit
+@js.common.named_scope
 def free_floating_mass_matrix(
     model: JaxSimModel, data: js.data.JaxSimModelData
 ) -> jtp.Matrix:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -104,6 +104,9 @@ def test_soft_contact_model(
 ):
     model = jaxsim_model_ergocub_reduced
 
+    with model.editable(validate=False) as model:
+        model.contact_model = jaxsim.rbda.contacts.SoftContacts()
+
     benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -132,3 +132,15 @@ def test_relaxed_rigid_contact_model(
         model.contact_model = jaxsim.rbda.contacts.RelaxedRigidContacts()
 
     benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)
+
+
+@pytest.mark.benchmark
+def test_simulation_step(
+    jaxsim_model_ergocub_reduced: js.model.JaxSimModel, benchmark, batch_size
+):
+    model = jaxsim_model_ergocub_reduced
+
+    with model.editable(validate=False) as model:
+        model.contact_model = jaxsim.rbda.contacts.RelaxedRigidContacts()
+
+    benchmark_test_function(js.model.step, model, benchmark, batch_size)


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for running GPU benchmarks on pull requests and scheduled intervals. The workflow is designed to automatically run benchmarks using JaxSim and post the results as comments on the pull request.

Key changes include:

* **New GitHub Actions Workflow**:
  * Added a new workflow named `GPU Benchmarks` to `.github/workflows/gpu_benchmark.yml` that triggers on pull requests and on a scheduled cron job.
  * Configured the workflow to run on self-hosted runners with GPU support and a specific Docker container image (`ghcr.io/nvidia/jax:jax`).
  * Included steps to checkout the repository, set up the environment, run GPU-specific benchmarks using `pytest`, and capture the results.
  * Added steps to post a debugging comment at the start of the benchmark run and to post the benchmark results as a comment on the pull request.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--380.org.readthedocs.build//380/

<!-- readthedocs-preview jaxsim end -->