### PR TITLE
Use cached joint transforms in RBDAs

### DIFF
--- a/src/jaxsim/api/data.py
+++ b/src/jaxsim/api/data.py
@@ -168,6 +168,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
                 base_linear_velocity_inertial=W_v_WB[0:3],
                 base_angular_velocity_inertial=W_v_WB[3:6],
                 joint_velocities=joint_velocities,
+                joint_transforms=joint_transforms,
             )
         )
 
@@ -489,6 +490,7 @@ class JaxSimModelData(common.ModelDataWithVelocityRepresentation):
             base_angular_velocity_inertial=jnp.atleast_2d(
                 base_angular_velocity_inertial
             ),
+            joint_transforms=joint_transforms,
         )
 
         # Adjust the output shapes.

--- a/src/jaxsim/api/integrators.py
+++ b/src/jaxsim/api/integrators.py
@@ -70,7 +70,6 @@ def semi_implicit_euler_integration(
             contact_state_derivative,
         )
 
-    # TODO: Avoid double replace, e.g. by computing cached value here
     data = dataclasses.replace(
         data,
         _base_quaternion=W_Q_B,
@@ -82,7 +81,7 @@ def semi_implicit_euler_integration(
         contact_state=integrated_contact_state,
     )
 
-    # Update the cached computations.
+    # Recompute kinematic caches for the new state.
     data = data.replace(model=model)
 
     return data

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -26,7 +26,7 @@ from jaxsim.api.kin_dyn_parameters import (
     LinkParametrizableShape,
     ScalingFactors,
 )
-from jaxsim.math import Adjoint, Cross, Skew
+from jaxsim.math import Adjoint, Cross, Skew, supported_joint_motion
 from jaxsim.parsers.descriptions import ModelDescription
 from jaxsim.parsers.descriptions.joint import JointDescription
 from jaxsim.parsers.descriptions.link import LinkDescription
@@ -1345,6 +1345,7 @@ def forward_dynamics_aba(
         base_linear_velocity=W_v_WB[0:3],
         base_angular_velocity=W_v_WB[3:6],
         joint_velocities=ṡ,
+        joint_transforms=data._joint_transforms,
         joint_forces=τ,
         link_forces=W_f_L,
         standard_gravity=model.gravity,
@@ -1522,6 +1523,7 @@ def forward_kinematics(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp
         joint_velocities=data.joint_velocities,
         base_linear_velocity_inertial=data._base_linear_velocity,
         base_angular_velocity_inertial=data._base_angular_velocity,
+        joint_transforms=data._joint_transforms,
     )
 
     return W_H_LL
@@ -1611,9 +1613,7 @@ def free_floating_mass_matrix_inverse(
     """
     M_inv_body = jaxsim.rbda.mass_inverse(
         model=model,
-        base_position=data.base_position,
-        base_quaternion=data.base_orientation,
-        joint_positions=data.joint_positions,
+        joint_transforms=data._joint_transforms,
     )
 
     match data.velocity_representation:
@@ -1878,6 +1878,7 @@ def inverse_dynamics(
         base_linear_acceleration=W_v̇_WB[0:3],
         base_angular_acceleration=W_v̇_WB[3:6],
         joint_accelerations=s̈,
+        joint_transforms=data._joint_transforms,
         link_forces=W_f_L,
         standard_gravity=model.gravity,
     )
@@ -2273,9 +2274,8 @@ def link_bias_accelerations(
     # Compute the parent-to-child adjoints and the motion subspaces of the joints.
     # These transforms define the relative kinematics of the entire model, including
     # the base transform for both floating-base and fixed-base models.
-    i_X_λi = model.kin_dyn_parameters.joint_transforms(
-        joint_positions=data.joint_positions, base_transform=W_H_B
-    )
+    # Ensure cached transforms stay on device when indexed with traced `i`.
+    i_X_λi = jnp.asarray(data._joint_transforms)
 
     # Extract the joint motion subspaces.
     S = model.kin_dyn_parameters.motion_subspaces
@@ -2388,6 +2388,73 @@ def link_bias_accelerations(
     )
 
     return O_v̇_WL
+
+
+@jax.jit
+def joint_transforms(
+    model: JaxSimModel, joint_positions: jtp.VectorLike, base_transform: jtp.MatrixLike
+) -> jtp.Array:
+    r"""
+    Return the transforms of the joints.
+
+    Args:
+        model: The model to consider.
+        joint_positions: The joint positions.
+        base_transform: The homogeneous matrix defining the base pose.
+
+    Returns:
+        The stacked transforms
+        :math:`{}^{i} \mathbf{H}_{\lambda(i)}(s)`
+        of each joint.
+    """
+
+    # Rename the base transform.
+    W_H_B = base_transform
+
+    # Extract the parent-to-predecessor fixed transforms of the joints.
+    λ_H_pre = jnp.vstack(
+        [
+            jnp.eye(4)[jnp.newaxis],
+            model.kin_dyn_parameters.joint_model.λ_H_pre[
+                1 : 1 + model.kin_dyn_parameters.number_of_joints()
+            ],
+        ]
+    )
+    if model.kin_dyn_parameters.number_of_joints() == 0:
+        pre_H_suc_J = jnp.empty((0, 4, 4))
+    else:
+        pre_H_suc_J = jax.vmap(supported_joint_motion)(
+            joint_types=jnp.array(
+                model.kin_dyn_parameters.joint_model.joint_types[1:]
+            ).astype(int),
+            joint_positions=jnp.array(joint_positions),
+            joint_axes=jnp.array(
+                [j.axis for j in model.kin_dyn_parameters.joint_model.joint_axis]
+            ),
+        )
+
+    # Extract the transforms and motion subspaces of the joints.
+    # We stack the base transform W_H_B at index 0, and a dummy motion subspace
+    # for either the fixed or free-floating joint connecting the world to the base.
+    pre_H_suc = jnp.vstack([W_H_B[jnp.newaxis, ...], pre_H_suc_J])
+
+    # Extract the successor-to-child fixed transforms.
+    # Note that here we include also the index 0 since suc_H_child[0] stores the
+    # optional pose of the base link w.r.t. the root frame of the model.
+    # This is supported by SDF when the base link <pose> element is defined.
+    suc_H_i = model.kin_dyn_parameters.joint_model.suc_H_i[
+        jnp.arange(0, 1 + model.number_of_joints())
+    ]
+
+    # Compute the overall transforms from the parent to the child of each joint by
+    # composing all the components of our joint model.
+    i_X_λ = jax.vmap(
+        lambda λ_Hi_pre, pre_Hi_suc, suc_Hi_i: Adjoint.from_transform(
+            transform=λ_Hi_pre @ pre_Hi_suc @ suc_Hi_i, inverse=True
+        )
+    )(λ_H_pre, pre_H_suc, suc_H_i)
+
+    return i_X_λ
 
 
 # ======

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -26,7 +26,7 @@ from jaxsim.api.kin_dyn_parameters import (
     LinkParametrizableShape,
     ScalingFactors,
 )
-from jaxsim.math import Adjoint, Cross, Skew, supported_joint_motion
+from jaxsim.math import Adjoint, Cross, Skew
 from jaxsim.parsers.descriptions import ModelDescription
 from jaxsim.parsers.descriptions.joint import JointDescription
 from jaxsim.parsers.descriptions.link import LinkDescription
@@ -2408,53 +2408,10 @@ def joint_transforms(
         of each joint.
     """
 
-    # Rename the base transform.
-    W_H_B = base_transform
-
-    # Extract the parent-to-predecessor fixed transforms of the joints.
-    λ_H_pre = jnp.vstack(
-        [
-            jnp.eye(4)[jnp.newaxis],
-            model.kin_dyn_parameters.joint_model.λ_H_pre[
-                1 : 1 + model.kin_dyn_parameters.number_of_joints()
-            ],
-        ]
+    return model.kin_dyn_parameters.joint_transforms(
+        joint_positions=joint_positions,
+        base_transform=base_transform,
     )
-    if model.kin_dyn_parameters.number_of_joints() == 0:
-        pre_H_suc_J = jnp.empty((0, 4, 4))
-    else:
-        pre_H_suc_J = jax.vmap(supported_joint_motion)(
-            joint_types=jnp.array(
-                model.kin_dyn_parameters.joint_model.joint_types[1:]
-            ).astype(int),
-            joint_positions=jnp.array(joint_positions),
-            joint_axes=jnp.array(
-                [j.axis for j in model.kin_dyn_parameters.joint_model.joint_axis]
-            ),
-        )
-
-    # Extract the transforms and motion subspaces of the joints.
-    # We stack the base transform W_H_B at index 0, and a dummy motion subspace
-    # for either the fixed or free-floating joint connecting the world to the base.
-    pre_H_suc = jnp.vstack([W_H_B[jnp.newaxis, ...], pre_H_suc_J])
-
-    # Extract the successor-to-child fixed transforms.
-    # Note that here we include also the index 0 since suc_H_child[0] stores the
-    # optional pose of the base link w.r.t. the root frame of the model.
-    # This is supported by SDF when the base link <pose> element is defined.
-    suc_H_i = model.kin_dyn_parameters.joint_model.suc_H_i[
-        jnp.arange(0, 1 + model.number_of_joints())
-    ]
-
-    # Compute the overall transforms from the parent to the child of each joint by
-    # composing all the components of our joint model.
-    i_X_λ = jax.vmap(
-        lambda λ_Hi_pre, pre_Hi_suc, suc_Hi_i: Adjoint.from_transform(
-            transform=λ_Hi_pre @ pre_Hi_suc @ suc_Hi_i, inverse=True
-        )
-    )(λ_H_pre, pre_H_suc, suc_H_i)
-
-    return i_X_λ
 
 
 # ======

--- a/src/jaxsim/rbda/aba.py
+++ b/src/jaxsim/rbda/aba.py
@@ -18,6 +18,7 @@ def aba(
     base_linear_velocity: jtp.VectorLike,
     base_angular_velocity: jtp.VectorLike,
     joint_velocities: jtp.VectorLike,
+    joint_transforms: jtp.MatrixLike,
     joint_forces: jtp.VectorLike | None = None,
     link_forces: jtp.MatrixLike | None = None,
     standard_gravity: jtp.FloatLike = STANDARD_GRAVITY,
@@ -35,6 +36,7 @@ def aba(
         base_angular_velocity:
             The angular velocity of the base link in inertial-fixed representation.
         joint_velocities: The velocities of the joints.
+        joint_transforms: The parent-to-child transforms of the joints.
         joint_forces: The forces applied to the joints.
         link_forces:
             The forces applied to the links expressed in the world frame.
@@ -85,12 +87,10 @@ def aba(
     W_X_B = W_H_B.adjoint()
     B_X_W = W_H_B.inverse().adjoint()
 
-    # Compute the parent-to-child adjoints of the joints.
+    # Extract the parent-to-child adjoints of the joints.
     # These transforms define the relative kinematics of the entire model, including
     # the base transform for both floating-base and fixed-base models.
-    i_X_λi = model.kin_dyn_parameters.joint_transforms(
-        joint_positions=s, base_transform=W_H_B.as_matrix()
-    )
+    i_X_λi = jnp.asarray(joint_transforms)
 
     # Extract the joint motion subspaces.
     S = model.kin_dyn_parameters.motion_subspaces

--- a/src/jaxsim/rbda/crba.py
+++ b/src/jaxsim/rbda/crba.py
@@ -7,7 +7,11 @@ import jaxsim.typing as jtp
 from . import utils
 
 
-def crba(model: js.model.JaxSimModel, *, joint_positions: jtp.Vector) -> jtp.Matrix:
+def crba(
+    model: js.model.JaxSimModel,
+    *,
+    joint_positions: jtp.Vector,
+) -> jtp.Matrix:
     """
     Compute the free-floating mass matrix using the Composite Rigid-Body Algorithm (CRBA).
 

--- a/src/jaxsim/rbda/rnea.py
+++ b/src/jaxsim/rbda/rnea.py
@@ -21,7 +21,7 @@ def rnea(
     base_linear_acceleration: jtp.Vector | None = None,
     base_angular_acceleration: jtp.Vector | None = None,
     joint_accelerations: jtp.Vector | None = None,
-    joint_transforms: jtp.Matrix,
+    joint_transforms: jtp.MatrixLike,
     link_forces: jtp.Matrix | None = None,
     standard_gravity: jtp.FloatLike = STANDARD_GRAVITY,
 ) -> tuple[jtp.Vector, jtp.Vector]:

--- a/tests/test_api_model_hw_parametrization.py
+++ b/tests/test_api_model_hw_parametrization.py
@@ -360,8 +360,14 @@ def test_hw_parameters_optimization(jaxsim_model_garpez: js.model.JaxSimModel):
             model=model, scaling_factors=scaling_factors
         )
 
+        # Sync the data's cached kinematics (joint transforms, link transforms, …)
+        # with the updated model geometry before running any dynamics.
+        updated_data = data.replace(model=updated_model)
+
         # Compute forward kinematics for the link.
-        W_H_L = js.model.forward_kinematics(model=updated_model, data=data)[link_idx]
+        W_H_L = js.model.forward_kinematics(model=updated_model, data=updated_data)[
+            link_idx
+        ]
 
         # Extract the height (z-axis position) of the link.
         link4_height = W_H_L[2, 3]  # Assuming z-axis is the third row.

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -6,6 +6,7 @@ import numpy as np
 from jax.test_util import check_grads
 
 import jaxsim.api as js
+import jaxsim.math
 import jaxsim.rbda
 import jaxsim.typing as jtp
 from jaxsim import VelRepr
@@ -244,7 +245,13 @@ def test_ad_fk(
         base_linear_velocity_inertial=W_v_lin,
         base_angular_velocity_inertial=W_v_ang,
         joint_velocities=ṡ,
-        joint_transforms=data._joint_transforms,
+        joint_transforms=model.kin_dyn_parameters.joint_transforms(
+            joint_positions=s,
+            base_transform=jaxsim.math.Transform.from_quaternion_and_translation(
+                translation=W_p_B,
+                quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+            ),
+        ),
     )
 
     # Check derivatives against finite differences.


### PR DESCRIPTION
The joint transforms were already cached inside `JaxSimModelData`, but they were not used in RBDAs.

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--510.org.readthedocs.build//510/

<!-- readthedocs-preview jaxsim end -->