### PR TITLE
Fix export model for hardware parameters

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -559,7 +559,7 @@ class JaxSimModel(JaxsimDataclass):
             # Update visual pose
             links_dict[link_name].visual.pose = rod.Pose.from_transform(
                 transform=np.array(hw_metadata.L_H_vis[link_index]),
-                relative_to=links_dict[link_name].visual.pose.relative_to,
+                relative_to=link_name,
             )
 
             # Update joint poses
@@ -573,7 +573,7 @@ class JaxSimModel(JaxsimDataclass):
                             transform=np.array(
                                 hw_metadata.L_H_pre[link_index, joint_index]
                             ),
-                            relative_to=joints_dict[joint_name].pose.relative_to,
+                            relative_to=link_name,
                         )
 
         # Export the URDF string.


### PR DESCRIPTION
This fixes the export model for hardware parameters by explicit the relative to frame for the joints and link

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--426.org.readthedocs.build//426/

<!-- readthedocs-preview jaxsim end -->