### PR TITLE
Remove `enum_tools` dependency and update documentation references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     "sphinx_multiversion",
-    "enum_tools.autoenum",
     "myst_nb",
     "sphinx_gallery.gen_gallery",
     "sphinxcontrib.collections",

--- a/docs/modules/api.rst
+++ b/docs/modules/api.rst
@@ -103,7 +103,7 @@ References
 Common
 ~~~~~~
 
-.. autoflag:: jaxsim.api.common.VelRepr
+.. autoclass:: jaxsim.api.common.VelRepr
     :members:
 
 .. autoclass:: jaxsim.api.common.ModelDataWithVelocityRepresentation

--- a/environment.yml
+++ b/environment.yml
@@ -40,9 +40,7 @@ dependencies:
   # Documentation dependencies
   # ==========================
   - cachecontrol
-  - enum_tools
   - filecache
-  - filelock
   - jinja2
   - myst-nb
   - pip


### PR DESCRIPTION
This PR eliminates the `enum_tools` dependency from the environment configuration, as a tentative to fix the RTD build, and updates the documentation to reflect the correct usage of `autoclass` for `VelRepr`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--385.org.readthedocs.build//385/

<!-- readthedocs-preview jaxsim end -->