### PR TITLE
Add fast Runge-Kutta4 integrator

### DIFF
--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -431,13 +431,6 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         if contact_state is None:
             contact_state = self.contact_state
 
-        if isinstance(model.contact_model, jaxsim.rbda.contacts.SoftContacts):
-            contact_state = {
-                "tangential_deformation": jnp.zeros_like(
-                    contact_state["tangential_deformation"]
-                )
-            }
-
         # Normalize the quaternion to avoid numerical issues.
         base_quaternion_norm = jaxsim.math.safe_norm(
             base_quaternion, axis=-1, keepdims=True
@@ -525,6 +518,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             _joint_transforms=joint_transforms,
             _link_transforms=link_transforms,
             _link_velocities=link_velocities,
+            contact_state=contact_state,
             validate=validate,
         )
 

--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -194,7 +194,7 @@ def rk4fast_integration(
             W_v̇_WB, s̈ = js.model.forward_dynamics_aba(
                 model=model,
                 data=data_ti,
-                joint_torques=joint_torques,
+                joint_forces=joint_torques,
                 link_forces=link_forces,
             )
 

--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -156,9 +156,113 @@ def rk4_integration(
     return data_tf.replace(model=model)
 
 
+def rk4fast_integration(
+    model: js.model.JaxSimModel,
+    data: JaxSimModelData,
+    link_forces: jtp.Vector,
+    joint_torques: jtp.Vector,
+) -> JaxSimModelData:
+    """
+    Integrate the system state using the Runge-Kutta 4 fast method.
+
+    Note:
+        This method is a faster version of the RK4 method, but it may not be as accurate.
+        It computes the contact forces only once at the beginning of the integration step.
+    """
+
+    dt = model.time_step
+
+    def f0(x) -> dict[str, jtp.Matrix]:
+
+        with data.switch_velocity_representation(jaxsim.VelRepr.Inertial):
+
+            data_ti = data.replace(model=model, **x)
+
+            return js.ode.system_dynamics(
+                model=model,
+                data=data_ti,
+                link_forces=link_forces,
+                joint_torques=joint_torques,
+            )
+
+    def f(x) -> dict[str, jtp.Matrix]:
+
+        with data.switch_velocity_representation(jaxsim.VelRepr.Inertial):
+
+            data_ti = data.replace(model=model, **x)
+
+            W_v̇_WB, s̈ = js.model.forward_dynamics_aba(
+                model=model,
+                data=data_ti,
+                joint_torques=joint_torques,
+                link_forces=link_forces,
+            )
+
+            W_ṗ_B, W_Q̇_B, ṡ = js.ode.system_position_dynamics(
+                data=data,
+                baumgarte_quaternion_regularization=1.0,
+            )
+
+        return dict(
+            base_position=W_ṗ_B,
+            base_quaternion=W_Q̇_B,
+            joint_positions=ṡ,
+            base_linear_velocity=W_v̇_WB[0:3],
+            base_angular_velocity=W_v̇_WB[3:6],
+            joint_velocities=s̈,
+            # The contact state is not updated here, as it is assumed to be constant.
+            contact_state=data_ti.contact_state,
+        )
+
+    base_quaternion_norm = jaxsim.math.safe_norm(data._base_quaternion, axis=-1)
+    base_quaternion = data._base_quaternion / jnp.where(
+        base_quaternion_norm == 0, 1.0, base_quaternion_norm
+    )
+
+    x_t0 = dict(
+        base_position=data._base_position,
+        base_quaternion=base_quaternion,
+        joint_positions=data._joint_positions,
+        base_linear_velocity=data._base_linear_velocity,
+        base_angular_velocity=data._base_angular_velocity,
+        joint_velocities=data._joint_velocities,
+        contact_state=data.contact_state,
+    )
+
+    euler_mid = lambda x, dxdt: x + (0.5 * dt) * dxdt
+    euler_fin = lambda x, dxdt: x + dt * dxdt
+
+    k1 = f0(x_t0)
+    k2 = f(jax.tree.map(euler_mid, x_t0, k1))
+    k3 = f(jax.tree.map(euler_mid, x_t0, k2))
+    k4 = f(jax.tree.map(euler_fin, x_t0, k3))
+
+    # Average the slopes and compute the RK4 state derivative.
+    average = lambda k1, k2, k3, k4: (k1 + 2 * k2 + 2 * k3 + k4) / 6
+
+    dxdt = jax.tree_util.tree_map(average, k1, k2, k3, k4)
+
+    # Integrate the dynamics
+    x_tf = jax.tree_util.tree_map(euler_fin, x_t0, dxdt)
+
+    data_tf = dataclasses.replace(
+        data,
+        _base_position=x_tf["base_position"],
+        _base_quaternion=x_tf["base_quaternion"],
+        _joint_positions=x_tf["joint_positions"],
+        _base_linear_velocity=x_tf["base_linear_velocity"],
+        _base_angular_velocity=x_tf["base_angular_velocity"],
+        _joint_velocities=x_tf["joint_velocities"],
+        contact_state=x_tf["contact_state"],
+    )
+
+    return data_tf.replace(model=model)
+
+
 _INTEGRATORS_MAP: dict[
     js.model.IntegratorType, Callable[..., js.data.JaxSimModelData]
 ] = {
     js.model.IntegratorType.SemiImplicitEuler: semi_implicit_euler_integration,
     js.model.IntegratorType.RungeKutta4: rk4_integration,
+    js.model.IntegratorType.RungeKutta4Fast: rk4fast_integration,
 }

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -29,6 +29,7 @@ class IntegratorType(enum.IntEnum):
 
     SemiImplicitEuler = enum.auto()
     RungeKutta4 = enum.auto()
+    RungeKutta4Fast = enum.auto()
 
 
 @jax_dataclasses.pytree_dataclass(eq=False, unsafe_hash=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,7 @@ def velocity_representation(request) -> jaxsim.VelRepr:
     params=[
         pytest.param(IntegratorType.SemiImplicitEuler, id="semi_implicit_euler"),
         pytest.param(IntegratorType.RungeKutta4, id="runge_kutta_4"),
+        pytest.param(IntegratorType.RungeKutta4Fast, id="runge_kutta_4_fast"),
     ],
 )
 def integrator(request) -> str:


### PR DESCRIPTION
This pull request introduces a new integration method, `RungeKutta4Fast`, which computes the contact forces at the initial integration stage only. The `pytest` suite has been extended to include this new method in the tests.
Moreover, a bug for which the contact state was not updated during the replace has been fixed.

New integration method:

* [`src/jaxsim/api/integrators.py`](diffhunk://#diff-33b49b4d51e5e0194d3ce2e4b4f53ef1901858b8ab341d88fa6c9620200094e1R159-R267): Added the `rk4fast_integration` function, which implements the Runge-Kutta 4 fast method for system state integration. This method is a faster version of the RK4 method but may be less accurate.
* [`src/jaxsim/api/model.py`](diffhunk://#diff-b9e4540bc2ab5035687424d186fab029dfec2756803d6e464ccceb89dd630a72R32): Added `RungeKutta4Fast` to the `IntegratorType` enum.

Data structure updates:

* [`src/jaxsim/api/data.py`](diffhunk://#diff-d377d6d95ae5a2ffe62db73e1f1c4dbaf6658f1c57a340aa8d15d70e78d3dde2L434-L440): Updated the `replace` method to include the `contact_state` parameter, ensuring the contact state is properly handled in the new integration method. [[1]](diffhunk://#diff-d377d6d95ae5a2ffe62db73e1f1c4dbaf6658f1c57a340aa8d15d70e78d3dde2L434-L440) [[2]](diffhunk://#diff-d377d6d95ae5a2ffe62db73e1f1c4dbaf6658f1c57a340aa8d15d70e78d3dde2R521)

Testing:

* [`tests/conftest.py`](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R136): Added a test parameter for the `RungeKutta4Fast` integration method to ensure it is tested alongside other integration methods.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--407.org.readthedocs.build//407/

<!-- readthedocs-preview jaxsim end -->