### PR TITLE
Decouple constraint forces computation from contact forces

### DIFF
--- a/src/jaxsim/api/contact.py
+++ b/src/jaxsim/api/contact.py
@@ -552,43 +552,9 @@ def link_contact_forces(
     # to the frames associated to the collidable points.
     W_f_L = link_forces_from_contact_forces(model=model, contact_forces=W_f_C)
 
-    # Process constraint wrenches if present.
-    if "constr_wrenches_inertial" in aux_dict:
-        wrench_pair_constr_inertial = aux_dict["constr_wrenches_inertial"]
-
-        # Retrieve the constraint map from the model's kinematic parameters.
-        constraint_map = model.kin_dyn_parameters.constraints
-
-        # Extract the frame indices of the constraints.
-        frame_idxs_1 = constraint_map.frame_idxs_1
-        frame_idxs_2 = constraint_map.frame_idxs_2
-
-        n_kin_constraints = frame_idxs_1.shape[0]
-
-        if n_kin_constraints > 0:
-            parent_link_indices = jax.vmap(
-                lambda frame_idx_1, frame_idx_2: jnp.array(
-                    (
-                        js.frame.idx_of_parent_link(model, frame_index=frame_idx_1),
-                        js.frame.idx_of_parent_link(model, frame_index=frame_idx_2),
-                    )
-                )
-            )(frame_idxs_1, frame_idxs_2)
-
-            # Apply each constraint wrench to its corresponding parent link in W_f_L.
-            def apply_wrench(W_f_L, parent_indices, wrench_pair):
-                W_f_L = W_f_L.at[parent_indices[0]].add(wrench_pair[0])
-                W_f_L = W_f_L.at[parent_indices[1]].add(wrench_pair[1])
-                return W_f_L
-
-            W_f_L = jax.vmap(apply_wrench, in_axes=(None, 0, 0))(
-                W_f_L, parent_link_indices, wrench_pair_constr_inertial
-            ).sum(axis=0)
-
     return W_f_L, aux_dict
 
 
-@staticmethod
 def link_forces_from_contact_forces(
     model: js.model.JaxSimModel,
     *,

--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -1216,9 +1216,17 @@ class ConstraintMap(JaxsimDataclass):
     K_D: jtp.Float = dataclasses.field(
         default_factory=lambda: jnp.array([], dtype=float)
     )
+    # Precomputed parent link indices for each constraint pair
+    parent_link_idxs_1: jtp.Int = dataclasses.field(
+        default_factory=lambda: jnp.array([], dtype=int)
+    )
+    parent_link_idxs_2: jtp.Int = dataclasses.field(
+        default_factory=lambda: jnp.array([], dtype=int)
+    )
 
     def add_constraint(
         self,
+        model: jaxsim.api.model.JaxSimModel,
         frame_idx_1: int,
         frame_idx_2: int,
         constraint_type: int,
@@ -1229,6 +1237,7 @@ class ConstraintMap(JaxsimDataclass):
         Add a constraint to the constraint map.
 
         Args:
+            model: The model for which the constraints are added.
             frame_idx_1: The index of the first frame.
             frame_idx_2: The index of the second frame.
             constraint_type: The type of constraint.
@@ -1245,22 +1254,34 @@ class ConstraintMap(JaxsimDataclass):
 
         # Set default values for Baumgarte coefficients if not provided
         if K_P is None:
-            K_P = 1000
+            K_P = jnp.array([1000.0])
         if K_D is None:
-            K_D = 2 * np.sqrt(K_P)
+            K_D = 2 * jnp.sqrt(K_P)
 
         # Create new arrays with the input elements appended
         new_frame_idxs_1 = jnp.append(self.frame_idxs_1, frame_idx_1)
-        new_frame_idxs2 = jnp.append(self.frame_idxs_2, frame_idx_2)
+        new_frame_idxs_2 = jnp.append(self.frame_idxs_2, frame_idx_2)
         new_constraint_types = jnp.append(self.constraint_types, constraint_type)
         new_K_P = jnp.append(self.K_P, K_P)
         new_K_D = jnp.append(self.K_D, K_D)
 
+        # Compute parent link indices (now always available since model is required)
+        parent_link_idx_1 = jaxsim.api.frame.idx_of_parent_link(
+            model, frame_index=frame_idx_1
+        )
+        parent_link_idx_2 = jaxsim.api.frame.idx_of_parent_link(
+            model, frame_index=frame_idx_2
+        )
+        new_parent_link_idxs_1 = jnp.append(self.parent_link_idxs_1, parent_link_idx_1)
+        new_parent_link_idxs_2 = jnp.append(self.parent_link_idxs_2, parent_link_idx_2)
+
         # Return a new ConstraintMap object with updated attributes
         return ConstraintMap(
             frame_idxs_1=new_frame_idxs_1,
-            frame_idxs_2=new_frame_idxs2,
+            frame_idxs_2=new_frame_idxs_2,
             constraint_types=new_constraint_types,
             K_P=new_K_P,
             K_D=new_K_D,
+            parent_link_idxs_1=new_parent_link_idxs_1,
+            parent_link_idxs_2=new_parent_link_idxs_2,
         )

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -286,14 +286,6 @@ class JaxSimModel(JaxsimDataclass):
             else jaxsim.rbda.contacts.RelaxedRigidContacts.build()
         )
 
-        if constraints is not None and not isinstance(
-            contact_model, jaxsim.rbda.contacts.RelaxedRigidContacts
-        ):
-            constraints = None
-            logging.warning(
-                f"Contact model {contact_model.__class__.__name__} does not support kinematic constraints. Use RelaxedRigidContacts instead."
-            )
-
         if contact_params is None:
             contact_params = contact_model._parameters_class()
 

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 import jaxsim.api as js
 import jaxsim.typing as jtp
 from jaxsim.math import Quaternion, Skew
+from jaxsim.rbda.kinematic_constraints import compute_constraint_wrenches
 
 from .common import VelRepr
 
@@ -18,7 +19,7 @@ def system_acceleration(
     *,
     link_forces: jtp.MatrixLike | None = None,
     joint_torques: jtp.VectorLike | None = None,
-) -> tuple[jtp.Vector, jtp.Vector]:
+) -> tuple[jtp.Vector, jtp.Vector, dict[str, jtp.PyTree]]:
     """
     Compute the system acceleration in the active representation.
 
@@ -31,8 +32,8 @@ def system_acceleration(
         joint_torques: The joint torques applied to the joints.
 
     Returns:
-        A tuple containing the base 6D acceleration in the active representation
-        and the joint accelerations.
+        A tuple containing the base 6D acceleration in the active representation,
+        the joint accelerations, and the contact state.
     """
 
     # ====================
@@ -53,18 +54,53 @@ def system_acceleration(
     W_f_L_terrain = jnp.zeros_like(f_L)
     contact_state_derivative = {}
 
-    if len(model.kin_dyn_parameters.contact_parameters.body) > 0:
+    # Compute the 6D forces W_f ∈ ℝ^{n_L × 6} applied to links due to contact
+    # with the terrain.
+    W_f_L_terrain, contact_state_derivative = js.contact.link_contact_forces(
+        model=model,
+        data=data,
+        link_forces=f_L,
+        joint_torques=joint_torques,
+    )
 
-        # Compute the 6D forces W_f ∈ ℝ^{n_L × 6} applied to links due to contact
-        # with the terrain.
-        W_f_L_terrain, contact_state_derivative = js.contact.link_contact_forces(
-            model=model,
-            data=data,
-            link_forces=f_L,
-            joint_torques=joint_torques,
-        )
+    # ==================================
+    # Compute kinematic constraint forces
+    # ==================================
 
+    # Sum up all the forces: external + contact
     W_f_L_total = f_L + W_f_L_terrain
+
+    # Compute the 6D forces W_f ∈ ℝ^{n_constraints × 2 × 6} applied to links due to
+    # kinematic constraints.
+    W_f_L_constraints = compute_constraint_wrenches(
+        model=model,
+        data=data,
+        link_forces_inertial=W_f_L_total,
+        joint_force_references=joint_torques,
+    )
+
+    # Apply constraint forces to the corresponding links
+    if W_f_L_constraints.shape[0] > 0:
+        # Get the constraint map from the model's kinematic parameters
+        constraint_map = model.kin_dyn_parameters.constraints
+
+        if constraint_map is not None:
+            # Stack the parent link indices for both sides of each constraint
+            parent_indices_flat = jnp.stack(
+                [
+                    constraint_map.parent_link_idxs_1,
+                    constraint_map.parent_link_idxs_2,
+                ],
+                axis=1,
+            ).reshape(-1)
+
+            # Flatten the constraint wrenches to match the flattened parent indices
+            constraint_wrenches_flat = W_f_L_constraints.reshape(-1, 6)
+
+            # Apply constraint wrenches using scatter_add for better performance
+            W_f_L_total = W_f_L_total.at[parent_indices_flat].add(
+                constraint_wrenches_flat
+            )
 
     # Update the contact state data. This is necessary only for the contact models
     # that require propagation and integration of contact state.
@@ -92,7 +128,10 @@ def system_acceleration(
         link_forces=references.link_forces(model=model, data=data),
     )
 
-    return v̇_WB, s̈, contact_state
+    # Combine contact and constraint state information
+    combined_state = contact_state.copy() if contact_state else {}
+
+    return v̇_WB, s̈, combined_state
 
 
 @jax.jit

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -54,14 +54,16 @@ def system_acceleration(
     W_f_L_terrain = jnp.zeros_like(f_L)
     contact_state_derivative = {}
 
-    # Compute the 6D forces W_f ∈ ℝ^{n_L × 6} applied to links due to contact
-    # with the terrain.
-    W_f_L_terrain, contact_state_derivative = js.contact.link_contact_forces(
-        model=model,
-        data=data,
-        link_forces=f_L,
-        joint_torques=joint_torques,
-    )
+    if len(model.kin_dyn_parameters.contact_parameters.body) > 0:
+
+        # Compute the 6D forces W_f ∈ ℝ^{n_L × 6} applied to links due to contact
+        # with the terrain.
+        W_f_L_terrain, contact_state_derivative = js.contact.link_contact_forces(
+            model=model,
+            data=data,
+            link_forces=f_L,
+            joint_torques=joint_torques,
+        )
 
     # ==================================
     # Compute kinematic constraint forces

--- a/src/jaxsim/api/ode.py
+++ b/src/jaxsim/api/ode.py
@@ -86,13 +86,9 @@ def system_acceleration(
 
         if constraint_map is not None:
             # Stack the parent link indices for both sides of each constraint
-            parent_indices_flat = jnp.stack(
-                [
-                    constraint_map.parent_link_idxs_1,
-                    constraint_map.parent_link_idxs_2,
-                ],
-                axis=1,
-            ).reshape(-1)
+            parent_indices_flat = jnp.concatenate(
+                [constraint_map.parent_link_idxs_1, constraint_map.parent_link_idxs_2],
+            )
 
             # Flatten the constraint wrenches to match the flattened parent indices
             constraint_wrenches_flat = W_f_L_constraints.reshape(-1, 6)
@@ -128,10 +124,7 @@ def system_acceleration(
         link_forces=references.link_forces(model=model, data=data),
     )
 
-    # Combine contact and constraint state information
-    combined_state = contact_state.copy() if contact_state else {}
-
-    return v̇_WB, s̈, combined_state
+    return v̇_WB, s̈, contact_state
 
 
 @jax.jit

--- a/src/jaxsim/mujoco/loaders.py
+++ b/src/jaxsim/mujoco/loaders.py
@@ -404,7 +404,7 @@ class RodModelToMjcf:
                     quat=" ".join(map(str, quat)),
                 )
             else:
-                warnings.warn(f"Parent link '{parent_name}' not found", stacklevel=2)
+                logging.debug(f"Parent link '{parent_name}' not found")
 
         # --------------
         # Add the motors

--- a/src/jaxsim/rbda/__init__.py
+++ b/src/jaxsim/rbda/__init__.py
@@ -8,10 +8,5 @@ from .jacobian import (
     jacobian_derivative_full_doubly_left,
     jacobian_full_doubly_left,
 )
-from .kinematic_constraints import (
-    compute_constraint_baumgarte_term,
-    compute_constraint_jacobians,
-    compute_constraint_jacobians_derivative,
-    compute_constraint_transforms,
-)
+from .kinematic_constraints import compute_constraint_wrenches
 from .rnea import rnea

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -12,13 +12,6 @@ import optax
 import jaxsim.api as js
 import jaxsim.typing as jtp
 from jaxsim.api.common import ModelDataWithVelocityRepresentation, VelRepr
-from jaxsim.rbda.kinematic_constraints import (
-    ConstraintMap,
-    compute_constraint_baumgarte_term,
-    compute_constraint_jacobians,
-    compute_constraint_jacobians_derivative,
-    compute_constraint_transforms,
-)
 
 from . import common, soft
 
@@ -352,10 +345,6 @@ class RelaxedRigidContacts(common.ContactModel):
         # collidable points.
         W_H_C = js.contact.transforms(model=model, data=data)
 
-        # Retrieve the kinematic constraints, if any.
-        kin_constraints: ConstraintMap = model.kin_dyn_parameters.constraints
-        n_kin_constraints: int = 6 * kin_constraints.frame_idxs_1.shape[0]
-
         with (
             data.switch_velocity_representation(VelRepr.Mixed),
             references.switch_velocity_representation(VelRepr.Mixed),
@@ -387,92 +376,18 @@ class RelaxedRigidContacts(common.ContactModel):
                 ),
             )
 
-        # Check if there are any kinematic constraints
-        if n_kin_constraints > 0:
-            with (
-                data.switch_velocity_representation(VelRepr.Mixed),
-                references.switch_velocity_representation(VelRepr.Mixed),
-            ):
-                J_constr = jax.vmap(
-                    compute_constraint_jacobians, in_axes=(None, None, 0)
-                )(model, data, kin_constraints)
-
-                J̇_constr = jax.vmap(
-                    compute_constraint_jacobians_derivative, in_axes=(None, None, 0)
-                )(model, data, kin_constraints)
-
-                W_H_constr_pairs = jax.vmap(
-                    compute_constraint_transforms, in_axes=(None, None, 0)
-                )(model, data, kin_constraints)
-
-                constr_baumgarte_term = jnp.ravel(
-                    jax.vmap(
-                        compute_constraint_baumgarte_term,
-                        in_axes=(0, None, 0, 0),
-                    )(
-                        J_constr,
-                        BW_ν,
-                        W_H_constr_pairs,
-                        kin_constraints,
-                    ),
-                )
-
-                J_constr = jnp.vstack(J_constr)
-                J̇_constr = jnp.vstack(J̇_constr)
-
-                R = jnp.diag(jnp.hstack([r, jnp.zeros(n_kin_constraints)]))
-                a_ref = jnp.hstack([a_ref, -constr_baumgarte_term])
-
-                J = jnp.vstack([Jl_WC, J_constr])
-                J̇ = jnp.vstack([J̇l_WC, J̇_constr])
-
-        else:
-            R = jnp.diag(r)
-
-            J = Jl_WC
-            J̇ = J̇l_WC
-
         # Compute the Delassus matrix for contacts (mixed representation).
-        G_contacts = Jl_WC @ jnp.linalg.pinv(M) @ Jl_WC.T
+        M_inv = jnp.linalg.pinv(M)
 
-        # Compute the Delassus matrix for constraints (inertial representation) if constraints exist.
-        with data.switch_velocity_representation(VelRepr.Inertial):
-            if n_kin_constraints > 0:
-                G_constraints = (
-                    J_constr
-                    @ jnp.linalg.pinv(
-                        js.model.free_floating_mass_matrix(
-                            model=model,
-                            data=data,
-                        )
-                    )
-                    @ J_constr.T
-                )
-            else:
-                G_constraints = jnp.zeros((0, 0))
-
-        # Combine the Delassus matrices for contacts and constraints if constraints exist.
-        if G_constraints.shape[0] > 0:
-            G = jnp.block(
-                [
-                    [
-                        G_contacts,
-                        jnp.zeros((G_contacts.shape[0], G_constraints.shape[1])),
-                    ],
-                    [
-                        jnp.zeros((G_constraints.shape[0], G_contacts.shape[1])),
-                        G_constraints,
-                    ],
-                ]
-            )
-        else:
-            G = G_contacts
+        # Compute the Delassus matrix directly using J and J̇.
+        G_contacts = Jl_WC @ M_inv @ Jl_WC.T
 
         # Compute the free mixed linear acceleration of the collidable points.
-        CW_al_free_WC = J @ BW_ν̇_free + J̇ @ BW_ν
+        CW_al_free_WC = Jl_WC @ BW_ν̇_free + J̇l_WC @ BW_ν
 
         # Calculate quantities for the linear optimization problem.
-        A = G + R
+        R = jnp.diag(r)
+        A = G_contacts + R
         b = CW_al_free_WC - a_ref
 
         # Create the objective function to minimize as a lambda computing the cost
@@ -561,9 +476,6 @@ class RelaxedRigidContacts(common.ContactModel):
             )[0]
         )(position, velocity).flatten()
 
