### PR TITLE
Update CI configuration to use Pixi in testing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -99,24 +99,21 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          lfs: true
 
-      - name: Install 'gz sdf' system command
-        if: |
-          contains(matrix.os, 'ubuntu') &&
-          (github.event_name != 'pull_request')
-        run: |
-          sudo apt update && sudo apt install -y lsb-release wget
-          sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-          wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-          sudo apt-get update
-          sudo apt install -y libsdformat14-dev libsdformat14
+      - uses: prefix-dev/setup-pixi@v0.8.5
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          pixi-version: "latest"
+          frozen: true
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
       - name: Run the Python tests
         if: |
           contains(matrix.os, 'ubuntu') &&
           (github.event_name != 'pull_request')
-        run: pytest
+        run: pixi run --frozen test
         env:
           # https://github.com/pytest-dev/pytest/issues/7443#issuecomment-656642591
           PY_COLORS: "1"


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflow configuration to use Pixi in testing.

Key changes include:

### Installation Process Updates:
* Modified the wheel installation command for Ubuntu to remove the `[all]` option. (`[.github/workflows/ci_cd.ymlL85-R85](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aL85-R85)`)

### Tool Updates:
* Replaced the `actions/checkout@v4` configuration to enable LFS (Large File Storage) support. (`[.github/workflows/ci_cd.ymlL101-R115](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aL101-R115)`)

### Command Updates:
* Updated the command for running Python tests to use `pixi run --frozen test` instead of `pytest`, ensuring compatibility with the new setup. (`[.github/workflows/ci_cd.ymlL101-R115](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aL101-R115)`)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--409.org.readthedocs.build//409/

<!-- readthedocs-preview jaxsim end -->