### PR TITLE
Improve gradient stability for dynamics computations

### DIFF
--- a/src/jaxsim/__init__.py
+++ b/src/jaxsim/__init__.py
@@ -20,7 +20,7 @@ def _jnp_options() -> None:
 
     # Notify the user if unsupported 64-bit precision was enforced on TPU.
     if (is_tpu or is_metal) and use_x64:
-        msg = f"64-bit precision is not allowed on {jax.devices()[0].platform.upper}. Enforcing 32bit precision."
+        msg = f"64-bit precision is not allowed on {jax.devices()[0].platform.upper()}. Enforcing 32bit precision."
         logging.warning(msg)
         use_x64 = False
 
@@ -36,9 +36,7 @@ def _jnp_options() -> None:
 
     # Warn about experimental usage of 32-bit precision.
     else:
-        logging.warning(
-            "Using 32-bit precision in JaxSim is still experimental, please avoid to use variable step integrators."
-        )
+        logging.warning("Using 32-bit precision in JaxSim is still experimental.")
 
 
 def _np_options() -> None:

--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -281,9 +281,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
         # we introduce a Baumgarte stabilization to let the quaternion converge to
         # a unit quaternion. In this case, it is not guaranteed that the quaternion
         # stored in the state is a unit quaternion.
-        norm = jaxsim.math.safe_norm(W_Q_B, axis=-1, keepdims=True)
-        W_Q_B = W_Q_B / (norm + jnp.finfo(float).eps * (norm == 0))
-        return W_Q_B
+        return jaxsim.math.normalize_quaternion(W_Q_B)
 
     @property
     def base_velocity(self) -> jtp.Vector:
