### PR TITLE
Increase minimum tolerance for hardware parametrization when using X32

### DIFF
--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -417,7 +417,9 @@ class JaxSimModel(JaxsimDataclass):
 
             # Skip unsupported links
             if not jnp.allclose(
-                self.kin_dyn_parameters.joint_model.suc_H_i[link_index], jnp.eye(4)
+                self.kin_dyn_parameters.joint_model.suc_H_i[link_index],
+                jnp.eye(4),
+                **(dict(atol=1e-6) if not jax.config.jax_enable_x64 else dict()),
             ):
                 logging.debug(
                     f"Skipping link '{link_name}' for hardware parametrization due to unsupported suc_H_link."


### PR DESCRIPTION
This pull request updates the `compute_hw_link_metadata` method in `src/jaxsim/api/model.py` to allow, in case of X32, to avoid skipping links only for a precision error on the computation of `jnp.allclose`

### Numerical precision handling:

* [`src/jaxsim/api/model.py`](diffhunk://#diff-b9e4540bc2ab5035687424d186fab029dfec2756803d6e464ccceb89dd630a72L420-R422): Updated the condition in `compute_hw_link_metadata` to dynamically set the `atol` parameter in `jnp.allclose` based on whether `jax_enable_x64` is enabled. This ensures better compatibility and precision handling for different configurations.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--428.org.readthedocs.build//428/

<!-- readthedocs-preview jaxsim end -->