### PR TITLE
Allow keyword arguments in `RigidContactsParams` constructor and fix benchmark tests

### DIFF
--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -65,6 +65,7 @@ class RigidContactsParams(ContactsParams):
         mu: jtp.FloatLike | None = None,
         K: jtp.FloatLike | None = None,
         D: jtp.FloatLike | None = None,
+        **kwargs,
     ) -> Self:
         """Create a `RigidContactParams` instance."""
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -106,6 +106,7 @@ def test_soft_contact_model(
 
     with model.editable(validate=False) as model:
         model.contact_model = jaxsim.rbda.contacts.SoftContacts()
+        model.contact_params = js.contact.estimate_good_contact_parameters(model=model)
 
     benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)
 
@@ -118,6 +119,7 @@ def test_rigid_contact_model(
 
     with model.editable(validate=False) as model:
         model.contact_model = jaxsim.rbda.contacts.RigidContacts()
+        model.contact_params = js.contact.estimate_good_contact_parameters(model=model)
 
     benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)
 
@@ -130,6 +132,7 @@ def test_relaxed_rigid_contact_model(
 
     with model.editable(validate=False) as model:
         model.contact_model = jaxsim.rbda.contacts.RelaxedRigidContacts()
+        model.contact_params = js.contact.estimate_good_contact_parameters(model=model)
 
     benchmark_test_function(js.ode.system_dynamics, model, benchmark, batch_size)
 
@@ -142,5 +145,6 @@ def test_simulation_step(
 
     with model.editable(validate=False) as model:
         model.contact_model = jaxsim.rbda.contacts.RelaxedRigidContacts()
+        model.contact_params = js.contact.estimate_good_contact_parameters(model=model)
 
     benchmark_test_function(js.model.step, model, benchmark, batch_size)


### PR DESCRIPTION
This pull request includes changes to the `src/jaxsim/rbda/contacts/rigid.py` and `tests/test_benchmark.py` files to enhance the flexibility of the `build` method and improve the test coverage by setting contact parameters in various test functions.

This fixes the failure on benchmark tests.

Enhancements to `build` method:

* [`src/jaxsim/rbda/contacts/rigid.py`](diffhunk://#diff-decb2fddb78cd2b19f40be80846f2f520b36eaf379a3313403e4b534621b8967R68): Added `**kwargs` to the `build` method to allow for additional keyword arguments.

Improvements to test coverage:

* [`tests/test_benchmark.py`](diffhunk://#diff-b49f4f447981fdb7600baea8cdf3d8936f69c22f1366b89455b4e313fd847686R109): Updated `test_soft_contact_model` to estimate and set good contact parameters.
* [`tests/test_benchmark.py`](diffhunk://#diff-b49f4f447981fdb7600baea8cdf3d8936f69c22f1366b89455b4e313fd847686R122): Updated `test_rigid_contact_model` to estimate and set good contact parameters.
* [`tests/test_benchmark.py`](diffhunk://#diff-b49f4f447981fdb7600baea8cdf3d8936f69c22f1366b89455b4e313fd847686R135): Updated `test_relaxed_rigid_contact_model` to estimate and set good contact parameters.
* [`tests/test_benchmark.py`](diffhunk://#diff-b49f4f447981fdb7600baea8cdf3d8936f69c22f1366b89455b4e313fd847686R148): Updated `test_simulation_step` to estimate and set good contact parameters.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--391.org.readthedocs.build//391/

<!-- readthedocs-preview jaxsim end -->