### PR TITLE
Update `RelaxedRigidContacts` default parameters

### DIFF
--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -27,7 +27,7 @@ class RelaxedRigidContactsParams(common.ContactsParams):
 
     # Time constant
     time_constant: jtp.Float = dataclasses.field(
-        default_factory=lambda: jnp.array(0.01, dtype=float)
+        default_factory=lambda: jnp.array(0.02, dtype=float)
     )
 
     # Adimensional damping coefficient
@@ -47,17 +47,17 @@ class RelaxedRigidContactsParams(common.ContactsParams):
 
     # Width
     width: jtp.Float = dataclasses.field(
-        default_factory=lambda: jnp.array(0.0001, dtype=float)
+        default_factory=lambda: jnp.array(0.001, dtype=float)
     )
 
     # Midpoint
     midpoint: jtp.Float = dataclasses.field(
-        default_factory=lambda: jnp.array(0.1, dtype=float)
+        default_factory=lambda: jnp.array(0.5, dtype=float)
     )
 
     # Power exponent
     power: jtp.Float = dataclasses.field(
-        default_factory=lambda: jnp.array(1.0, dtype=float)
+        default_factory=lambda: jnp.array(2.0, dtype=float)
     )
 
     # Stiffness
@@ -72,7 +72,7 @@ class RelaxedRigidContactsParams(common.ContactsParams):
 
     # Friction coefficient
     mu: jtp.Float = dataclasses.field(
-        default_factory=lambda: jnp.array(0.5, dtype=float)
+        default_factory=lambda: jnp.array(0.005, dtype=float)
     )
 
     def __hash__(self) -> int:


### PR DESCRIPTION
This pull request includes several modifications to the `RelaxedRigidContactsParams` class in the `src/jaxsim/rbda/contacts/relaxed_rigid.py` file from https://github.com/google-deepmind/mujoco/blob/12b40b948e39a20bdc0c67ec23eceb618748ed66/src/engine/engine_io.c#L97-L110. The changes primarily involve updating the default values for various parameters. 

Parameter updates:

* [`time_constant`](diffhunk://#diff-4465afc5357a08994f4ce0fce330c32ab819938dbfe2fbb9d4e1974e44d46409L30-R30): Changed the default value from `0.01` to `0.02`.
* [`width`](diffhunk://#diff-4465afc5357a08994f4ce0fce330c32ab819938dbfe2fbb9d4e1974e44d46409L50-R60): Changed the default value from `0.0001` to `0.001`.
* [`midpoint`](diffhunk://#diff-4465afc5357a08994f4ce0fce330c32ab819938dbfe2fbb9d4e1974e44d46409L50-R60): Changed the default value from `0.1` to `0.5`.
* [`power`](diffhunk://#diff-4465afc5357a08994f4ce0fce330c32ab819938dbfe2fbb9d4e1974e44d46409L50-R60): Changed the default value from `1.0` to `2.0`.
* [`mu`](diffhunk://#diff-4465afc5357a08994f4ce0fce330c32ab819938dbfe2fbb9d4e1974e44d46409L75-R75): Changed the default value from `0.5` to `0.005`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--392.org.readthedocs.build//392/

<!-- readthedocs-preview jaxsim end -->