### PR TITLE
Improve stability by clipping contact model stiffness and damping

### DIFF
--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -133,28 +133,30 @@ class ContactsParams(JaxsimDataclass):
         ξ = damping_ratio
         δ_max = max_penetration
         μc = static_friction_coefficient
+        nc = number_of_active_collidable_points_steady_state
 
         # Compute the total mass of the model.
         m = jnp.array(model.kin_dyn_parameters.link_parameters.mass).sum()
 
-        # Rename the standard gravity.
-        g = standard_gravity
-
-        # Compute the average support force on each collidable point.
-        f_average = m * g / number_of_active_collidable_points_steady_state
-
         # Compute the stiffness to get the desired steady-state penetration.
         # Note that this is dependent on the non-linear exponent used in
         # the damping term of the Hunt/Crossley model.
-        K = f_average / jnp.power(δ_max, 1 + p) if stiffness is None else stiffness
+        if stiffness is None:
+            # Compute the average support force on each collidable point.
+            f_average = m * standard_gravity / nc
+
+            stiffness = f_average / jnp.power(δ_max, 1 + p)
+            stiffness = jnp.clip(stiffness, 0, 1e6)
 
         # Compute the damping using the damping ratio.
-        critical_damping = 2 * jnp.sqrt(K * m)
-        D = ξ * critical_damping if damping is None else damping
+        critical_damping = 2 * jnp.sqrt(stiffness * m)
+        if damping is None:
+            damping = ξ * critical_damping
+            damping = jnp.clip(damping, 0, 1e4)
 
         return self.build(
-            K=K,
-            D=D,
+            K=stiffness,
+            D=damping,
             mu=μc,
             p=p,
             q=q,

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -18,6 +18,10 @@ except ImportError:
     from typing_extensions import Self
 
 
+MAX_STIFFNESS = 1e6
+MAX_DAMPING = 1e4
+
+
 @functools.partial(jax.jit, static_argnames=("terrain",))
 def compute_penetration_data(
     p: jtp.VectorLike,
@@ -146,13 +150,13 @@ class ContactsParams(JaxsimDataclass):
             f_average = m * standard_gravity / nc
 
             stiffness = f_average / jnp.power(δ_max, 1 + p)
-            stiffness = jnp.clip(stiffness, 0, 1e6)
+            stiffness = jnp.clip(stiffness, 0, MAX_STIFFNESS)
 
         # Compute the damping using the damping ratio.
         critical_damping = 2 * jnp.sqrt(stiffness * m)
         if damping is None:
             damping = ξ * critical_damping
-            damping = jnp.clip(damping, 0, 1e4)
+            damping = jnp.clip(damping, 0, MAX_DAMPING)
 
         return self.build(
             K=stiffness,


### PR DESCRIPTION
See https://github.com/ami-iit/component_darwin/issues/71#issuecomment-2876371718

> Today, with @younik we have done some investigations, namely: 
> note: helped means that the NaN appeared later on in the training 
> 
> - Changing the value of TN curve made it more stable, but did not solve the issue, 
> - Changing the time step of the simulation  solved it, but in favour of too slow simulation 
> - Removing all collisions but the sole one, did not help, 
> - Changing the maximum penetration, 👍  solved the issue
> 
> It seems that the issue is that the damping and stiffness are not bounded, but compute,d giving the maximum penetration. For ergoCub, they were too high, causing the simulation to explode. By clipping the value here https://github.com/amue i-iit/jaxsim/blob/89fde4dca237c854f1bf2653e4b05f877910f255/src/jaxsim/rbda/contacts/common.py#L84-L162 it seems that everything work .  
> 
> @younik  please add the related PR 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--424.org.readthedocs.build//424/

<!-- readthedocs-preview jaxsim end -->