@@ -370,10 +368,9 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             The updated `JaxSimModelData` object.
         """
 
-        W_Q_B = jnp.array(base_quaternion, dtype=float)
-
-        norm = jaxsim.math.safe_norm(W_Q_B, axis=-1)
-        W_Q_B = W_Q_B / (norm + jnp.finfo(float).eps * (norm == 0))
+        W_Q_B = jaxsim.math.normalize_quaternion(
+            jnp.array(base_quaternion, dtype=float)
+        )
 
         return self.replace(model=model, base_quaternion=W_Q_B)
 
@@ -432,12 +429,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             contact_state = self.contact_state
 
         # Normalize the quaternion to avoid numerical issues.
-        base_quaternion_norm = jaxsim.math.safe_norm(
-            base_quaternion, axis=-1, keepdims=True
-        )
-        base_quaternion = base_quaternion / jnp.where(
-            base_quaternion_norm == 0, 1.0, base_quaternion_norm
-        )
+        base_quaternion = jaxsim.math.normalize_quaternion(base_quaternion)
 
         joint_positions = jnp.atleast_2d(joint_positions.squeeze()).astype(float)
         joint_velocities = jnp.atleast_2d(joint_velocities.squeeze()).astype(float)

--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -58,9 +58,7 @@ def semi_implicit_euler_integration(
         W_p_B = data.base_position + dt * W_ṗ_B
         W_Q_B = data.base_orientation + dt * W_Q̇_B
 
-        base_quaternion_norm = jaxsim.math.safe_norm(W_Q_B, axis=-1)
-
-        W_Q_B = W_Q_B / jnp.where(base_quaternion_norm == 0, 1.0, base_quaternion_norm)
+        W_Q_B = jaxsim.math.normalize_quaternion(W_Q_B)
 
         s = data.joint_positions + dt * ṡ
 
@@ -111,10 +109,7 @@ def rk4_integration(
                 joint_torques=joint_torques,
             )
 
-    base_quaternion_norm = jaxsim.math.safe_norm(data._base_quaternion, axis=-1)
-    base_quaternion = data._base_quaternion / jnp.where(
-        base_quaternion_norm == 0, 1.0, base_quaternion_norm
-    )
+    base_quaternion = jaxsim.math.normalize_quaternion(data._base_quaternion)
 
     x_t0 = dict(
         base_position=data._base_position,
@@ -218,10 +213,7 @@ def rk4fast_integration(
             contact_state=data_ti.contact_state,
         )
 
-    base_quaternion_norm = jaxsim.math.safe_norm(data._base_quaternion, axis=-1)
-    base_quaternion = data._base_quaternion / jnp.where(
-        base_quaternion_norm == 0, 1.0, base_quaternion_norm
-    )
+    base_quaternion = jaxsim.math.normalize_quaternion(data._base_quaternion)
 
     x_t0 = dict(
         base_position=data._base_position,

--- a/src/jaxsim/math/__init__.py
+++ b/src/jaxsim/math/__init__.py
@@ -4,7 +4,7 @@ from .inertia import Inertia
 from .linalg import safe_inv, safe_lstsq, spd_solve, standard_solve
 from .quaternion import Quaternion
 from .rotation import Rotation
-from .safe import normalize_quaternion, safe_divide, safe_normalize
+from .safe import normalize_quaternion, safe_divide, safe_normalize, smooth_relu
 from .skew import Skew
 from .transform import Transform
 from .utils import safe_norm

--- a/src/jaxsim/math/__init__.py
+++ b/src/jaxsim/math/__init__.py
@@ -1,8 +1,10 @@
 from .adjoint import Adjoint
 from .cross import Cross
 from .inertia import Inertia
+from .linalg import safe_inv, safe_lstsq, spd_solve, standard_solve
 from .quaternion import Quaternion
 from .rotation import Rotation
+from .safe import normalize_quaternion, safe_divide, safe_normalize
 from .skew import Skew
 from .transform import Transform
 from .utils import safe_norm

--- a/src/jaxsim/math/linalg.py
+++ b/src/jaxsim/math/linalg.py
@@ -1,0 +1,326 @@
+import functools
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+
+import jaxsim.typing as jtp
+
+
+def _get_eps(dtype: jnp.dtype) -> float:
+    """Get appropriate epsilon for regularization based on dtype."""
+    return jnp.finfo(dtype).eps ** 0.5
+
+
+# =================================================
+# Symmetric Positive-Definite Solve with Custom JVP
+# =================================================
+
+
+@functools.partial(jax.custom_jvp, nondiff_argnums=(2, 3))
+def spd_solve(
+    A: jtp.Matrix,
+    b: jtp.Array,
+    regularization: float | None = None,
+    solver: Literal["cholesky", "lu"] = "cholesky",
+) -> jtp.Array:
+    """
+    Solve a linear system Ax = b where A is SPD.
+
+    This uses Cholesky decomposition by default. It includes automatic
+    regularization to handle near-singular matrices in float32.
+
+    Args:
+        A: Symmetric positive-definite matrix of shape (n, n).
+        b: Right-hand side vector of shape (n,) or matrix of shape (n, m).
+        regularization: Optional regularization to add to diagonal. If None,
+            uses dtype-appropriate default.
+        solver: Solver method - "cholesky" (default) or "lu".
+
+    Returns:
+        Solution x such that Ax = b.
+    """
+    return _spd_solve_impl(A, b, regularization, solver)
+
+
+def _spd_solve_impl(
+    A: jtp.Matrix,
+    b: jtp.Array,
+    regularization: float | None,
+    solver: Literal["cholesky", "lu"],
+) -> jtp.Array:
+
+    dtype = A.dtype
+
+    # Apply regularization if specified or use default for float32
+    if regularization is not None:
+        A_reg = A + regularization * jnp.eye(A.shape[0], dtype=dtype)
+    elif dtype == jnp.float32:
+        # Auto-regularize for float32 to improve stability
+        eps = _get_eps(dtype)
+        A_reg = A + eps * jnp.trace(A) / A.shape[0] * jnp.eye(A.shape[0], dtype=dtype)
+    else:
+        A_reg = A
+
+    if solver == "cholesky":
+
+        # Cholesky decomposition: A = L @ L.T
+        L = jax.scipy.linalg.cholesky(A_reg, lower=True)
+
+        # Solve L @ y = b, then L.T @ x = y
+        y = jax.scipy.linalg.solve_triangular(L, b, lower=True)
+        x = jax.scipy.linalg.solve_triangular(L.T, y, lower=False)
+
+        # Iterative refinement for float32 reusing L factorization
+        def chol_refinement_body(carry, _):
+            x_curr, L_fac, A_mat, b_vec = carry
+            residual = b_vec - A_mat @ x_curr
+            y = jax.scipy.linalg.solve_triangular(L_fac, residual, lower=True)
+            correction = jax.scipy.linalg.solve_triangular(L_fac.T, y, lower=False)
+            x_next = x_curr + correction
+            return (x_next, L_fac, A_mat, b_vec), None
+
+        if dtype == jnp.float32:
+            (x, _, _, _), _ = jax.lax.scan(
+                chol_refinement_body, (x, L, A_reg, b), jnp.arange(1)
+            )
+    else:
+        # Fall back to LU decomposition
+        x = jnp.linalg.solve(A_reg, b)
+
+        # Iterative refinement for float32 using standard solve
+        def lu_refinement_body(carry, _):
+            x_curr, A_mat, b_vec = carry
+            residual = b_vec - A_mat @ x_curr
+            correction = jnp.linalg.solve(A_mat, residual)
+            x_next = x_curr + correction
+            return (x_next, A_mat, b_vec), None
+
+        if dtype == jnp.float32:
+            (x, _, _), _ = jax.lax.scan(
+                lu_refinement_body, (x, A_reg, b), jnp.arange(1)
+            )
+
+    return x
+
+
+@spd_solve.defjvp
+def _spd_solve_jvp(regularization, solver, primals, tangents):
+    """
+    Use custom JVP for SPD solve using implicit differentiation.
+
+    For Ax = b, the derivatives are:
+        dx = A^{-1} @ (db - dA @ x)
+
+    This is more efficient than the default JVP because we reuse the
+    factorization from the forward pass.
+    """
+    A, b = primals
+    dA, db = tangents
+
+    # Forward pass
+    x = _spd_solve_impl(A, b, regularization, solver)
+
+    # Compute tangent using implicit differentiation
+    # dx = A^{-1} @ (db - dA @ x)
+    rhs = db - dA @ x
+    dx = _spd_solve_impl(A, rhs, regularization, solver)
+
+    return x, dx
+
+
+# =================================================
+# Standard Solve with Regularization and Custom JVP
+# =================================================
+
+
+@functools.partial(jax.custom_jvp, nondiff_argnums=(2,))
+def standard_solve(
+    A: jtp.Matrix,
+    b: jtp.Array,
+    regularization: float | None = None,
+) -> jtp.Array:
+    """
+    Solve a linear system Ax = b with optional regularization.
+
+    This is a general-purpose solver that handles non-SPD matrices.
+    For SPD matrices, use `spd_solve` instead for better performance.
+
+    Args:
+        A: Square matrix of shape (n, n).
+        b: Right-hand side vector of shape (n,) or matrix of shape (n, m).
+        regularization: Optional regularization to add to diagonal.
+
+    Returns:
+        Solution x such that Ax = b.
+    """
+    return _standard_solve_impl(A, b, regularization)
+
+
+def _standard_solve_impl(
+    A: jtp.Matrix,
+    b: jtp.Array,
+    regularization: float | None,
+) -> jtp.Array:
+    """Use iterative refinement for float32 of standard solve."""
+    dtype = A.dtype
+
+    if regularization is not None:
+        A_reg = A + regularization * jnp.eye(A.shape[0], dtype=dtype)
+    elif dtype == jnp.float32:
+        # Auto-regularize for float32
+        eps = _get_eps(dtype)
+        A_reg = A + eps * jnp.eye(A.shape[0], dtype=dtype)
+    else:
+        A_reg = A
+
+    # Initial solve
+    x = jnp.linalg.solve(A_reg, b)
+
+    # Iterative refinement for float32 using JIT-compatible loop
+    def refinement_step(i, x_carry):
+        residual = b - A_reg @ x_carry
+        correction = jnp.linalg.solve(A_reg, residual)
+        return x_carry + correction
+
+    # Apply refinement iteration for float32
+    x = jax.lax.cond(
+        dtype == jnp.float32,
+        lambda x: jax.lax.fori_loop(0, 1, refinement_step, x),
+        lambda x: x,
+        x,
+    )
+
+    return x
+
+
+@standard_solve.defjvp
+def _standard_solve_jvp(regularization, primals, tangents):
+    """Use custom JVP for standard solve using implicit differentiation."""
+    A, b = primals
+    dA, db = tangents
+
+    x = _standard_solve_impl(A, b, regularization)
+    rhs = db - dA @ x
+    dx = _standard_solve_impl(A, rhs, regularization)
+
+    return x, dx
+
+
+# ===================================
+# Safe Matrix Inverse with Custom JVP
+# ===================================
+
+
+@functools.partial(jax.custom_jvp, nondiff_argnums=(1,))
+def safe_inv(
+    A: jtp.Matrix,
+    regularization: float | None = None,
+) -> jtp.Matrix:
+    """
+    Compute the inverse of a matrix with optional regularization.
+
+    Args:
+        A: Square matrix of shape (n, n).
+        regularization: Optional regularization to add to diagonal.
+
+    Returns:
+        Inverse of A.
+    """
+    return _safe_inv_impl(A, regularization)
+
+
+def _safe_inv_impl(
+    A: jtp.Matrix,
+    regularization: float | None,
+) -> jtp.Matrix:
+
+    dtype = A.dtype
+
+    if regularization is not None:
+        A = A + regularization * jnp.eye(A.shape[0], dtype=dtype)
+    elif dtype == jnp.float32:
+        eps = _get_eps(dtype)
+        A = A + eps * jnp.eye(A.shape[0], dtype=dtype)
+
+    return jnp.linalg.inv(A)
+
+
+@safe_inv.defjvp
+def _safe_inv_jvp(regularization, primals, tangents):
+    """
+    Use custom JVP for matrix inverse.
+
+    For A^{-1}, the derivative is:
+        d(A^{-1}) = -A^{-1} @ dA @ A^{-1}
+    """
+    (A,) = primals
+    (dA,) = tangents
+
+    A_inv = _safe_inv_impl(A, regularization)
+    dA_inv = -A_inv @ dA @ A_inv
+
+    return A_inv, dA_inv
+
+
+# ==================================
+# Safe Least Squares with Custom JVP
+# ==================================
+
+
+@functools.partial(jax.custom_jvp, nondiff_argnums=(2,))
+def safe_lstsq(
+    A: jtp.Matrix,
+    b: jtp.Array,
+    rcond: float | None = None,
+) -> jtp.Array:
+    """
+    Solve a least-squares problem min ||Ax - b||_2.
+
+    This provides a numerically stable least-squares solver with a custom JVP
+    for efficient differentiation.
+
+    Args:
+        A: Matrix of shape (m, n).
+        b: Right-hand side vector of shape (m,) or matrix of shape (m, k).
+        rcond: Cut-off ratio for small singular values. If None, uses
+            dtype-appropriate default.
+
+    Returns:
+        Least-squares solution x.
+    """
+    return _safe_lstsq_impl(A, b, rcond)
+
+
+def _safe_lstsq_impl(
+    A: jtp.Matrix,
+    b: jtp.Array,
+    rcond: float | None,
+) -> jtp.Array:
+    dtype = A.dtype
+
+    if rcond is None:
+        rcond = _get_eps(dtype) * max(A.shape)
+
+    x, _, _, _ = jnp.linalg.lstsq(A, b, rcond=rcond)
+    return x
+
+
+@safe_lstsq.defjvp
+def _safe_lstsq_jvp(rcond, primals, tangents):
+    """
+    Use pseudo-inverse based differentiation on custom JVP for least squares.
+    """
+    A, b = primals
+    dA, db = tangents
+
+    x = _safe_lstsq_impl(A, b, rcond)
+
+    # Compute pseudo-inverse of A
+    dtype = A.dtype
+    actual_rcond = rcond if rcond is not None else _get_eps(dtype) * max(A.shape)
+    A_pinv = jnp.linalg.pinv(A, rcond=actual_rcond)
+
+    dx = A_pinv @ (db - dA @ x)
+
+    return x, dx

--- a/src/jaxsim/math/rotation.py
+++ b/src/jaxsim/math/rotation.py
@@ -3,6 +3,7 @@ import jaxlie
 
 import jaxsim.typing as jtp
 
+from .safe import safe_normalize
 from .skew import Skew
 from .utils import safe_norm
 
@@ -75,8 +76,7 @@ class Rotation:
 
         c1 = 2 * jnp.sin(theta / 2.0) ** 2
 
-        safe_theta = jnp.where(theta == 0, 1.0, theta)
-        u = vector / safe_theta
+        u, _ = safe_normalize(vector)
         u = jnp.vstack(u.squeeze())
 
         R = c * jnp.eye(3) - s * Skew.wedge(u) + c1 * u @ u.T

--- a/src/jaxsim/math/safe.py
+++ b/src/jaxsim/math/safe.py
@@ -1,0 +1,285 @@
+"""Gradient-safe math primitives with custom JVP rules."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+import jaxsim.typing as jtp
+
+# ===========================
+# smooth_relu with custom JVP
+# ===========================
+
+
+def smooth_relu(
+    x: jtp.ArrayLike,
+    *,
+    transition_width: float = 1e-4,
+) -> jtp.Array:
+    """
+    ReLU (max(0, x)) with an exact forward pass but a sigmoid-smoothed gradient.
+
+    The forward output is identical to ``jnp.maximum(0, x)``. The custom JVP
+    replaces the step-function sub-gradient with a sigmoid of configurable width,
+    eliminating the gradient discontinuity at x = 0. This is particularly useful
+    for contact penetration depth, where the hard step produces gradient jumps
+    of several orders of magnitude at the contact surface.
+
+    Args:
+        x: Input array.
+        transition_width:
+            Width of the smooth gradient transition zone around zero (in the
+            same units as *x*).  Default 1e-4 (0.1 mm for SI contact problems).
+
+    Returns:
+        ``max(0, x)`` with a smooth gradient.
+    """
+
+    if transition_width <= 0:
+        raise ValueError(
+            f"transition_width must be strictly positive, got {transition_width}"
+        )
+
+    return _make_smooth_relu(transition_width)(jnp.asarray(x))
+
+
+def _make_smooth_relu(transition_width):
+
+    @jax.custom_jvp
+    def _smooth_relu(x):
+        return jnp.maximum(0.0, x)
+
+    @_smooth_relu.defjvp
+    def _smooth_relu_jvp(primals, tangents):
+        (x,) = primals
+        (x_dot,) = tangents
+
+        primal_out = jnp.maximum(0.0, x)
+
+        # Sigmoid-smoothed gradient: converges to step(x) as width → 0.
+        beta = 1.0 / transition_width
+        tangent_out = jax.nn.sigmoid(x * beta) * x_dot
+
+        return primal_out, tangent_out
+
+    return _smooth_relu
+
+
+def safe_divide(
+    numerator: jtp.ArrayLike,
+    denominator: jtp.ArrayLike,
+    *,
+    default: jtp.ArrayLike | float = 0.0,
+    min_denominator: jtp.FloatLike | None = None,
+) -> jtp.Array:
+    """
+    Divide two arrays while guarding small denominators.
+
+    Args:
+        numerator: The numerator.
+        denominator: The denominator.
+        default: The value returned when the denominator is too small.
+        min_denominator:
+            The minimum absolute denominator considered safe. If omitted, machine
+            epsilon of the promoted dtype is used.
+
+    Returns:
+        The guarded quotient.
+    """
+
+    numerator = jnp.asarray(numerator)
+    denominator = jnp.asarray(denominator)
+
+    # Promote to a floating dtype so that jnp.finfo is always valid.
+    dtype = jnp.result_type(numerator, denominator)
+    if not jnp.issubdtype(dtype, jnp.inexact):
+        dtype = jnp.result_type(dtype, jnp.float32)
+
+    numerator = numerator.astype(dtype)
+    denominator = denominator.astype(dtype)
+    default = jnp.asarray(default, dtype=dtype)
+
+    eps = (
+        jnp.asarray(min_denominator, dtype=dtype)
+        if min_denominator is not None
+        else jnp.asarray(jnp.finfo(dtype).eps, dtype=dtype)
+    )
+
+    safe_denominator = jnp.where(
+        jnp.abs(denominator) > eps, denominator, jnp.asarray(1, dtype=dtype)
+    )
+    quotient = numerator / safe_denominator
+
+    return jnp.where(jnp.abs(denominator) > eps, quotient, default)
+
+
+# ==============================
+# safe_normalize with custom JVP
+# ==============================
+
+
+def safe_normalize(
+    array: jtp.ArrayLike,
+    *,
+    axis: int | tuple[int, ...] | None = -1,
+    keepdims: bool = False,
+    default: jtp.ArrayLike | None = None,
+    min_norm: jtp.FloatLike | None = None,
+) -> tuple[jtp.Array, jtp.Array]:
+    """
+    Normalize an array while guarding zero-norm inputs.
+
+    Uses a custom JVP rule that projects the tangent vector onto the tangent
+    plane of the unit sphere, avoiding gradient blowup near zero-norm inputs.
+
+    Args:
+        array: The array to normalize.
+        axis: The axis or axes along which to normalize.
+        keepdims: Whether to keep the reduced dimensions in the returned norm.
+        default:
+            Optional normalized fallback returned when the norm is too small.
+            If omitted, zeros are returned.
+        min_norm: Optional minimum safe norm.
+
+    Returns:
+        A tuple with the normalized array and the corresponding norm.
+    """
+
+    array = jnp.asarray(array)
+    normalized, norm = _make_safe_normalize(axis, keepdims, min_norm)(array)
+
+    if default is not None:
+        default = jnp.asarray(default, dtype=array.dtype)
+        norm_check = jnp.linalg.norm(array, axis=axis, keepdims=True)
+        dtype = array.dtype
+        eps = (
+            jnp.asarray(min_norm, dtype=dtype)
+            if min_norm is not None
+            else jnp.asarray(jnp.finfo(dtype).eps, dtype=dtype)
+        )
+        normalized = jnp.where(norm_check > eps, normalized, default)
+
+    return normalized, norm
+
+
+def _make_safe_normalize(axis, keepdims, min_norm):
+
+    @jax.custom_jvp
+    def _safe_normalize(array):
+        norm = jnp.linalg.norm(array, axis=axis, keepdims=True)
+        dtype = array.dtype
+        eps = (
+            jnp.asarray(min_norm, dtype=dtype)
+            if min_norm is not None
+            else jnp.asarray(jnp.finfo(dtype).eps, dtype=dtype)
+        )
+        is_safe = norm > eps
+        safe_n = jnp.where(is_safe, norm, 1.0)
+        normalized = jnp.where(is_safe, array / safe_n, jnp.zeros_like(array))
+
+        norm_out = norm if keepdims else jnp.squeeze(norm, axis=axis)
+        return normalized, norm_out
+
+    @_safe_normalize.defjvp
+    def _safe_normalize_jvp(primals, tangents):
+        (array,) = primals
+        (array_dot,) = tangents
+
+        normalized, norm_out = _safe_normalize(array)
+
+        norm = jnp.linalg.norm(array, axis=axis, keepdims=True)
+        dtype = array.dtype
+        eps = (
+            jnp.asarray(min_norm, dtype=dtype)
+            if min_norm is not None
+            else jnp.asarray(jnp.finfo(dtype).eps, dtype=dtype)
+        )
+        is_safe = norm > eps
+        safe_n = jnp.where(is_safe, norm, 1.0)
+
+        # Unit vector (finite even when norm ≈ 0 because safe_n = 1).
+        n = array / safe_n
+
+        # Project tangent onto the tangent plane of the unit sphere:
+        #   d(x/‖x‖) = (ẋ − n⟨n, ẋ⟩) / ‖x‖
+        proj = jnp.sum(n * array_dot, axis=axis, keepdims=True)
+        normalized_tangent = jnp.where(
+            is_safe,
+            (array_dot - n * proj) / safe_n,
+            jnp.zeros_like(array),
+        )
+
+        # Norm tangent: d‖x‖ = ⟨n, ẋ⟩
+        norm_tangent = jnp.where(is_safe, proj, jnp.zeros_like(norm))
+        norm_tangent = (
+            norm_tangent if keepdims else jnp.squeeze(norm_tangent, axis=axis)
+        )
+
+        return (normalized, norm_out), (normalized_tangent, norm_tangent)
+
+    return _safe_normalize
+
+
+# ====================================
+# normalize_quaternion with custom JVP
+# ====================================
+
+
+@jax.custom_jvp
+def normalize_quaternion(quaternion: jtp.ArrayLike) -> jtp.Array:
+    """
+    Normalize a quaternion with an identity fallback for zero-norm inputs.
+
+    Uses a custom JVP rule that projects the tangent onto the tangent plane
+    of S³, producing zero gradients for degenerate (zero-norm) quaternions.
+
+    Args:
+        quaternion: The quaternion in WXYZ representation.
+
+    Returns:
+        A safely normalized quaternion.
+    """
+
+    quaternion = jnp.asarray(quaternion)
+    norm = jnp.linalg.norm(quaternion, axis=-1, keepdims=True)
+    eps = jnp.finfo(quaternion.dtype).eps
+    is_safe = norm > eps
+    safe_n = jnp.where(is_safe, norm, 1.0)
+    result = quaternion / safe_n
+
+    default = jnp.broadcast_to(
+        jnp.asarray([1.0, 0.0, 0.0, 0.0], dtype=quaternion.dtype),
+        quaternion.shape,
+    )
+    return jnp.where(is_safe, result, default)
+
+
+@normalize_quaternion.defjvp
+def _normalize_quaternion_jvp(primals, tangents):
+    (quaternion,) = primals
+    (q_dot,) = tangents
+
+    quaternion = jnp.asarray(quaternion)
+    norm = jnp.linalg.norm(quaternion, axis=-1, keepdims=True)
+    eps = jnp.finfo(quaternion.dtype).eps
+    is_safe = norm > eps
+    safe_n = jnp.where(is_safe, norm, 1.0)
+
+    n = quaternion / safe_n
+
+    default = jnp.broadcast_to(
+        jnp.asarray([1.0, 0.0, 0.0, 0.0], dtype=quaternion.dtype),
+        quaternion.shape,
+    )
+    primal_out = jnp.where(is_safe, n, default)
+
+    # Project tangent onto S³ tangent plane: (q̇ − n⟨n, q̇⟩) / ‖q‖
+    proj = jnp.sum(n * q_dot, axis=-1, keepdims=True)
+    tangent_out = jnp.where(
+        is_safe,
+        (q_dot - n * proj) / safe_n,
+        jnp.zeros_like(quaternion),
+    )
+
+    return primal_out, tangent_out

