### PR TITLE
Add gazebo installation instruction for pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ If you need URDF support, follow the [official instructions](https://gazebosim.o
 making sure to obtain `sdformat ≥ 13.0` and `gz-tools ≥ 2.0`.
 
 You don't need to install the entire Gazebo Sim suite.
-For example, on Ubuntu, you can only install the `libsdformat13 gz-tools2` packages.
+For example, on Ubuntu, it is sufficient to install the `libsdformat*` and `gz-tools2` packages.
 
 If you need GPU support, follow the official [installation instructions][jax_gpu] of JAX.
 


### PR DESCRIPTION
Since we need gazebo sim for urdf support and to run the provided example, I add info on how to install it via pip. 

The instructions have been taken directly from [ROD](https://github.com/ami-iit/rod) since is the library that needs it

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--467.org.readthedocs.build//467/

<!-- readthedocs-preview jaxsim end -->