### PR TITLE
Exclude github-actions PRs from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,3 +3,4 @@ changelog:
     authors:
       - dependabot
       - pre-commit-ci
+      - github-actions


### PR DESCRIPTION
This pull request updates the `.github/release.yml` file to include `github-actions` as an author in the changelog configuration.

* [`.github/release.yml`](diffhunk://#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R6): Added `github-actions` to the list of excluded authors under the `changelog` section.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--414.org.readthedocs.build//414/

<!-- readthedocs-preview jaxsim end -->