### PR TITLE
Use specific Docker image SHA256 for benchmarks

### DIFF
--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -16,7 +16,7 @@ jobs:
   benchmark:
     runs-on: self-hosted
     container:
-      image: ghcr.io/nvidia/jax:jax
+      image: ghcr.io/nvidia/jax@sha256:fdc493f32727405514caaecd9f0ea508a56cf645424cc66e03fedd8141c493bb
       options: --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864
 
     steps:


### PR DESCRIPTION
This pull request updates the container image in the `gpu_benchmark.yml` workflow file to use a specific image digest for better reproducibility.

* [`.github/workflows/gpu_benchmark.yml`](diffhunk://#diff-c68852206255717ae4766792bbe78bc2dbfef4159a68adb0b25f6ccec20ea0ccL19-R19): Updated the container image to use the digest `sha256:fdc493f32727405514caaecd9f0ea508a56cf645424cc66e03fedd8141c493bb` instead of the tag `jax`.