### PR TITLE
Enable reverse-mode autodiff for contact solves via gradients override

### DIFF
--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -3,8 +3,6 @@ import os
 import jax
 import jax.numpy as jnp
 import numpy as np
-import optax
-import pytest
 from jax.test_util import check_grads
 
 import jaxsim.api as js
@@ -350,11 +348,6 @@ def test_ad_integration(
 
     model = jaxsim_models_types
 
-    # TODO: Remove when https://github.com/google-deepmind/optax/pull/1190 is included in a release.
-    # Skip if `optax` version is less or equal to "0.2.4" and the model is ergoCub.
-    if model.name() == "ergoCub" and optax.__version__ <= "0.2.4":
-        pytest.skip("Skipping ergoCub model with optax version <= 0.2.4.")
-
     _, subkey = jax.random.split(prng_key, num=2)
     data, references = get_random_data_and_references(
         model=model, velocity_representation=VelRepr.Inertial, key=subkey
@@ -416,13 +409,11 @@ def test_ad_integration(
         return xf_W_p_B, xf_W_Q_B, xf_s, xf_W_v_WB, xf_ṡ
 
     # Check derivatives against finite differences.
-    # We set forward mode only because the backward mode is not supported by the
-    # current implementation of `optax` optimizers in the relaxed rigid contact model.
     check_grads(
         f=step,
         args=(W_p_B, W_Q_B, s, W_v_WB, ṡ, τ, W_f_L),
         order=AD_ORDER,
-        modes=["fwd"],
+        modes=["fwd", "rev"],
         eps=ε,
     )
 


### PR DESCRIPTION
This pull request includes changes to improve the optimization process in the `relaxed_rigid` module and updates to the `test_automatic_differentiation` tests. The most important changes include replacing the optimization function with a custom linear solver, removing unnecessary imports, and updating the gradient check modes. Additionally, this update enables reverse-mode automatic differentiation by injecting implicit gradients at the contact solve, which also allows the use of non-differentiable GPU-based solvers while maintaining differentiability for parameters optimization.

Improvements to optimization process:

* [`src/jaxsim/rbda/contacts/relaxed_rigid.py`](diffhunk://#diff-4465afc5357a08994f4ce0fce330c32ab819938dbfe2fbb9d4e1974e44d46409L480-R496): Wrapped the `run_optimization` function with `jax.lax.custom_linear_solve` to override gradient computation with implicit differences.

Updates to tests:

* [`tests/test_automatic_differentiation.py`](diffhunk://#diff-d9535bc164ad7c0a31f18f88ad7ccc7c0e615f38b4430b34226a643396024fd4L353-L357): Removed the conditional skip for the `ergoCub` model when `optax` version is less than or equal to 0.2.4.
* [`tests/test_automatic_differentiation.py`](diffhunk://#diff-d9535bc164ad7c0a31f18f88ad7ccc7c0e615f38b4430b34226a643396024fd4L419-R416): Updated the `check_grads` function to include both forward and reverse modes for gradient checking.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--394.org.readthedocs.build//394/

<!-- readthedocs-preview jaxsim end -->