### PR TITLE
Allow passing camera tracking modality to the visualizer

### DIFF
--- a/src/jaxsim/mujoco/utils.py
+++ b/src/jaxsim/mujoco/utils.py
@@ -145,6 +145,7 @@ class MujocoCamera:
     @staticmethod
     def build_from_target_view(
         camera_name: str,
+        mode: str = "fixed",
         lookat: Sequence[float | int] | npt.NDArray = (0, 0, 0),
         distance: float | int | npt.NDArray = 3,
         azimuth: float | int | npt.NDArray = 90,
@@ -166,6 +167,12 @@ class MujocoCamera:
 
         Args:
             camera_name: The name of the camera.
+            mode: Camera positioning mode:
+                - **"fixed"**: Fixed position and orientation relative to the body.
+                - **"track"**: Fixed offset from the body in world coordinates, constant orientation.
+                - **"trackcom"**: Like `"track"`, but relative to the center of mass of the subtree.
+                - **"targetbody"**: Fixed position in body frame, oriented toward a target body.
+                - **"targetbodycom"**: Like `"targetbody"`, but targets the subtree's center of mass.
             lookat: The target point to look at (origin of `T`).
             distance:
                 The distance from the target point (displacement between the origins
@@ -214,7 +221,7 @@ class MujocoCamera:
 
         return MujocoCamera.build(
             name=camera_name,
-            mode="fixed",
+            mode=mode,
             fovy=f"{fovy if degrees else np.rad2deg(fovy)}",
             pos=" ".join(p.astype(str).tolist()),
             quat=" ".join(Q.astype(str).tolist()),


### PR DESCRIPTION
This pull request includes changes to the `src/jaxsim/mujoco/utils.py` file to enhance the functionality of the `build_from_target_view` method by adding a new parameter for camera positioning mode.

Enhancements to camera positioning:

* [`src/jaxsim/mujoco/utils.py`](diffhunk://#diff-6ffc9107c91a9277abe3597243c25a1e1a35e8a4c810cbe632ea2f6924a900d8R148): Added a new parameter `mode` to the `build_from_target_view` method, allowing different camera positioning modes such as "fixed", "track", "trackcom", "targetbody", and "targetbodycom". This change provides more flexibility in camera positioning. [[1]](diffhunk://#diff-6ffc9107c91a9277abe3597243c25a1e1a35e8a4c810cbe632ea2f6924a900d8R148) [[2]](diffhunk://#diff-6ffc9107c91a9277abe3597243c25a1e1a35e8a4c810cbe632ea2f6924a900d8R170-R175)
* [`src/jaxsim/mujoco/utils.py`](diffhunk://#diff-6ffc9107c91a9277abe3597243c25a1e1a35e8a4c810cbe632ea2f6924a900d8L217-R224): Updated the call to `MujocoCamera.build` to use the new `mode` parameter instead of a fixed value.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--390.org.readthedocs.build//390/

<!-- readthedocs-preview jaxsim end -->