### PR TITLE
Make `pixi.lock` updates be authored by Github Actions Bot

### DIFF
--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -55,3 +55,5 @@ jobs:
           labels: pixi
           add-paths: pixi.lock
           delete-branch: true
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
This PR ensures that the committer and the author of the `pixi.lock` updates is Github Actions Bot. (See https://github.com/peter-evans/create-pull-request/issues/3317)

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--456.org.readthedocs.build//456/

<!-- readthedocs-preview jaxsim end -->