### PR TITLE
Add LFS instructions for Pixi installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ You can enforce GPU support, if needed, by also specifying `"jaxlib = * = *cuda*
 > ### Note
 > The minimum version of `pixi` required is `0.39.0`.
 
-Since the `pixi.lock` file is stored using Git LFS, make sure you have Git LFS installed and properly configured on your system before installation. After cloning the repository, run:
+Since the `pixi.lock` file is stored using Git LFS, make sure you have [Git LFS](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) installed and properly configured on your system before installation. After cloning the repository, run:
 
 ```bash
 git lfs install && git lfs pull
@@ -242,7 +242,7 @@ pip install --no-deps -e .
 > ### Note
 > The minimum version of `pixi` required is `0.39.0`.
 
-Since the `pixi.lock` file is stored using Git LFS, make sure you have Git LFS installed and properly configured on your system before installation. After cloning the repository, run:
+Since the `pixi.lock` file is stored using Git LFS, make sure you have [Git LFS](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) installed and properly configured on your system before installation. After cloning the repository, run:
 
 ```bash
 git lfs install && git lfs pull


### PR DESCRIPTION
This pull request updates the `README.md` file to include instructions for handling Git LFS files. The changes ensure that users are aware of the need for Git LFS and provide clear steps to set it up before proceeding with the installation with Pixi.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173-R180): Added a note about Git LFS requirements and included commands (`git lfs install && git lfs pull`) to ensure all LFS-tracked files are downloaded after cloning the repository. This update appears twice in the file to cover different installation contexts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173-R180) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R245-R252)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--441.org.readthedocs.build//441/

<!-- readthedocs-preview jaxsim end -->