### PR TITLE
Automatically trigger GPU benchmarks on pushes to `main` branch

### DIFF
--- a/.github/workflows/gpu_benchmark.yml
+++ b/.github/workflows/gpu_benchmark.yml
@@ -1,6 +1,9 @@
 name: GPU Benchmarks
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for GPU benchmarks to automatically trigger on pushes to the `main` branch.

GPU benchmark results shown on pull requests were not being updated correctly when the cached benchmark data from main became outdated. This happened because the workflow only ran on PR events, not on updates to main itself—so the baseline comparison data could be stale.

* [`.github/workflows/gpu_benchmark.yml`](diffhunk://#diff-c68852206255717ae4766792bbe78bc2dbfef4159a68adb0b25f6ccec20ea0ccR4-R6): Added a `push` trigger configuration to run the workflow on pushes to the `main` branch.