--- a/src/jaxsim/rbda/contacts/common.py
+++ b/src/jaxsim/rbda/contacts/common.py
@@ -7,6 +7,7 @@ import jax
 import jax.numpy as jnp
 
 import jaxsim.api as js
+import jaxsim.math
 import jaxsim.terrain
 import jaxsim.typing as jtp
 from jaxsim.math import STANDARD_GRAVITY
@@ -52,7 +53,10 @@ def compute_penetration_data(
     h = jnp.array([0, 0, terrain.height(x=px, y=py) - pz])
 
     # Compute the penetration depth normal to the terrain.
-    δ = jnp.maximum(0.0, jnp.dot(h, n̂))
+    # Use smooth_relu to eliminate the gradient discontinuity at the contact
+    # surface: the forward pass is exact max(0, ·), but the JVP uses a
+    # sigmoid-smoothed gradient over a configurable transition zone.
+    δ = jaxsim.math.smooth_relu(jnp.dot(h, n̂))
 
     # Compute the penetration normal velocity.
     δ_dot = -jnp.dot(W_ṗ_C, n̂)

--- a/src/jaxsim/rbda/contacts/relaxed_rigid.py
+++ b/src/jaxsim/rbda/contacts/relaxed_rigid.py
@@ -11,6 +11,7 @@ import optax
 from optax.tree_utils import tree_get
 
 import jaxsim.api as js
+import jaxsim.math
 import jaxsim.typing as jtp
 from jaxsim.api.common import ModelDataWithVelocityRepresentation, VelRepr
 
@@ -628,9 +629,9 @@ class RelaxedRigidContacts(common.ContactModel):
 
             # Compute the regularization term.
             R = (
-                (2 * μ**2 * (1 - ξ) / (ξ + 1e-12))
+                jaxsim.math.safe_divide(2 * μ**2 * (1 - ξ), ξ, min_denominator=1e-6)
                 * (1 + μ**2)
-                @ jnp.linalg.inv(M_L[link_idx, :3, :3])
+                @ jaxsim.math.safe_inv(M_L[link_idx, :3, :3])
             )
 
             # Return the computed values, setting them to zero in case of no contact.

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -260,7 +260,7 @@ class SoftContacts(common.ContactModel):
         force_normal_mag = (K * δp) * δ + (D * δq) * δ̇
 
         # Depending on the magnitude of δ̇, the normal force could be negative.
-        force_normal_mag = jnp.maximum(0.0, force_normal_mag)
+        force_normal_mag = jaxsim.math.smooth_relu(force_normal_mag)
 
         # Compute the 3D linear force in C[W] frame.
         f_normal = force_normal_mag * n̂

--- a/src/jaxsim/rbda/contacts/soft.py
+++ b/src/jaxsim/rbda/contacts/soft.py
@@ -291,11 +291,7 @@ class SoftContacts(common.ContactModel):
         )
 
         # Compute the direction of the tangential force.
