### PR TITLE
Exclude overlapping collidable points during collision parsing

### DIFF
--- a/docs/guide/configuration.rst
+++ b/docs/guide/configuration.rst
@@ -17,6 +17,10 @@ Environment variables starting with ``JAXSIM_COLLISION_`` are used to configure 
 
   *Default:* ``False``.
 
+- ``JAXSIM_COLLISION_INCLUDE_OVERLAPS``: Enables or disables the inclusion of overlapping collision points.
+
+  *Default:* ``False``.
+
 - ``JAXSIM_COLLISION_USE_BOTTOM_ONLY``: Limits collision detection to only the bottom half of the box or sphere.
 
   *Default:* ``False``.

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -805,11 +805,14 @@ class ContactParameters(JaxsimDataclass):
             "false",
             "0",
         }:
-            points, idxs = jnp.unique(all_points, axis=0, return_index=True)
-            selected_points = map(collidable_points.__getitem__, idxs)
+            _, idxs = jnp.unique(all_points, axis=0, return_index=True)
+            idxs = jnp.sort(idxs)
         else:
-            points = all_points
-            selected_points = iter(collidable_points)
+            idxs = jnp.arange(len(collidable_points))
+
+        # Select unique points and corresponding link indices.
+        points = all_points[idxs]
+        selected_points = map(collidable_points.__getitem__, idxs)
 
         # Extract the indices of the links to which the collidable points are rigidly attached.
         link_index_of_points = tuple(

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -797,13 +797,18 @@ class ContactParameters(JaxsimDataclass):
         collidable_points = model_description.all_enabled_collidable_points()
 
         # Extract the positions L_p_C of the collidable points w.r.t. the link frames
-        # they are rigidly attached to.
-        points = jnp.vstack([cp.position for cp in collidable_points])
+        # they are rigidly attached to. We exclude overlapping points.
+        points, idxs = jnp.unique(
+            jnp.vstack([cp.position for cp in collidable_points]),
+            axis=0,
+            return_index=True,
+        )
 
         # Extract the indices of the links to which the collidable points are rigidly
         # attached to.
         link_index_of_points = tuple(
-            links_dict[cp.parent_link.name].index for cp in collidable_points
+            links_dict[cp.parent_link.name].index
+            for cp in map(collidable_points.__getitem__, idxs)
         )
 
         # Build the ContactParameters object.


### PR DESCRIPTION
This PR implements a logic to filter out overlapping collidable points when extracting their positions, ensuring unique points are processed for contact parameters. This is particularly useful when dealing with closed-loop kinematic chains or ErgoCub models

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--382.org.readthedocs.build//382/

<!-- readthedocs-preview jaxsim end -->