-        if n_kin_constraints > 0:
-            init_params = jnp.hstack([init_params, jnp.zeros(n_kin_constraints)])
-
         # Get the solver options.
         solver_options = self.solver_options
 
@@ -589,32 +501,22 @@ class RelaxedRigidContacts(common.ContactModel):
             has_aux=True,
         )
 
-        if n_kin_constraints > 0:
-            # Extract the last n_kin_constr values from the solution and split them into 6D wrenches
-            kin_constr_wrench_inertial = solution[-n_kin_constraints:].reshape(-1, 6)
-
-            # Form an array of tuples with each wrench and its opposite using jax constructs
-            kin_constr_wrench_pairs_inertial = jnp.stack(
-                (kin_constr_wrench_inertial, -kin_constr_wrench_inertial), axis=1
-            )
-
-            # Reshape the optimized solution to be a matrix of 3D contact forces.
-            CW_fl_C = solution[0:-n_kin_constraints].reshape(-1, 3)
-        else:
-            kin_constr_wrench_pairs_inertial = jnp.zeros((0, 2, 6))
-            CW_fl_C = solution.reshape(-1, 3)
+        # Reshape the optimized solution to be a matrix of 3D contact forces.
+        CW_fl_C = solution.reshape(-1, 3)
 
         # Convert the contact forces from mixed to inertial-fixed representation.
