### PR TITLE
Add `gravity` parameter in `build_from_model_description`

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -149,7 +149,7 @@ class JaxSimModel(JaxsimDataclass):
                 This is usually automatically inferred.
             considered_joints:
                 The list of joints to consider. If None, all joints are considered.
-            gravity: The gravity constant.
+            gravity: The gravity constant. Normally passed as a positive value.
 
         Returns:
             The built Model object.
@@ -179,7 +179,7 @@ class JaxSimModel(JaxsimDataclass):
             contact_model=contact_model,
             contacts_params=contact_params,
             integrator=integrator,
-            gravity=gravity,
+            gravity=-gravity,
         )
 
         # Store the origin of the model, in case downstream logic needs it.

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -179,7 +179,7 @@ class JaxSimModel(JaxsimDataclass):
             contact_model=contact_model,
             contacts_params=contact_params,
             integrator=integrator,
-            gravity=-gravity,
+            gravity=gravity,
         )
 
         # Store the origin of the model, in case downstream logic needs it.

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -124,6 +124,7 @@ class JaxSimModel(JaxsimDataclass):
         integrator: IntegratorType | None = None,
         is_urdf: bool | None = None,
         considered_joints: Sequence[str] | None = None,
+        gravity: jtp.FloatLike = jaxsim.math.STANDARD_GRAVITY,
     ) -> JaxSimModel:
         """
         Build a Model object from a model description.
@@ -148,6 +149,7 @@ class JaxSimModel(JaxsimDataclass):
                 This is usually automatically inferred.
             considered_joints:
                 The list of joints to consider. If None, all joints are considered.
+            gravity: The gravity constant.
 
         Returns:
             The built Model object.
@@ -177,6 +179,7 @@ class JaxSimModel(JaxsimDataclass):
             contact_model=contact_model,
             contacts_params=contact_params,
             integrator=integrator,
+            gravity=gravity,
         )
 
         # Store the origin of the model, in case downstream logic needs it.


### PR DESCRIPTION
Probably in one of the refactoring we lost the possibility to pass the gravity constant in the `JaxSimModel.build_from_model_description` function

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--389.org.readthedocs.build//389/

<!-- readthedocs-preview jaxsim end -->