### PR TITLE
Ensure version file is written before running tests

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -109,6 +109,13 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
+      - name: Ensure version file is written
+        if: |
+          contains(matrix.os, 'ubuntu') &&
+          (github.event_name != 'pull_request')
+        run: |
+          pixi run --frozen python -m setuptools_scm --force-write-version-file
+
       - name: Run the Python tests
         if: |
           contains(matrix.os, 'ubuntu') &&


### PR DESCRIPTION
This pull request updates the CI/CD workflow to ensure the version file is explicitly written before running Python tests. 

This fixes the CI failures on main branch.


Workflow enhancements:

* [`.github/workflows/ci_cd.yml`](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aR112-R115): Added a step named "Ensure version file is written" to run `setuptools_scm` with the `--force-write-version-file` flag, ensuring the version file is created before executing Python tests.