-        W_f_C = ModelDataWithVelocityRepresentation.other_representation_to_inertial(
-            array=jnp.zeros((W_H_C.shape[0], 6)).at[:, :3].set(CW_fl_C),
-            transform=W_H_C,
-            other_representation=VelRepr.Mixed,
-            is_force=True,
-        )
+        W_f_C = jax.vmap(
+            lambda CW_fl_C, W_H_C: (
+                ModelDataWithVelocityRepresentation.other_representation_to_inertial(
+                    array=jnp.zeros(6).at[0:3].set(CW_fl_C),
+                    transform=W_H_C,
+                    other_representation=VelRepr.Mixed,
+                    is_force=True,
+                )
+            ),
+        )(CW_fl_C, W_H_C)
 
-        return W_f_C, {
-            "constr_wrenches_inertial": kin_constr_wrench_pairs_inertial,
-        }
+        return W_f_C, {}
 
     @staticmethod
     def _regularizers(

--- a/src/jaxsim/rbda/kinematic_constraints.py
+++ b/src/jaxsim/rbda/kinematic_constraints.py
@@ -1,99 +1,145 @@
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 
 import jaxsim.api as js
 import jaxsim.typing as jtp
-from jaxsim.api.common import VelRepr
+from jaxsim.api.common import ModelDataWithVelocityRepresentation, VelRepr
 from jaxsim.api.kin_dyn_parameters import ConstraintMap
+from jaxsim.math.adjoint import Adjoint
 from jaxsim.math.rotation import Rotation
+from jaxsim.math.transform import Transform
 
 
-def compute_constraint_jacobians(
+def compute_constraint_transforms_batched(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
-    constraint: ConstraintMap,
+    constraints: ConstraintMap,
 ) -> jtp.Matrix:
     """
-    Compute the constraint Jacobian matrix representing the kinematic constraints between two frames.
+    Compute the transformation matrices for kinematic constraints between pairs of frames.
 
     Args:
-        model: The JaxSim model.
-        data: The data of the considered model.
-        constraint: The considered constraint.
+        model: The JaxSim model containing the robot description.
+        data: The model data containing current state information.
+        constraints: The constraint map containing frame indices and parent link information.
 
     Returns:
-        The resulting constraint Jacobian matrix representing the kinematic constraint
-        between the two specified frames, in inertial representation.
+        A matrix with shape (n_constraints, 2, 4, 4) containing the transformation matrices
+        for each constraint pair. The second dimension contains [W_H_F1, W_H_F2] where
+        W_H_F1 and W_H_F2 are the world-to-frame transformation matrices.
     """
+    W_H_L = data._link_transforms
 
-    J_WF1 = js.frame.jacobian(
-        model=model,
-        data=data,
-        frame_index=constraint.frame_idxs_1,
-        output_vel_repr=VelRepr.Inertial,
-    )
-    J_WF2 = js.frame.jacobian(
-        model=model,
-        data=data,
-        frame_index=constraint.frame_idxs_2,
-        output_vel_repr=VelRepr.Inertial,
-    )
+    frame_idxs_1 = constraints.frame_idxs_1
+    frame_idxs_2 = constraints.frame_idxs_2
 
-    return J_WF1 - J_WF2
+    parent_link_idxs_1 = constraints.parent_link_idxs_1
+    parent_link_idxs_2 = constraints.parent_link_idxs_2
+
+    def get_L_H_F(frame_index):
+        # Get the static frame pose wrt the parent link.
+        return model.kin_dyn_parameters.frame_parameters.transform[
+            frame_index - model.number_of_links()
+        ]
+
+    # Vectorize over frame indices
+    L_H_F1 = jax.vmap(get_L_H_F)(frame_idxs_1)
+    L_H_F2 = jax.vmap(get_L_H_F)(frame_idxs_2)
+
+    # Compute the homogeneous transformation matrices for the two frames
+    W_H_F1 = W_H_L[parent_link_idxs_1] @ L_H_F1
+    W_H_F2 = W_H_L[parent_link_idxs_2] @ L_H_F2
+
+    return jnp.stack([W_H_F1, W_H_F2], axis=1)
 
 
-def compute_constraint_jacobians_derivative(
+def compute_constraint_jacobians_batched(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
-    constraint: ConstraintMap,
+    constraints: ConstraintMap,
+    W_H_constraint_pairs: jtp.Matrix,
 ) -> jtp.Matrix:
     """
-    Compute the derivative of the constraint Jacobian matrix representing the kinematic constraints between two frames.
-
+    Compute the constraint Jacobian matrices for kinematic constraints in a batched manner.
     Args:
-        model: The JaxSim model.
-        data: The data of the considered model.
-        constraint: The considered constraint.
+        model: The JaxSim model containing the robot description.
+        data: The model data containing current state information.
+        constraints: The constraint map containing frame indices and parent link information.
+        W_H_constraint_pairs: Transformation matrices for constraint frame pairs with shape
+                              (n_constraints, 2, 4, 4).
 
     Returns:
-        The resulting constraint Jacobian derivative matrix representing the kinematic constraint
-        between the two specified frames, in inertial representation.
+        A matrix with shape (n_constraints, 6, n_dofs) containing the constraint Jacobian
+        matrices.
     """
 
-    J̇_WF1 = js.frame.jacobian_derivative(
-        model=model,
-        data=data,
-        frame_index=constraint.frame_idxs_1,
-        output_vel_repr=VelRepr.Inertial,
-    )
-    J̇_WF2 = js.frame.jacobian_derivative(
-        model=model,
-        data=data,
-        frame_index=constraint.frame_idxs_2,
-        output_vel_repr=VelRepr.Inertial,
+    with data.switch_velocity_representation(VelRepr.Body):
+        # Doubly-left free-floating Jacobian.
+        L_J_WL_B = js.model.generalized_free_floating_jacobian(
+            model=model, data=data, output_vel_repr=VelRepr.Body
+        )
+
+        # Link transforms
+        W_H_L = data._link_transforms
+
+    def compute_frame_jacobian_mixed(L_J_WL, W_H_L, W_H_F, parent_link_index):
+        """Compute the jacobian of a frame in mixed representation."""
+        # Select the jacobian of the parent link
+        L_J_WL = L_J_WL[parent_link_index]
+
+        # Compute the jacobian of the frame in mixed representation
+        W_H_L = W_H_L[parent_link_index]
+        F_H_L = Transform.inverse(W_H_F) @ W_H_L
+        FW_H_F = W_H_F.at[0:3, 3].set(jnp.zeros(3))
+        FW_H_L = FW_H_F @ F_H_L
+        FW_X_L = Adjoint.from_transform(transform=FW_H_L)
+        FW_J_WL = FW_X_L @ L_J_WL
+        O_J_WL_I = FW_J_WL
+
+        return O_J_WL_I
+
+    def compute_constraint_jacobian(L_J_WL, W_H_F, constraint):
+        """Compute the constraint jacobian for a single constraint pair."""
+
+        J_WF1 = compute_frame_jacobian_mixed(
+            L_J_WL, W_H_L, W_H_F[0], constraint.parent_link_idxs_1
+        )
+        J_WF2 = compute_frame_jacobian_mixed(
+            L_J_WL, W_H_L, W_H_F[1], constraint.parent_link_idxs_2
+        )
+
+        return J_WF1 - J_WF2
+
+    # Vectorize the computation of constraint Jacobians
+    constraint_jacobians = jax.vmap(compute_constraint_jacobian, in_axes=(None, 0, 0))(
+        L_J_WL_B, W_H_constraint_pairs, constraints
     )
 
-    return J̇_WF1 - J̇_WF2
+    return constraint_jacobians
 
 
 def compute_constraint_baumgarte_term(
     J_constr: jtp.Matrix,
     nu: jtp.Vector,
-    W_H_F_constr: tuple[jtp.Matrix, jtp.Matrix],
+    W_H_F_constr: jtp.Matrix,
     constraint: ConstraintMap,
 ) -> jtp.Vector:
     """
     Compute the Baumgarte stabilization term for kinematic constraints.
 
+    The Baumgarte stabilization method is used to stabilize constraint violations
+    by adding proportional and derivative terms to the constraint equation. This
+    helps prevent constraint drift and improves numerical stability.
+
     Args:
-        J_constr: The constraint Jacobian matrix.
-        nu: The generalized velocity vector.
-        W_H_F_constr: A tuple containing the homogeneous transformation matrices
-            of two frames (W_H_F1 and W_H_F2) with respect to the world frame.
-        K_P: The proportional gain for position and orientation error correction.
-        K_D: The derivative gain for velocity error correction.
-        constraint: The considered constraint.
+        J_constr: The constraint Jacobian matrix with shape (6, n_dofs).
+        nu: The generalized velocity vector with shape (n_dofs,).
+        W_H_F_constr: Array containing the homogeneous transformation matrices
+                      of two frames [W_H_F1, W_H_F2] with respect to the world frame,
+                      with shape (2, 4, 4).
+        constraint: The constraint object containing stabilization gains K_P and K_D.
 
     Returns:
         The computed Baumgarte stabilization term.
@@ -121,28 +167,180 @@ def compute_constraint_baumgarte_term(
     return baumgarte_term
 
 
-def compute_constraint_transforms(
+@jax.jit
+@js.common.named_scope
+def compute_constraint_wrenches(
     model: js.model.JaxSimModel,
     data: js.data.JaxSimModelData,
-    constraint: ConstraintMap,
+    *,
+    joint_force_references: jtp.VectorLike | None = None,
+    link_forces_inertial: jtp.MatrixLike | None = None,
+    regularization: jtp.Float = 1e-3,
 ) -> jtp.Matrix:
     """
-    Compute the transformation matrices for a given kinematic constraint between two frames.
+    Compute the constraint wrenches for kinematic constraints.
+
+    This function solves the constraint forces needed to satisfy kinematic constraints
+    between pairs of frames. It uses the Baumgarte stabilization method and computes
+    the constraint wrenches in inertial representation.
 
     Args:
         model: The JaxSim model.
-        data: The data of the considered model.
-        constraint: The considered constraint.
+        data: The model data.
+        joint_force_references: Optional joint force/torque references to apply. If None,
+                               zero forces are used.
+        link_forces_inertial: Optional link forces applied in inertial representation.
+                             If None, zero forces are used.
+        regularization: Regularization parameter for the constraint solver to improve
+                       numerical stability. Default is 1e-3.
 
     Returns:
-        A matrix containing the tuple of transformation matrices of the two frames.
+        Array with shape (n_constraints, 2, 6) containing constraint wrench pairs
+        in inertial representation. Each constraint produces two equal and opposite
+        wrenches applied to the constrained frames.
     """
 
-    W_H_F1 = js.frame.transform(
-        model=model, data=data, frame_index=constraint.frame_idxs_1
-    )
-    W_H_F2 = js.frame.transform(
-        model=model, data=data, frame_index=constraint.frame_idxs_2
+    # Retrieve the kinematic constraints, if any.
+    kin_constraints = model.kin_dyn_parameters.constraints
+
+    n_kin_constraints = (
+        0
+        if (kin_constraints is None) or (kin_constraints.frame_idxs_1.shape[0] == 0)
+        else 6 * kin_constraints.frame_idxs_1.shape[0]
     )
 
-    return jnp.array((W_H_F1, W_H_F2))
+    # Return empty results if no constraints exist
+    if n_kin_constraints == 0:
+        return jnp.zeros((0, 2, 6))
+
+    # Build joint forces if not provided
+    τ_references = (
+        jnp.asarray(joint_force_references, dtype=float)
+        if joint_force_references is not None
+        else jnp.zeros_like(data.joint_positions)
+    )
+
+    # Build link forces if not provided
+    W_f_L = (
+        jnp.atleast_2d(jnp.array(link_forces_inertial).squeeze())
+        if link_forces_inertial is not None
+        else jnp.zeros((model.number_of_links(), 6))
+    ).astype(float)
+
+    # Create references object for handling different velocity representations
+    references = js.references.JaxSimModelReferences.build(
+        model=model,
+        joint_force_references=τ_references,
+        link_forces=W_f_L,
+        velocity_representation=VelRepr.Inertial,
+    )
+
+    with (
+        data.switch_velocity_representation(VelRepr.Mixed),
+        references.switch_velocity_representation(VelRepr.Mixed),
+    ):
+        BW_ν = data.generalized_velocity
+
+        # Compute free acceleration without constraints
+        BW_ν̇_free = jnp.hstack(
+            js.model.forward_dynamics_aba(
+                model=model,
+                data=data,
+                link_forces=references.link_forces(model=model, data=data),
+                joint_forces=references.joint_force_references(model=model),
+            )
+        )
+
+        # Compute mass matrix
+        M = js.model.free_floating_mass_matrix(model=model, data=data)
+
+        W_H_constr_pairs = compute_constraint_transforms_batched(
+            model=model,
+            data=data,
+            constraints=kin_constraints,
+        )
+
+        # Compute constraint jacobians
+        J_constr = compute_constraint_jacobians_batched(
+            model=model,
+            data=data,
+            constraints=kin_constraints,
+            W_H_constraint_pairs=W_H_constr_pairs,
+        )
+
+        # Compute Baumgarte stabilization term
+        constr_baumgarte_term = jnp.ravel(
+            jax.vmap(
+                compute_constraint_baumgarte_term,
+                in_axes=(0, None, 0, 0),
+            )(
+                J_constr,
+                BW_ν,
+                W_H_constr_pairs,
+                kin_constraints,
+            ),
+        )
+
+        # Stack constraint jacobians
+        J_constr = jnp.vstack(J_constr)
+
+        # Compute Delassus matrix for constraints
+        G_constraints = J_constr @ jnp.linalg.solve(M, J_constr.T)
+
+        # Compute constraint acceleration
+        # TODO: add J̇_constr with efficient computation
+        CW_al_free_constr = J_constr @ BW_ν̇_free
+
+        # Setup constraint optimization problem
+        constraint_regularization = regularization * jnp.ones(n_kin_constraints)
+        R = jnp.diag(constraint_regularization)
+        A = G_constraints + R
+        b = CW_al_free_constr + constr_baumgarte_term
+
+        # Solve for constraint forces
+        kin_constr_wrench_mixed = jnp.linalg.solve(A, -b).reshape(-1, 6)
+
+        # Convert wrenches in inertial representation
+
+    def transform_wrenches_to_inertial(wrench, transform_pair):
+        """
+        Transform wrench pairs in inertial representation.
+
+        Args:
+            wrench: Wrench vector with shape (6).
+            transform_pair: Pair of transformation matrices [W_H_F1, W_H_F2]
+                           with shape (2, 4, 4).
+
+        Returns:
+            Stack of transformed wrenches with shape (2, 6).
+        """
+        W_H_F1, W_H_F2 = transform_pair[0], transform_pair[1]
+        wrench_F1 = wrench
+        wrench_F2 = -wrench
+
+        # Create wrench pair directly
+        # Transform both at once
+        wrench_F1_inertial = (
+            ModelDataWithVelocityRepresentation.other_representation_to_inertial(
+                array=wrench_F1,
+                transform=W_H_F1,
+                other_representation=VelRepr.Mixed,
+                is_force=True,
+            )
+        )
+        wrench_F2_inertial = (
+            ModelDataWithVelocityRepresentation.other_representation_to_inertial(
+                array=wrench_F2,
+                transform=W_H_F2,
+                other_representation=VelRepr.Mixed,
+                is_force=True,
+            )
+        )
+
+        return jnp.stack([wrench_F1_inertial, wrench_F2_inertial])
+
+    kin_constr_wrench_pairs_inertial = jax.vmap(transform_wrenches_to_inertial)(
+        kin_constr_wrench_mixed, W_H_constr_pairs
+    )
+
+    return kin_constr_wrench_pairs_inertial

--- a/tests/assets/4_bar_opened.urdf
+++ b/tests/assets/4_bar_opened.urdf
@@ -1,0 +1,137 @@
+<robot name="4_bar_opened">
+    <!-- Link AB -->
+    <link name="AB">
+        <inertial>
+            <mass value="1.0" />
+            <inertia ixx="0.02167" iyy="0.00167" izz="0.02167" ixy="0.0" ixz="0.0" iyz="0.0" />
+        </inertial>
+        <visual>
+            <geometry>
+                <box size="0.1 0.5 0.1" />
+            </geometry>
+        </visual>
+    </link>
+
+    <!-- Link BC1 -->
+    <link name="BC1">
+        <inertial>
+            <origin xyz="0 0.125 0" rpy="0 0 0" />
+            <mass value="0.5" />
+            <inertia ixx="0.010835" iyy="0.000835" izz="0.010835" ixy="0.0" ixz="0.0" iyz="0.0" />
+        </inertial>
+        <visual>
+            <origin xyz="0 0.125 0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1 0.25 0.1" />
+            </geometry>
+        </visual>
+    </link>
+
+    <!-- Frame at the end of BC1 -->
+    <link name="BC1_frame" />
+
+    <joint name="BC1_frame_joint" type="fixed">
+        <parent link="BC1" />
+        <child link="BC1_frame" />
+        <origin xyz="0 0.25 0" rpy="0 0 0" />
+    </joint>
+
+    <!-- Link BC2 -->
+    <link name="BC2">
+        <inertial>
+            <origin xyz="0 0.125 0" rpy="0 0 0" />
+            <mass value="0.5" />
+            <inertia ixx="0.010835" iyy="0.000835" izz="0.010835" ixy="0.0" ixz="0.0" iyz="0.0" />
+        </inertial>
+        <visual>
+            <origin xyz="0 0.125 0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1 0.25 0.1" /> <!-- Dummy frame link -->
+            </geometry>
+        </visual>
+    </link>
+
+    <!-- Frame at the end of BC2 -->
+    <link name="BC2_frame" />
+
+    <joint name="BC2_frame_joint" type="fixed">
+        <parent link="BC2" />
+        <child link="BC2_frame" />
+        <origin xyz="0 0.25 0" rpy="0 0 3.1416" />
+    </joint>
+
+    <!-- Link CD -->
+    <link name="CD">
+        <inertial>
+            <origin xyz="0 0.25 0" rpy="0 0 0" />
+            <mass value="1.0" />
+            <inertia ixx="0.02167" iyy="0.00167" izz="0.02167" ixy="0.0" ixz="0.0" iyz="0.0" />
+        </inertial>
+        <visual>
+            <origin xyz="0 0.25 0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1 0.5 0.1" />
+            </geometry>
+            <material name="Cyan">
+                <color rgba="0 1.0 1.0 1.0" />
+            </material>
+        </visual>
+        <collision>
+            <origin xyz="0 0.25 0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1 0.5 0.1" />
+            </geometry>
+        </collision>
+    </link>
+
+    <!-- Link DA -->
+    <link name="DA">
+        <inertial>
+            <origin xyz="0 0.25 0" rpy="0 0 0" />
+            <mass value="1.0" />
+            <inertia ixx="0.02167" iyy="0.00167" izz="0.02167" ixy="0.0" ixz="0.0" iyz="0.0" />
+        </inertial>
+        <visual>
+            <origin xyz="0 0.25 0" rpy="0 0 0" />
+            <geometry>
+                <box size="0.1 0.5 0.1" />
+            </geometry>
+        </visual>
+    </link>
+
+    <!-- Joint B -->
+    <joint name="B" type="revolute">
+        <parent link="AB" />
+        <child link="BC1" />
+        <origin xyz="0 -0.25 0" rpy="0 0 1.57" />
+        <axis xyz="0 0 1" />
+        <limit lower="-1.57" upper="1.57" effort="30" velocity="1.0" />
+    </joint>
+
+    <!-- Joint C -->
+    <joint name="C" type="revolute">
+        <parent link="CD" />
+        <child link="BC2" />
+        <origin xyz="0 0.5 0" rpy="0 0 1.57" />
+        <axis xyz="0 0 1" />
+        <limit lower="-1.57" upper="1.57" effort="30" velocity="1.0" />
+    </joint>
+
+    <!-- Joint D -->
+    <joint name="D" type="revolute">
+        <parent link="DA" />
+        <child link="CD" />
+        <origin xyz="0 0.5 0" rpy="0 0 1.57" />
+        <axis xyz="0 0 1" />
+        <limit lower="-1.57" upper="1.57" effort="30" velocity="1.0" />
+    </joint>
+
+    <!-- Joint A -->
+    <joint name="A" type="revolute">
+        <parent link="AB" />
+        <child link="DA" />
+        <origin xyz="0 0.25 0" rpy="0 0 1.57" />
+        <axis xyz="0 0 1" />
+        <limit lower="-1.57" upper="1.57" effort="30" velocity="1.0" />
+    </joint>
+</robot>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -741,6 +741,22 @@ def jaxsim_model_cartpole() -> js.model.JaxSimModel:
     return model
 
 
+@pytest.fixture(scope="session")
+def jaxsim_model_4_bar_linkage() -> js.model.JaxSimModel:
+    """
+    Fixture providing the JaxSim model of a 4-bar linkage (opened configuration).
+
+    Returns:
+        The JaxSim model of the 4-bar linkage.
+    """
+
+    model_path = pathlib.Path(__file__).parent / "assets" / "4_bar_opened.urdf"
+    rod_model = load_model_from_file(model_path, is_urdf=True)
+    model = build_jaxsim_model(model_description=rod_model)
+
+    return model
+
+
 # ============================
 # Collections of JaxSim models
 # ============================

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -607,7 +607,7 @@ def test_simulation_with_kinematic_constraints_4_bar_linkage(
     pos1 = H_frame1[:3, 3]
     pos2 = H_frame2[:3, 3]
     assert pos1 == pytest.approx(
-        pos2, abs=1e-3
+        pos2, abs=1e-6
     ), f"Frame position mismatch. pos1={pos1}, pos2={pos2}, diff={pos1 - pos2}"
 
     # Orientation check


### PR DESCRIPTION
This PR refactors the handling of kinematic constraints and contact forces, by decoupling a particular contact model to be able to also compute contact forces. 

The main changes include shifting kinematic constraint force computation to the ODE system level, and optimizing how constraint forces are applied to links. Additionally, the constraint map now precomputes parent link indices for efficiency.

One additional change is the fact that due to inefficiencies in  `frame` API (see #451 ) there's some code duplication inside `kineamatic_constraint.py` to exploit data reuse and improve performances. Once #451 will be addressed, the code can be further simplified.


<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--452.org.readthedocs.build//452/

<!-- readthedocs-preview jaxsim end -->