### PR TITLE
Compute the quaternion derivative by using the Hamilton product

### DIFF
--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -52,7 +52,6 @@ def semi_implicit_euler_integration(
         W_Q̇_B = jaxsim.math.Quaternion.derivative(
             quaternion=data.base_orientation,
             omega=W_ω_WB,
-            omega_in_body_fixed=False,
         ).squeeze()
 
         W_p_B = data.base_position + dt * W_ṗ_B

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -164,7 +164,6 @@ def system_position_dynamics(
     W_Q̇_B = Quaternion.derivative(
         quaternion=W_Q_B,
         omega=W_ω_WB,
-        omega_in_body_fixed=False,
         K=baumgarte_quaternion_regularization,
     ).squeeze()
 

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -68,7 +68,6 @@ class Quaternion:
     def derivative(
         quaternion: jtp.Vector,
         omega: jtp.Vector,
-        omega_in_body_fixed: bool = False,
         K: float = 0.1,
     ) -> jtp.Vector:
         """

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -87,7 +87,17 @@ class Quaternion:
         # Construct pure quaternion: (scalar damping term, angular velocity components)
         ω_quat = jnp.hstack([K * safe_norm(ω) * (1 - safe_norm(quaternion)), ω])
 
-        # Apply quaternion multiplication based on frame representation
+        # Quaternion multiplication using index tables.
+        # This approach avoids using the explicit quaternion multiplication formula
+        # by encoding the necessary element-wise products and signs via indexed operations.
+        # Given two quaternions q and w, their Hamilton product q ⊗ w can be written
+        # as a combination of q[i] * w[j] terms with appropriate signs.
+        # i_idx and j_idx define which elements of the outer product q ⊗ w to select.
+        # For example, i_idx[1][2] = 2 and j_idx[1][2] = 3 means: take q[2] * w[3] for this term.
+        # sign_matrix[i][j] gives the sign (+1 or -1) to apply to each q[i] * w[j] term,
+        # depending on quaternion multiplication rules.
+        # This indexed summation reproduces the Hamilton product of quaternions in a
+        # vectorized way, and is suitable for use with JAX.
         i_idx = jnp.array([[0, 1, 2, 3], [0, 1, 2, 3], [0, 2, 3, 1], [0, 3, 1, 2]])
         j_idx = jnp.array([[0, 1, 2, 3], [1, 0, 3, 2], [2, 0, 1, 3], [3, 0, 2, 1]])
         sign_matrix = jnp.array(

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -76,59 +76,38 @@ class Quaternion:
         Args:
             quaternion: Quaternion in XYZW representation.
             omega: Angular velocity vector.
-            omega_in_body_fixed (bool): Whether the angular velocity is in the body-fixed frame.
             K (float): A scaling factor.
 
         Returns:
             The derivative of the quaternion.
         """
         ω = omega.squeeze()
-        quaternion = quaternion.squeeze()
+        q = quaternion.squeeze()
 
-        def Q_body(q: jtp.Vector) -> jtp.Matrix:
-            qw, qx, qy, qz = q
+        # Construct pure quaternion: (scalar damping term, angular velocity components)
+        ω_quat = jnp.hstack([K * safe_norm(ω) * (1 - safe_norm(quaternion)), ω])
 
-            return jnp.array(
-                [
-                    [qw, -qx, -qy, -qz],
-                    [qx, qw, -qz, qy],
-                    [qy, qz, qw, -qx],
-                    [qz, -qy, qx, qw],
-                ]
-            )
-
-        def Q_inertial(q: jtp.Vector) -> jtp.Matrix:
-            qw, qx, qy, qz = q
-
-            return jnp.array(
-                [
-                    [qw, -qx, -qy, -qz],
-                    [qx, qw, qz, -qy],
-                    [qy, -qz, qw, qx],
-                    [qz, qy, -qx, qw],
-                ]
-            )
-
-        Q = jax.lax.cond(
-            pred=omega_in_body_fixed,
-            true_fun=Q_body,
-            false_fun=Q_inertial,
-            operand=quaternion,
+        # Apply quaternion multiplication based on frame representation
+        i_idx = jnp.array([[0, 1, 2, 3], [0, 1, 2, 3], [0, 2, 3, 1], [0, 3, 1, 2]])
+        j_idx = jnp.array([[0, 1, 2, 3], [1, 0, 3, 2], [2, 0, 1, 3], [3, 0, 2, 1]])
+        sign_matrix = jnp.array(
+            [
+                [1, -1, -1, -1],
+                [1, 1, 1, -1],
+                [1, 1, 1, -1],
+                [1, 1, 1, -1],
+            ]
         )
 
-        norm_ω = safe_norm(ω)
+        # Compute quaternion derivative via Einstein summation
+        q_outer = jnp.einsum("...i,...j->...ij", q, ω_quat)
 
-        qd = 0.5 * (
-            Q
-            @ jnp.hstack(
-                [
-                    K * norm_ω * (1 - safe_norm(quaternion)),
-                    ω,
-                ]
-            )
+        Qd = jnp.sum(
+            sign_matrix * q_outer[..., i_idx, j_idx],
+            axis=-1,
         )
 
-        return jnp.vstack(qd)
+        return 0.5 * Qd
 
     @staticmethod
     def integration(

--- a/src/jaxsim/math/quaternion.py
+++ b/src/jaxsim/math/quaternion.py
@@ -100,7 +100,7 @@ class Quaternion:
         )
 
         # Compute quaternion derivative via Einstein summation
-        q_outer = jnp.einsum("...i,...j->...ij", q, ω_quat)
+        q_outer = jnp.outer(q, ω_quat)
 
         Qd = jnp.sum(
             sign_matrix * q_outer[..., i_idx, j_idx],

--- a/tests/test_api_frame.py
+++ b/tests/test_api_frame.py
@@ -266,7 +266,6 @@ def test_frame_jacobian_derivative(
         W_Q̇_B = Quaternion.derivative(
             quaternion=data.base_orientation,
             omega=B_ω_WB,
-            omega_in_body_fixed=True,
             K=0.0,
         ).squeeze()
 

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -360,7 +360,6 @@ def test_link_jacobian_derivative(
         W_Q̇_B = jaxsim.math.Quaternion.derivative(
             quaternion=data.base_orientation,
             omega=B_ω_WB,
-            omega_in_body_fixed=True,
             K=0.0,
         ).squeeze()
 

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -466,7 +466,6 @@ def test_coriolis_matrix(
         W_Q̇_B = jaxsim.math.Quaternion.derivative(
             quaternion=data.base_orientation,
             omega=B_ω_WB,
-            omega_in_body_fixed=True,
             K=0.0,
         ).squeeze()
 


### PR DESCRIPTION
This pull request includes several changes to the quaternion derivative calculations. The primary focus is on computing it by using the Hamilton product of quaternions, which allowed removing the `omega_in_body_fixed` parameter

Refactoring and simplification:

* [`src/jaxsim/math/quaternion.py`](diffhunk://#diff-03197f574252e3d07472d558e9b1e402e4a5139ee0d9f4d92a78818299561aafL71): Removed the `omega_in_body_fixed` parameter and refactored the `Quaternion.derivative` method to simplify the quaternion multiplication process. This includes the removal of the conditional logic for frame representation and the introduction of a more efficient computation using Einstein summation. [[1]](diffhunk://#diff-03197f574252e3d07472d558e9b1e402e4a5139ee0d9f4d92a78818299561aafL71) [[2]](diffhunk://#diff-03197f574252e3d07472d558e9b1e402e4a5139ee0d9f4d92a78818299561aafL80-R110)

Associated method calls updated:

* [`src/jaxsim/api/integrators.py`](diffhunk://#diff-33b49b4d51e5e0194d3ce2e4b4f53ef1901858b8ab341d88fa6c9620200094e1L55): Removed the `omega_in_body_fixed` parameter from the call to `Quaternion.derivative` in the `semi_implicit_euler_integration` function.
* [`src/jaxsim/api/ode.py`](diffhunk://#diff-5a992d6e02acddeb8cf23d21fa124750c80efd0234f9b3db840041fd7a602b29L131): Removed the `omega_in_body_fixed` parameter from the call to `Quaternion.derivative` in the `system_position_dynamics` function.
* [`tests/test_api_frame.py`](diffhunk://#diff-4e1c8d24898ae6710935ab409713452b512cef4991ba756700883b20166cd406L270): Removed the `omega_in_body_fixed` parameter from the call to `Quaternion.derivative` in the `compute_q̇` function.
* [`tests/test_api_link.py`](diffhunk://#diff-84fa59de8bb7185910d5e08365ac56136a256f30901dc0d30da30d8b48c3be49L360): Removed the `omega_in_body_fixed` parameter from the call to `Quaternion.derivative` in the `compute_q̇` function.
* [`tests/test_api_model.py`](diffhunk://#diff-4cda1019189e1ba59de5a3d73f5e78a64ca5e21bda7231ac2591c20bf377ae4bL461): Removed the `omega_in_body_fixed` parameter from the call to `Quaternion.derivative` in the `compute_q̇` function.