### PR TITLE
Remove deprecated `jaxlib.xla_extension.XlaRuntimeError`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   # ===========================
   - python >= 3.12.0
   - coloredlogs
-  - jax >= 0.4.26
-  - jaxlib >= 0.4.26
+  - jax >= 0.4.34
+  - jaxlib >= 0.4.34
   - jaxlie >= 1.3.0
   - jax-dataclasses >= 1.4.0
   - optax >= 0.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ classifiers = [
 ]
 dependencies = [
     "coloredlogs",
-    "jax >= 0.4.26",
-    "jaxlib >= 0.4.26",
+    "jax >= 0.4.34",
+    "jaxlib >= 0.4.34",
     "jaxlie >= 1.3.0",
     "jax_dataclasses >= 1.4.0",
     "pptree",

--- a/tests/test_api_frame.py
+++ b/tests/test_api_frame.py
@@ -1,7 +1,7 @@
 import jax
 import jax.numpy as jnp
-import jaxlib.xla_extension
 import pytest
+from jax.errors import JaxRuntimeError
 
 import jaxsim.api as js
 from jaxsim import VelRepr
@@ -50,22 +50,22 @@ def test_frame_index(jaxsim_models_types: js.model.JaxSimModel):
     with pytest.raises(ValueError):
         _ = js.frame.name_to_idx(model=model, frame_name="non_existent_frame")
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.frame.idx_to_name(model=model, frame_index=-1)
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.frame.idx_to_name(model=model, frame_index=n_l - 1)
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.frame.idx_to_name(model=model, frame_index=n_l + n_f)
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.frame.idx_of_parent_link(model=model, frame_index=-1)
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.frame.idx_of_parent_link(model=model, frame_index=n_l - 1)
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.frame.idx_of_parent_link(model=model, frame_index=n_l + n_f)
 
 

--- a/tests/test_api_joint.py
+++ b/tests/test_api_joint.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
-import jaxlib.xla_extension
 import pytest
+from jax.errors import JaxRuntimeError
 
 import jaxsim.api as js
 
@@ -39,7 +39,7 @@ def test_joint_index(
     with pytest.raises(ValueError):
         _ = js.joint.name_to_idx(model=model, joint_name="non_existent_joint")
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.joint.idx_to_name(model=model, joint_index=-1)
 
     with pytest.raises(IndexError):

--- a/tests/test_api_link.py
+++ b/tests/test_api_link.py
@@ -1,7 +1,7 @@
 import jax
 import jax.numpy as jnp
-import jaxlib.xla_extension
 import pytest
+from jax.errors import JaxRuntimeError
 
 import jaxsim.api as js
 import jaxsim.math
@@ -44,7 +44,7 @@ def test_link_index(
     with pytest.raises(ValueError):
         _ = js.link.name_to_idx(model=model, link_name="non_existent_link")
 
-    with pytest.raises(jaxlib.xla_extension.XlaRuntimeError):
+    with pytest.raises(JaxRuntimeError):
         _ = js.link.idx_to_name(model=model, link_index=-1)
 
     with pytest.raises(IndexError):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -3,8 +3,8 @@ from contextlib import redirect_stdout
 
 import jax
 import jax.numpy as jnp
-import jaxlib.xla_extension
 import pytest
+from jax.errors import JaxRuntimeError
 
 from jaxsim import exceptions
 
@@ -68,7 +68,7 @@ def test_exceptions_in_jit_functions():
     # Let's trigger a ValueError exception by passing 42.
     data = 42
     with pytest.raises(
-        jaxlib.xla_extension.XlaRuntimeError,
+        JaxRuntimeError,
         match=f"ValueError: Raising ValueError since data={data}",
     ):
         _ = jit_compiled_function(data=data)
@@ -78,7 +78,7 @@ def test_exceptions_in_jit_functions():
     # Let's trigger a RuntimeError exception by passing -42.
     data = -42
     with pytest.raises(
-        jaxlib.xla_extension.XlaRuntimeError,
+        JaxRuntimeError,
         match=f"RuntimeError: Raising RuntimeError since data={data}",
     ):
         _ = jit_compiled_function(data=data)


### PR DESCRIPTION
This pull request updates exception handling in the test suite by replacing references to `jaxlib.xla_extension.XlaRuntimeError` with `jax.errors.JaxRuntimeError`, reflecting changes in the JAX library. The changes ensure compatibility with the updated exception hierarchy in JAX.

### Updates to exception handling:

* **Imports updated across test files**: Replaced `jaxlib.xla_extension` import with `jax.errors` and added `JaxRuntimeError` import in the following files: `tests/test_api_frame.py`, `tests/test_api_joint.py`, `tests/test_api_link.py`, and `tests/test_exceptions.py`. [[1]](diffhunk://#diff-4e1c8d24898ae6710935ab409713452b512cef4991ba756700883b20166cd406L3-R4) [[2]](diffhunk://#diff-0ab6815e3c94863845d1a3946572e83640bcde1b59ea811b87aada07046d5b60L2-R3) [[3]](diffhunk://#diff-84fa59de8bb7185910d5e08365ac56136a256f30901dc0d30da30d8b48c3be49L3-R4) [[4]](diffhunk://#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccL6-R7)

* **Test assertions updated**:
  - In `tests/test_api_frame.py`: Updated all `pytest.raises` assertions to use `JaxRuntimeError` instead of `jaxlib.xla_extension.XlaRuntimeError` in `test_frame_index`.
  - In `tests/test_api_joint.py`: Updated `pytest.raises` assertion in `test_joint_index` to use `JaxRuntimeError`.
  - In `tests/test_api_link.py`: Updated `pytest.raises` assertion in `test_link_index` to use `JaxRuntimeError`.
  - In `tests/test_exceptions.py`: Updated `pytest.raises` assertions in `jit_compiled_function` to use `JaxRuntimeError`, ensuring proper exception matching for `ValueError` and `RuntimeError` triggers. [[1]](diffhunk://#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccL71-R71) [[2]](diffhunk://#diff-f46006e3f43ffb1dd5d6862005427f6620f4dcfb1fa2f883d8482550069eeeccL81-R81)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--435.org.readthedocs.build//435/

<!-- readthedocs-preview jaxsim end -->