### PR TITLE
Implement parametric collision shapes scaling

### DIFF
--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -1067,6 +1067,70 @@ class HwLinkMetadata(JaxsimDataclass):
         )
 
     @staticmethod
+    def compute_contact_points(
+        original_contact_params: jtp.Vector,
+        shape_types: jtp.Vector,
+        original_com_positions: jtp.Vector,
+        updated_com_positions: jtp.Vector,
+        scaling_factors: ScalingFactors,
+    ) -> jtp.Matrix:
+        """
+        Compute the new contact points based on the original contact parameters and
+        the scaling factors.
+
+        Args:
+            original_contact_params: The original contact parameters.
+            shape_types: The shape types of the links (e.g., box, sphere, cylinder).
+            original_com_positions: The original center of mass positions of the links.
+            updated_com_positions: The updated center of mass positions of the links.
+            scaling_factors: The scaling factors for the link dimensions.
+
+        Returns:
+            The new contact points positions in the parent link frame.
+        """
+
+        parent_link_indices = np.array(original_contact_params.body)
+
+        # Translate the original contact point positions in the origin, so
+        # that we can apply the scaling factors.
+        L_p_Ci = (
+            original_contact_params.point - original_com_positions[parent_link_indices]
+        )
+
+        # Extract the shape types of the parent links.
+        parent_shape_types = jnp.array(shape_types[parent_link_indices])
+
+        def sphere(parent_idx, L_p_C):
+            r = scaling_factors.dims[parent_idx][0]
+            return L_p_C * r
+
+        def cylinder(parent_idx, L_p_C):
+            # TODO: Cylinder collisions are not currently supported in JaxSim.
+            return L_p_C
+
+        def box(parent_idx, L_p_C):
+            lx, ly, lz = scaling_factors.dims[parent_idx]
+            return jnp.hstack(
+                [
+                    L_p_C[0] * lx,
+                    L_p_C[1] * ly,
+                    L_p_C[2] * lz,
+                ]
+            )
+
+        new_positions = jax.vmap(
+            lambda shape_idx, parent_idx, L_p_C: jax.lax.switch(
+                shape_idx, (box, cylinder, sphere), parent_idx, L_p_C
+            )
+        )(
+            parent_shape_types,
+            parent_link_indices,
+            L_p_Ci,
+        )
+
+        return new_positions + updated_com_positions[parent_link_indices]
+
+    @staticmethod
     def compute_inertia_link(I_com, mass, L_H_G) -> jtp.Matrix:
         """
         Compute the inertia tensor of the link based on its shape and mass.

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -2380,6 +2380,18 @@ def update_hw_parameters(
         ),
     )
 
+    # Compute the contact parameters
+    points = HwLinkMetadata.compute_contact_points(
+        original_contact_params=kin_dyn_params.contact_parameters,
+        shape_types=updated_hw_link_metadata.shape,
+        original_com_positions=link_parameters.center_of_mass,
+        updated_com_positions=updated_link_parameters.center_of_mass,
+        scaling_factors=scaling_factors,
+    )
+
+    # Update contact parameters
+    updated_contact_parameters = kin_dyn_params.contact_parameters.replace(point=points)
+
     # Update joint model transforms (λ_H_pre)
     def update_λ_H_pre(joint_index):
         # Extract the transforms and masks for the current joint index across all links
@@ -2420,6 +2432,7 @@ def update_hw_parameters(
     # Replace the kin_dyn_parameters with updated values
     updated_kin_dyn_params = kin_dyn_params.replace(
         link_parameters=updated_link_parameters,
+        contact_parameters=updated_contact_parameters,
         hw_link_metadata=updated_hw_link_metadata,
         joint_model=updated_joint_model,
     )

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -567,6 +567,9 @@ class JaxSimModel(JaxsimDataclass):
                 links_dict[link_name].collision.geometry.cylinder.radius = float(
                     dims[0]
                 )
+                links_dict[link_name].collision.geometry.cylinder.length = float(
+                    dims[1]
+                )
             else:
                 logging.debug(f"Skipping unsupported shape for link '{link_name}'")
                 continue

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -557,11 +557,16 @@ class JaxSimModel(JaxsimDataclass):
             dims = hw_metadata.dims[link_index]
             if shape == LinkParametrizableShape.Box:
                 links_dict[link_name].visual.geometry.box.size = dims.tolist()
+                links_dict[link_name].collision.geometry.box.size = dims.tolist()
             elif shape == LinkParametrizableShape.Sphere:
                 links_dict[link_name].visual.geometry.sphere.radius = float(dims[0])
+                links_dict[link_name].collision.geometry.sphere.radius = float(dims[0])
             elif shape == LinkParametrizableShape.Cylinder:
                 links_dict[link_name].visual.geometry.cylinder.radius = float(dims[0])
                 links_dict[link_name].visual.geometry.cylinder.length = float(dims[1])
+                links_dict[link_name].collision.geometry.cylinder.radius = float(
+                    dims[0]
+                )
             else:
                 logging.debug(f"Skipping unsupported shape for link '{link_name}'")
                 continue

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -2353,10 +2353,12 @@ def update_hw_parameters(
     link_parameters: LinkParameters = kin_dyn_params.link_parameters
     hw_link_metadata: HwLinkMetadata = kin_dyn_params.hw_link_metadata
 
+    has_joints = model.number_of_joints() > 0
+
     # Apply scaling to hw_link_metadata using vmap
-    updated_hw_link_metadata = jax.vmap(HwLinkMetadata.apply_scaling)(
-        hw_link_metadata, scaling_factors
-    )
+    updated_hw_link_metadata = jax.vmap(
+        HwLinkMetadata.apply_scaling, in_axes=(0, 0, None)
+    )(hw_link_metadata, scaling_factors, has_joints)
 
     # Compute mass and inertia once and unpack the results
     m_updated, I_com_updated = jax.vmap(HwLinkMetadata.compute_mass_and_inertia)(
@@ -2415,19 +2417,23 @@ def update_hw_parameters(
             lambda: kin_dyn_params.joint_model.λ_H_pre[joint_index + 1],
         )
 
-    # Apply the update function to all joint indices
-    updated_λ_H_pre = jax.vmap(update_λ_H_pre)(
-        jnp.arange(kin_dyn_params.number_of_joints())
-    )
-    # NOTE: λ_H_pre should be of len (1+n_joints) with the 0-th element equal
-    # to identity to represent the world-to-base tree transform. See JointModel class
-    updated_λ_H_pre_with_base = jnp.concatenate(
-        (jnp.eye(4).reshape(1, 4, 4), updated_λ_H_pre), axis=0
-    )
-    # Replace the joint model with the updated transforms
-    updated_joint_model = kin_dyn_params.joint_model.replace(
-        λ_H_pre=updated_λ_H_pre_with_base
-    )
+    if has_joints:
+        # Apply the update function to all joint indices
+        updated_λ_H_pre = jax.vmap(update_λ_H_pre)(
+            jnp.arange(kin_dyn_params.number_of_joints())
+        )  # NOTE: λ_H_pre should be of len (1+n_joints) with the 0-th element equal
+        # to identity to represent the world-to-base tree transform. See JointModel class
+        updated_λ_H_pre_with_base = jnp.concatenate(
+            (jnp.eye(4).reshape(1, 4, 4), updated_λ_H_pre), axis=0
+        )
+        # Replace the joint model with the updated transforms
+        updated_joint_model = kin_dyn_params.joint_model.replace(
+            λ_H_pre=updated_λ_H_pre_with_base
+        )
+
+    else:
+        # If there are no joints, we can just use the identity transform
+        updated_joint_model = kin_dyn_params.joint_model
 
     # Replace the kin_dyn_parameters with updated values
     updated_kin_dyn_params = kin_dyn_params.replace(

--- a/tests/test_api_model_hw_parametrization.py
+++ b/tests/test_api_model_hw_parametrization.py
@@ -377,10 +377,14 @@ def test_hw_parameters_optimization(jaxsim_model_garpez: js.model.JaxSimModel):
     assert current_loss < 1e-3, "Optimization did not converge to the target height."
 
 
-def test_hw_parameters_collision_scaling(jaxsim_model_box: js.model.JaxSimModel):
+def test_hw_parameters_collision_scaling(
+    jaxsim_model_box: js.model.JaxSimModel, prng_key: jax.Array
+):
     """
     Test that the collision elements of the model are updated correctly during the scaling of the model hw parameters.
     """
+
+    _, subkey = jax.random.split(prng_key, num=2)
 
     # TODO: the jaxsim_model_box has an additional frame, which is handled wrongly
     # during the export of the updated model. For this reason, we recreate the model
@@ -427,7 +431,12 @@ def test_hw_parameters_collision_scaling(jaxsim_model_box: js.model.JaxSimModel)
         # The base position is set to the nominal height of the box scaled by the scaling factor,
         # plus a small offset to avoid immediate collision with the ground.
         # This ensures that the box has enough space to fall and settle at the expected height.
-        base_position=jnp.array([0.0, 0.0, nominal_height * scaling_factor + 0.01]),
+        base_position=jnp.array(
+            [
+                *jax.random.uniform(subkey, shape=(2,)),
+                nominal_height * scaling_factor + 0.01,
+            ]
+        ),
     )
 
     num_steps = 1000  # Number of simulation steps

--- a/tests/test_api_model_hw_parametrization.py
+++ b/tests/test_api_model_hw_parametrization.py
@@ -377,30 +377,59 @@ def test_hw_parameters_optimization(jaxsim_model_garpez: js.model.JaxSimModel):
     assert current_loss < 1e-3, "Optimization did not converge to the target height."
 
 
-def test_hw_parameters_collision_scaling(jaxsim_model_sphere: js.model.JaxSimModel):
+def test_hw_parameters_collision_scaling(jaxsim_model_box: js.model.JaxSimModel):
     """
     Test that the collision elements of the model are updated correctly during the scaling of the model hw parameters.
     """
 
-    model = jaxsim_model_sphere
+    # TODO: the jaxsim_model_box has an additional frame, which is handled wrongly
+    # during the export of the updated model. For this reason, we recreate the model
+    # from scratch here.
+    del jaxsim_model_box
+
+    import rod.builder.primitives
+
+    # Create on-the-fly a ROD model of a box.
+    rod_model = (
+        rod.builder.primitives.BoxBuilder(x=0.3, y=0.2, z=0.1, mass=1.0, name="box")
+        .build_model()
+        .add_link(name="box_link")
+        .add_inertial()
+        .add_visual()
+        .add_collision()
+        .build()
+    )
+
+    model = js.model.JaxSimModel.build_from_model_description(
+        model_description=rod_model
+    )
 
     # Define the scaling factor for the sphere's radius
-    scaling_factor = 2.0
+    scaling_factor = 5.0
 
     # Define the nominal radius of the sphere
-    nominal_radius = model.kin_dyn_parameters.hw_link_metadata.dims[0, 0]
+    nominal_height = model.kin_dyn_parameters.hw_link_metadata.dims[0, 2]
 
     # Define scaling parameters
     scaling_parameters = ScalingFactors(
-        dims=jnp.ones((model.number_of_links(), 3)).at[0, 0].set(scaling_factor),
+        dims=jnp.ones((model.number_of_links(), 3)) * scaling_factor,
         density=jnp.array([1.0]),
     )
 
     # Update the model with the scaling parameters
     updated_model = js.model.update_hw_parameters(model, scaling_parameters)
 
-    # Simulate the sphere falling under gravity
-    data = js.data.JaxSimModelData.build(model=updated_model)
+    # Simulate the box falling under gravity
+    data = js.data.JaxSimModelData.build(
+        model=updated_model,
+        # Set the initial position of the box's base to be slightly above the ground
+        # to allow it to settle at the expected height after scaling.
+        # The base position is set to the nominal height of the box scaled by the scaling factor,
+        # plus a small offset to avoid immediate collision with the ground.
+        # This ensures that the box has enough space to fall and settle at the expected height.
+        base_position=jnp.array([0.0, 0.0, nominal_height * scaling_factor + 0.01]),
+    )
+
     num_steps = 1000  # Number of simulation steps
 
     for _ in range(num_steps):
@@ -409,13 +438,13 @@ def test_hw_parameters_collision_scaling(jaxsim_model_sphere: js.model.JaxSimMod
             data=data,
         )
 
-    # Get the final height of the sphere's base
+    # Get the final height of the box's base
     updated_base_height = data.base_position[2]
 
     # Compute the expected height (nominal radius * scaling factor)
-    expected_height = nominal_radius * scaling_factor
+    expected_height = nominal_height * scaling_factor / 2
 
-    # Assert that the sphere settles at the expected height
+    # Assert that the box settles at the expected height
     assert jnp.isclose(
         updated_base_height, expected_height, atol=1e-3
     ), f"model base height mismatch: expected {expected_height}, got {updated_base_height}"

--- a/tests/test_api_model_hw_parametrization.py
+++ b/tests/test_api_model_hw_parametrization.py
@@ -408,7 +408,7 @@ def test_hw_parameters_collision_scaling(
         model_description=rod_model
     )
 
-    # Define the scaling factor for the sphere's radius
+    # Define the scaling factor for the model
     scaling_factor = 5.0
 
     # Define the nominal radius of the sphere

--- a/tests/test_api_model_hw_parametrization.py
+++ b/tests/test_api_model_hw_parametrization.py
@@ -325,10 +325,7 @@ def test_hw_parameters_optimization(jaxsim_model_garpez: js.model.JaxSimModel):
 
     # Define the initial hardware parameters (scaling factors).
     initial_dims = jnp.ones(
-        (
-            model.number_of_links(),
-            3,
-        )
+        (model.number_of_links(), 3)
     )  # Initial dimensions (1.0 for all links).
     initial_density = jnp.ones(
         (model.number_of_links(),)
@@ -391,7 +388,7 @@ def test_hw_parameters_collision_scaling(jaxsim_model_sphere: js.model.JaxSimMod
     scaling_factor = 2.0
 
     # Define the nominal radius of the sphere
-    nominal_radius = jaxsim_model_sphere.kin_dyn_parameters.hw_link_metadata.dims[0, 0]
+    nominal_radius = model.kin_dyn_parameters.hw_link_metadata.dims[0, 0]
 
     # Define scaling parameters
     scaling_parameters = ScalingFactors(
@@ -400,9 +397,7 @@ def test_hw_parameters_collision_scaling(jaxsim_model_sphere: js.model.JaxSimMod
     )
 
     # Update the model with the scaling parameters
-    updated_model = js.model.update_hw_parameters(
-        jaxsim_model_sphere, scaling_parameters
-    )
+    updated_model = js.model.update_hw_parameters(model, scaling_parameters)
 
     # Simulate the sphere falling under gravity
     data = js.data.JaxSimModelData.build(model=updated_model)


### PR DESCRIPTION
This PR adds the scaling of collision shapes. 
Additionally, a workaround has been added to fix the handling of jointless models. This involves the introduction of a `has_joints` variable, which can be easily handled using a pure-Python `if`-conditional since it's static.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--430.org.readthedocs.build//430/

<!-- readthedocs-preview jaxsim end -->