### PR TITLE
Filter out bot-authored commits from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
This pull request includes a small change to the `.github/release.yml` file. The change updates the configuration to exclude specific authors from the changelog.

* [`.github/release.yml`](diffhunk://#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R1-R5): Added configuration to exclude `dependabot` and `pre-commit-ci` authors from the changelog.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--401.org.readthedocs.build//401/

<!-- readthedocs-preview jaxsim end -->