### PR TITLE
Reduce logging verbosity when installing in editable mode

### DIFF
--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -167,7 +167,7 @@ class ModelDescription(KinematicGraph):
         logging.warning(
             "The joint order in the model description is not preserved when reducing "
             "the model. Consider using the `names_to_indices` method to get the correct "
-            "order of the joints."
+            "order of the joints, or use the `joint_names()` method to inspect the internal joint ordering."
         )
 
         if len(set(considered_joints) - set(self.joint_names())) != 0:

--- a/src/jaxsim/parsers/descriptions/model.py
+++ b/src/jaxsim/parsers/descriptions/model.py
@@ -164,6 +164,12 @@ class ModelDescription(KinematicGraph):
             A `ModelDescription` instance that only includes the considered joints.
         """
 
+        logging.warning(
+            "The joint order in the model description is not preserved when reducing "
+            "the model. Consider using the `names_to_indices` method to get the correct "
+            "order of the joints."
+        )
+
         if len(set(considered_joints) - set(self.joint_names())) != 0:
             extra_joints = set(considered_joints) - set(self.joint_names())
             msg = f"Found joints not part of the model: {extra_joints}"

--- a/src/jaxsim/parsers/kinematic_graph.py
+++ b/src/jaxsim/parsers/kinematic_graph.py
@@ -453,7 +453,7 @@ class KinematicGraph(Sequence[LinkDescription]):
             parent_of_link_to_remove = links_dict[link.parent_name]
 
             msg = "Lumping chain: {}->({})->{}"
-            logging.info(
+            logging.debug(
                 msg.format(
                     link_to_remove.name,
                     self.joints_connection_dict[

--- a/src/jaxsim/parsers/rod/parser.py
+++ b/src/jaxsim/parsers/rod/parser.py
@@ -75,7 +75,7 @@ def extract_model_data(
             )
 
     # Log model name.
-    logging.debug(msg=f"Found model '{sdf_model.name}' in SDF resource")
+    logging.info(msg=f"Found model '{sdf_model.name}' in SDF resource")
 
     # Jaxsim supports only models compatible with URDF, i.e. those having all links
     # directly attached to their parent joint without additional roto-translations.
@@ -187,7 +187,7 @@ def extract_model_data(
         base_link_name = joints_with_world_parent[0].child.name
 
         msg = "Combining the pose of base link '{}' with the pose of joint '{}'"
-        logging.info(msg.format(base_link_name, joints_with_world_parent[0].name))
+        logging.debug(msg.format(base_link_name, joints_with_world_parent[0].name))
 
         # Combine the pose of the base link (child of the found fixed joint)
         # with the pose of the fixed joint connecting with the world.

--- a/src/jaxsim/rbda/contacts/rigid.py
+++ b/src/jaxsim/rbda/contacts/rigid.py
@@ -140,7 +140,7 @@ class RigidContacts(ContactModel):
         """
 
         if len(kwargs) != 0:
-            logging.debug(msg=f"Ignoring extra arguments: {kwargs}")
+            logging.warning(msg=f"Ignoring extra arguments: {kwargs}")
 
         # Get the default solver options.
         default_solver_options = dict(

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -147,7 +147,7 @@ class SoftContacts(common.ContactModel):
         """
 
         if len(kwargs) != 0:
-            logging.debug(msg=f"Ignoring extra arguments: {kwargs}")
+            logging.warning(msg=f"Ignoring extra arguments: {kwargs}")
 
         return cls(**kwargs)
 


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve logging and functionality in the `jaxsim` package. The most important changes include modifications to the logging levels, adjustments to method signatures, and updates to logging messages for better clarity and debugging.

### Logging Level Adjustments:
* [`src/jaxsim/__init__.py`](diffhunk://#diff-0337b2c3fb745046b61f763e207c23796ad221f8ca2f76d63ff12e50e303f111L70-R105): Refactored `_get_default_logging_level` to remove the `env_var` argument, added logic to set logging levels based on environment variables and debugger presence, and updated the logging configuration accordingly.

### Logging Message Updates:
* [`src/jaxsim/parsers/descriptions/model.py`](diffhunk://#diff-33686fcbe9125711717b0452ef8c43314da2e4944e46a3114887f6849746d45bR167-R172): Added a warning message in the `reduce` method to inform users about the potential issue with joint order preservation.
* [`src/jaxsim/parsers/kinematic_graph.py`](diffhunk://#diff-8a31d70a69e2fffeaff20f532e76c00e3728e8dff6a8d6d9c29d014979db4a4eL456-R456): Changed a logging message level from `info` to `debug` in the `reduce` method for better debugging.
* [`src/jaxsim/parsers/rod/parser.py`](diffhunk://#diff-c6cbde984d16aa53109b98d1a9c67c73e36bec7e4f402c499d4c8fd0a3cd00d3L78-R78): Adjusted logging levels in `extract_model_data` method to use `info` and `debug` levels appropriately. [[1]](diffhunk://#diff-c6cbde984d16aa53109b98d1a9c67c73e36bec7e4f402c499d4c8fd0a3cd00d3L78-R78) [[2]](diffhunk://#diff-c6cbde984d16aa53109b98d1a9c67c73e36bec7e4f402c499d4c8fd0a3cd00d3L190-R190)
* `src/jaxsim/rbda/contacts/rigid.py` and `src/jaxsim/rbda/contacts/soft.py`: Updated logging levels from `debug` to `warning` when ignoring extra arguments in the `build` method. [[1]](diffhunk://#diff-decb2fddb78cd2b19f40be80846f2f520b36eaf379a3313403e4b534621b8967L143-R143) [[2]](diffhunk://#diff-3915f66755e281a8c69c1649856605e5be9c7144c78b0b21d8f145059606d9d3L150-R150)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--398.org.readthedocs.build//398/

<!-- readthedocs-preview jaxsim end -->