### PR TITLE
Speed up Gazebo SDF installation in CI workflows

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -105,12 +105,11 @@ jobs:
           contains(matrix.os, 'ubuntu') &&
           (github.event_name != 'pull_request')
         run: |
+          sudo apt update && sudo apt install -y lsb-release wget
+          sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+          wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install lsb-release gnupg
-          sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install gz-ionic sdf
+          sudo apt install -y libsdformat14-dev libsdformat14
 
       - name: Run the Python tests
         if: |


### PR DESCRIPTION
This pull request includes changes to the CI/CD workflow configuration file to update the installation process for Gazebo and its dependencies. <!-- With these modifications we pass from about **2m 7s** to about **38s** (average between Python 3.10, 3.11 and 3.12) -->

Changes to CI/CD workflow:

* [`.github/workflows/ci_cd.yml`](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aR126-R130): Updated the commands to add the Gazebo repository and its key, and modified the package installation process to include `libsdformat14-dev` instead of `gz-ionic` and `sdf`.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--403.org.readthedocs.build//403/

<!-- readthedocs-preview jaxsim end -->