### PR TITLE
Remove path filtering on CI triggers

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -100,28 +100,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            conf: &conf
-              - 'pyproject.toml'
-              - 'setup.cfg'
-              - 'setup.py'
-            src: &src
-              - 'src/**'
-            tests: &tests
-              - 'tests/**'
-            all:
-              - *conf
-              - *src
-              - *tests
-
       - name: Install 'gz sdf' system command
         if: |
           contains(matrix.os, 'ubuntu') &&
-          (github.event_name != 'pull_request' ||
-           steps.changes.outputs.all == 'true')
+          (github.event_name != 'pull_request')
         run: |
           sudo apt-get update
           sudo apt-get install lsb-release gnupg
@@ -133,8 +115,7 @@ jobs:
       - name: Run the Python tests
         if: |
           contains(matrix.os, 'ubuntu') &&
-          (github.event_name != 'pull_request' ||
-           steps.changes.outputs.all == 'true')
+          (github.event_name != 'pull_request')
         run: pytest
         env:
           # https://github.com/pytest-dev/pytest/issues/7443#issuecomment-656642591


### PR DESCRIPTION
This pull request involves the removal of a paths filter and the simplification of conditional statements for running certain jobs.

CI/CD workflow configuration updates:

* Removed the `dorny/paths-filter@v3` action and its associated filters for configuration, source, and test files.
* Simplified the conditional statements for installing the 'gz sdf' system command and running Python tests by removing the dependency on the paths filter outputs. [[1]](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aL103-R106) [[2]](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aL136-R118)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--404.org.readthedocs.build//404/

<!-- readthedocs-preview jaxsim end -->