### PR TITLE
Update `pyproject.toml` license info according to PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ maintainers = [
     { name = "Filippo Luca Ferretti", email = "filippo.ferretti@iit.it" },
     { name = "Alessandro Croci", email = "alessandro.croci@iit.it" },
 ]
-license.file = "LICENSE"
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 keywords = [
     "physics",
     "physics engine",
@@ -29,7 +30,6 @@ classifiers = [
     "Framework :: Robot Framework",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
     "Operating System :: Microsoft",


### PR DESCRIPTION
This pull request updates the licensing information in the `pyproject.toml` file to align with the BSD-3-Clause license standard and removes an outdated classifier entry.

### Licensing updates:

* Updated the `license` field to specify "BSD-3-Clause" and added a `license-files` field to include the `LICENSE` file, replacing the previous `license.file` entry. (`pyproject.toml`, [pyproject.tomlL14-R15](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L14-R15))

### Classifier adjustments:

* Removed the outdated classifier `"License :: OSI Approved :: BSD License"` from the `classifiers` list, as it is no longer needed with the updated license field. (`pyproject.toml`, [pyproject.tomlL32](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L32))#license and https://peps.python.org/pep-0639/

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--415.org.readthedocs.build//415/

<!-- readthedocs-preview jaxsim end -->