### PR TITLE
Update bots name to be excluded from releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,6 @@
 changelog:
   exclude:
     authors:
-      - dependabot
-      - pre-commit-ci
-      - github-actions
+      - dependabot[bot]
+      - pre-commit-ci[bot]
+      - github-actions[bot]


### PR DESCRIPTION
This PR updates bots name to be excluded from release notes

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--461.org.readthedocs.build//461/

<!-- readthedocs-preview jaxsim end -->