### PR TITLE
Implement custom JVP rule for improving `safe_norm` computation speed

### DIFF
--- a/src/jaxsim/math/utils.py
+++ b/src/jaxsim/math/utils.py
@@ -1,6 +1,48 @@
+import functools
+
+import jax
 import jax.numpy as jnp
 
 import jaxsim.typing as jtp
+
+
+@functools.cache
+def _make_safe_norm(axis, keepdims):
+    @jax.custom_jvp
+    def _safe_norm(array: jtp.ArrayLike) -> jtp.Array:
+        """
+        Compute an array norm handling NaNs and making sure that
+        it is safe to get the gradient.
+
+        Args:
+            array: The array for which to compute the norm.
+
+        Returns:
+            The norm of the array with handling for zero arrays to avoid NaNs.
+        """
+        # Compute the norm of the array along the specified axis.
+        return jnp.linalg.norm(array, axis=axis, keepdims=keepdims)
+
+    @_safe_norm.defjvp
+    def _safe_norm_jvp(primals, tangents):
+        (x,), (x_dot,) = primals, tangents
+
+        # Check if the entire array is composed of zeros.
+        is_zero = jnp.all(x == 0.0)
+
+        # Replace zeros with an array of ones temporarily to avoid division by zero.
+        # This ensures the computation of norm does not produce NaNs or Infs.
+        array = jnp.where(is_zero, jnp.ones_like(x), x)
+
+        # Compute the norm of the array along the specified axis.
+        norm = jnp.linalg.norm(array, axis=axis, keepdims=keepdims)
+
+        dot = jnp.sum(array * x_dot, axis=axis, keepdims=keepdims)
+        tangent = jnp.where(is_zero, 0.0, dot / norm)
+
+        return jnp.where(is_zero, 0.0, norm), tangent
+
+    return _safe_norm
 
 
 def safe_norm(array: jtp.ArrayLike, *, axis=None, keepdims: bool = False) -> jtp.Array:
@@ -16,17 +58,4 @@ def safe_norm(array: jtp.ArrayLike, *, axis=None, keepdims: bool = False) -> jtp
     Returns:
         The norm of the array with handling for zero arrays to avoid NaNs.
     """
-
-    # Check if the entire array is composed of zeros.
-    is_zero = jnp.allclose(array, 0.0)
-
-    # Replace zeros with an array of ones temporarily to avoid division by zero.
-    # This ensures the computation of norm does not produce NaNs or Infs.
-    array = jnp.where(is_zero, jnp.ones_like(array), array)
-
-    # Compute the norm of the array along the specified axis.
-    norm = jnp.linalg.norm(array, axis=axis, keepdims=keepdims)
-
-    # Use `jnp.where` to set the norm to 0.0 where the input array was all zeros.
-    # This usage supports potential batch processing for future scalability.
-    return jnp.where(is_zero, 0.0, norm)
+    return _make_safe_norm(axis, keepdims)(array)

--- a/src/jaxsim/math/utils.py
+++ b/src/jaxsim/math/utils.py
@@ -1,12 +1,9 @@
-import functools
-
 import jax
 import jax.numpy as jnp
 
 import jaxsim.typing as jtp
 
 
-@functools.cache
 def _make_safe_norm(axis, keepdims):
     @jax.custom_jvp
     def _safe_norm(array: jtp.ArrayLike) -> jtp.Array:


### PR DESCRIPTION
This pull request introduces a custom JVP rule for the `safe_norm` function to handle NaNs and zero arrays more effectively during gradient computation, while having the same speed of the plain `jnp.linalg.norm` when the gradients are not necessary. This enhancement improves the runtime speed of the `safe_norm` function

Note that `@jax.custom_jvp` only supports functions with positional args or positional-or-keyword, for this reason the non-array args (axis, keepdims) should be trated as static. For this reason a wrapper factory was necessary

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--411.org.readthedocs.build//411/

<!-- readthedocs-preview jaxsim end -->