### PR TITLE
Activate warmup run by default for benchmarks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ no-build-isolation = ["jaxsim"]
 
 [tool.pixi.feature.test.tasks]
 pipcheck = "pip check"
-benchmark = { cmd = "pytest --benchmark-only", depends-on = ["pipcheck"] }
+benchmark = { cmd = "pytest --benchmark-only --benchmark-warmup=ON", depends-on = ["pipcheck"] }
 lint = { cmd = "pre-commit run --all-files --hook-stage=manual" }
 test = { cmd = "pytest", depends-on = ["pipcheck"] }
 


### PR DESCRIPTION
This PR enables by default the warmup runs for `pytest-benchmark`. (see https://pytest-benchmark.readthedocs.io/en/latest/usage.html)