-        # To prevent dividing by zero, we use a switch statement.
-        norm = jaxsim.math.safe_norm(f_tangential)
-        f_tangential_direction = f_tangential / (
-            norm + jnp.finfo(float).eps * (norm == 0)
-        )
+        f_tangential_direction, norm = jaxsim.math.safe_normalize(f_tangential)
 
         # Project the tangential force to the friction cone if slipping.
         f_tangential = jnp.where(

--- a/src/jaxsim/rbda/mass_inverse.py
+++ b/src/jaxsim/rbda/mass_inverse.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import jaxlie
 
 import jaxsim.api as js
+import jaxsim.math
 import jaxsim.typing as jtp
 
 from . import utils
@@ -157,7 +158,7 @@ def mass_inverse(
     S0 = jnp.eye(6, dtype=float)
     U0 = I_A[0] @ S0
     D0 = S0.T @ U0
-    D0_inv = jnp.linalg.inv(D0)
+    D0_inv = jaxsim.math.safe_inv(D0)
 
     # Base rows 0..5 in ν
     base_rows = slice(0, 6)

--- a/src/jaxsim/terrain/terrain.py
+++ b/src/jaxsim/terrain/terrain.py
@@ -59,7 +59,8 @@ class Terrain(abc.ABC):
             [(h_xm - h_xp) / (2 * self.delta), (h_ym - h_yp) / (2 * self.delta), 1.0]
         )
 
-        return n / jaxsim.math.safe_norm(n, axis=-1)
+        n_hat, _ = jaxsim.math.safe_normalize(n, axis=-1)
+        return n_hat
 
 
 @jax_dataclasses.pytree_dataclass


### PR DESCRIPTION
This PR adds custom JVPs and safe math operations to speed up and improve the stability of autodiff, especially when using single-point precision. Moreover, it substitute the `jnp.max` in the contact detection with a ReLU function to improve the stability of contact dynamics.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--505.org.readthedocs.build//505/

<!-- readthedocs-preview jaxsim end -->