### PR TITLE
Reduce batch size in example notebook to avoid cell timeout in RTD build

### DIFF
--- a/examples/jaxsim_as_physics_engine_advanced.ipynb
+++ b/examples/jaxsim_as_physics_engine_advanced.ipynb
@@ -213,7 +213,7 @@
     "key = jax.random.PRNGKey(seed=0)\n",
     "\n",
     "# Split subkeys for sampling random initial data.\n",
-    "batch_size = 16\n",
+    "batch_size = 9\n",
     "row_length = int(jnp.sqrt(batch_size))\n",
     "row_dist = 0.3 * row_length\n",
     "key, *subkeys = jax.random.split(key=key, num=batch_size + 1)\n",


### PR DESCRIPTION


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--425.org.readthedocs.build//425/

<!-- readthedocs-preview jaxsim end -->