### PR TITLE
Add parallel ABA and forward kinematics with pointer jumping

### DIFF
--- a/src/jaxsim/api/kin_dyn_parameters.py
+++ b/src/jaxsim/api/kin_dyn_parameters.py
@@ -44,6 +44,13 @@ class KinDynParameters(JaxsimDataclass):
     _support_body_array_bool: Static[HashedNumpyArray]
     _motion_subspaces: Static[HashedNumpyArray]
 
+    # Tree level structure for parallel algorithms.
+    # level_nodes: (n_levels, max_width) array of link indices at each depth level,
+    #   padded with 0 for levels with fewer nodes than max_width.
+    # level_mask: (n_levels, max_width) boolean mask, True for real nodes.
+    _level_nodes: Static[HashedNumpyArray]
+    _level_mask: Static[HashedNumpyArray]
+
     # Links
     link_parameters: LinkParameters
 
@@ -83,6 +90,70 @@ class KinDynParameters(JaxsimDataclass):
         Return the boolean support parent array :math:`\kappa_{b}(i)` of the model.
         """
         return self._support_body_array_bool.get()
+
+    @property
+    def level_nodes(self) -> jtp.Matrix:
+        r"""
+        Return the tree level nodes array of shape ``(n_levels, max_width)``.
+        Each row contains the link indices at the corresponding depth level,
+        padded with 0 for levels with fewer nodes than ``max_width``.
+        """
+        return self._level_nodes.get()
+
+    @property
+    def level_mask(self) -> jtp.Matrix:
+        r"""
+        Return the tree level mask of shape ``(n_levels, max_width)``.
+        Each entry is ``True`` for real nodes and ``False`` for padding.
+        """
+        return self._level_mask.get()
+
+    @staticmethod
+    def _compute_tree_levels(
+        parent_array: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Compute the tree level decomposition from a parent array.
+
+        Args:
+            parent_array: Array of shape ``(n,)`` where ``parent_array[i]``
+                is the parent of link ``i``. ``parent_array[0] == -1`` for the root.
+
+        Returns:
+            A tuple ``(level_nodes, level_mask)`` where:
+            - ``level_nodes`` has shape ``(n_levels, max_width)`` with link
+              indices at each depth level (padded with 0).
+            - ``level_mask`` has shape ``(n_levels, max_width)`` with ``True``
+              for real nodes.
+        """
+        import numpy as np
+
+        n = len(parent_array)
+
+        # Compute depth of each node.
+        depth = np.zeros(n, dtype=int)
+        for i in range(1, n):
+            depth[i] = depth[parent_array[i]] + 1
+
+        max_depth = int(depth.max()) if n > 0 else 0
+        n_levels = max_depth + 1
+
+        # Group nodes by depth level.
+        levels: list[list[int]] = [[] for _ in range(n_levels)]
+        for i in range(n):
+            levels[depth[i]].append(i)
+
+        max_width = max(len(lev) for lev in levels) if levels else 1
+
+        # Build padded arrays.
+        level_nodes = np.zeros((n_levels, max_width), dtype=int)
+        level_mask = np.zeros((n_levels, max_width), dtype=bool)
+        for d, lev in enumerate(levels):
+            for j, node_idx in enumerate(lev):
+                level_nodes[d, j] = node_idx
+                level_mask[d, j] = True
+
+        return level_nodes, level_mask
 
     @staticmethod
     def build(
@@ -261,6 +332,13 @@ class KinDynParameters(JaxsimDataclass):
 
         motion_subspaces = jnp.vstack([jnp.zeros((6, 1))[jnp.newaxis, ...], S_J])
 
+        # ====================
+        # Tree level structure
+        # ====================
+
+        parent_array_np = np.array([-1, *list(parent_array_dict.values())], dtype=int)
+        level_nodes, level_mask = KinDynParameters._compute_tree_levels(parent_array_np)
+
         # ===========
         # Constraints
         # ===========
@@ -276,6 +354,8 @@ class KinDynParameters(JaxsimDataclass):
             _parent_array=HashedNumpyArray(array=parent_array),
             _support_body_array_bool=HashedNumpyArray(array=support_body_array_bool),
             _motion_subspaces=HashedNumpyArray(array=motion_subspaces),
+            _level_nodes=HashedNumpyArray(array=level_nodes),
+            _level_mask=HashedNumpyArray(array=level_mask),
             link_parameters=link_parameters,
             joint_model=joint_model,
             joint_parameters=joint_parameters,

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1617,10 +1617,6 @@ def forward_dynamics_aba(
 
     aba_fn = jaxsim.rbda.aba_parallel if parallel else jaxsim.rbda.aba
 
-    extra_kwargs = {}
-    if parallel:
-        extra_kwargs["joint_transforms"] = data._joint_transforms
-
     W_v̇_WB, s̈ = aba_fn(
         model=model,
         base_position=W_p_B,
@@ -1629,11 +1625,13 @@ def forward_dynamics_aba(
         base_linear_velocity=W_v_WB[0:3],
         base_angular_velocity=W_v_WB[3:6],
         joint_velocities=ṡ,
-        joint_transforms=data._joint_transforms,
+        joint_transforms=model.kin_dyn_parameters.joint_transforms(
+            joint_positions=s,
+            base_transform=data.base_transform,
+        ),
         joint_forces=τ,
         link_forces=W_f_L,
         standard_gravity=model.gravity,
-        **extra_kwargs,
     )
 
     # =============
@@ -1813,9 +1811,12 @@ def forward_kinematics(
         else jaxsim.rbda.forward_kinematics_model
     )
 
-    extra_kwargs = {}
-    if parallel:
-        extra_kwargs["joint_transforms"] = data._joint_transforms
+    # Recompute joint transforms from the model to ensure gradients
+    # flow through model parameters.
+    joint_transforms = model.kin_dyn_parameters.joint_transforms(
+        joint_positions=data.joint_positions,
+        base_transform=data.base_transform,
+    )
 
     W_H_LL, _ = fk_fn(
         model=model,
@@ -1825,7 +1826,7 @@ def forward_kinematics(
         joint_velocities=data.joint_velocities,
         base_linear_velocity_inertial=data._base_linear_velocity,
         base_angular_velocity_inertial=data._base_angular_velocity,
-        **extra_kwargs,
+        joint_transforms=joint_transforms,
     )
 
     return W_H_LL

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1785,22 +1785,39 @@ def forward_dynamics_crb(
     return v̇_WB, s̈
 
 
-@jax.jit
+@functools.partial(jax.jit, static_argnames=("parallel",))
 @js.common.named_scope
-def forward_kinematics(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp.Matrix:
+def forward_kinematics(
+    model: JaxSimModel,
+    data: js.data.JaxSimModelData,
+    *,
+    parallel: bool = False,
+) -> jtp.Matrix:
     """
     Compute the forward kinematics of the model.
 
     Args:
         model: The model to consider.
         data: The data of the considered model.
+        parallel: If True, use the level-parallel FK implementation that
+            processes independent tree branches simultaneously.
 
     Returns:
         The nL x 4 x 4 array containing the stacked homogeneous transformations
         of the links. The first axis is the link index.
     """
 
-    W_H_LL, _ = jaxsim.rbda.forward_kinematics_model(
+    fk_fn = (
+        jaxsim.rbda.forward_kinematics_model_parallel
+        if parallel
+        else jaxsim.rbda.forward_kinematics_model
+    )
+
+    extra_kwargs = {}
+    if parallel:
+        extra_kwargs["joint_transforms"] = data._joint_transforms
+
+    W_H_LL, _ = fk_fn(
         model=model,
         base_position=data.base_position,
         base_quaternion=data.base_quaternion,
@@ -1808,7 +1825,7 @@ def forward_kinematics(model: JaxSimModel, data: js.data.JaxSimModelData) -> jtp
         joint_velocities=data.joint_velocities,
         base_linear_velocity_inertial=data._base_linear_velocity,
         base_angular_velocity_inertial=data._base_angular_velocity,
-        joint_transforms=data._joint_transforms,
+        **extra_kwargs,
     )
 
     return W_H_LL

--- a/src/jaxsim/api/model.py
+++ b/src/jaxsim/api/model.py
@@ -1540,7 +1540,7 @@ def forward_dynamics(
     )
 
 
-@jax.jit
+@functools.partial(jax.jit, static_argnames=("parallel",))
 @js.common.named_scope
 def forward_dynamics_aba(
     model: JaxSimModel,
@@ -1548,6 +1548,7 @@ def forward_dynamics_aba(
     *,
     joint_forces: jtp.VectorLike | None = None,
     link_forces: jtp.MatrixLike | None = None,
+    parallel: bool = False,
 ) -> tuple[jtp.Vector, jtp.Vector]:
     """
     Compute the forward dynamics of the model with the ABA algorithm.
@@ -1560,6 +1561,10 @@ def forward_dynamics_aba(
         link_forces:
             The link 6D forces to consider as a matrix of shape `(nL, 6)`.
             The frame in which they are expressed must be `data.velocity_representation`.
+        parallel:
+            If ``True``, use the level-parallel ABA implementation that
+            processes independent tree branches simultaneously.
+            Beneficial on GPU or for wide/deep kinematic trees.
 
     Returns:
         A tuple containing the 6D acceleration in the active representation of the
@@ -1610,7 +1615,13 @@ def forward_dynamics_aba(
     # Compute forward dynamics
     # ========================
 
-    W_v̇_WB, s̈ = jaxsim.rbda.aba(
+    aba_fn = jaxsim.rbda.aba_parallel if parallel else jaxsim.rbda.aba
+
+    extra_kwargs = {}
+    if parallel:
+        extra_kwargs["joint_transforms"] = data._joint_transforms
+
+    W_v̇_WB, s̈ = aba_fn(
         model=model,
         base_position=W_p_B,
         base_quaternion=W_Q_B,
@@ -1622,6 +1633,7 @@ def forward_dynamics_aba(
         joint_forces=τ,
         link_forces=W_f_L,
         standard_gravity=model.gravity,
+        **extra_kwargs,
     )
 
     # =============

--- a/src/jaxsim/rbda/__init__.py
+++ b/src/jaxsim/rbda/__init__.py
@@ -1,5 +1,6 @@
 from . import actuation, contacts
 from .aba import aba
+from .aba_parallel import aba_parallel
 from .collidable_points import collidable_points_pos_vel
 from .crba import crba
 from .forward_kinematics import forward_kinematics_model

--- a/src/jaxsim/rbda/__init__.py
+++ b/src/jaxsim/rbda/__init__.py
@@ -4,6 +4,7 @@ from .aba_parallel import aba_parallel
 from .collidable_points import collidable_points_pos_vel
 from .crba import crba
 from .forward_kinematics import forward_kinematics_model
+from .forward_kinematics_parallel import forward_kinematics_model_parallel
 from .jacobian import (
     jacobian,
     jacobian_derivative_full_doubly_left,

--- a/src/jaxsim/rbda/aba.py
+++ b/src/jaxsim/rbda/aba.py
@@ -88,8 +88,6 @@ def aba(
     B_X_W = W_H_B.inverse().adjoint()
 
     # Extract the parent-to-child adjoints of the joints.
-    # These transforms define the relative kinematics of the entire model, including
-    # the base transform for both floating-base and fixed-base models.
     i_X_λi = jnp.asarray(joint_transforms)
 
     # Extract the joint motion subspaces.

--- a/src/jaxsim/rbda/aba_parallel.py
+++ b/src/jaxsim/rbda/aba_parallel.py
@@ -1,0 +1,328 @@
+import math
+
+import jax
+import jax.numpy as jnp
+import jaxlie
+
+import jaxsim.api as js
+import jaxsim.typing as jtp
+from jaxsim.math import STANDARD_GRAVITY, Adjoint, Cross
+
+from . import utils
+
+
+def aba_parallel(
+    model: js.model.JaxSimModel,
+    *,
+    base_position: jtp.VectorLike,
+    base_quaternion: jtp.VectorLike,
+    joint_positions: jtp.VectorLike,
+    base_linear_velocity: jtp.VectorLike,
+    base_angular_velocity: jtp.VectorLike,
+    joint_velocities: jtp.VectorLike,
+    joint_transforms: jtp.MatrixLike,
+    joint_forces: jtp.VectorLike | None = None,
+    link_forces: jtp.MatrixLike | None = None,
+    standard_gravity: jtp.FloatLike = STANDARD_GRAVITY,
+) -> tuple[jtp.Vector, jtp.Vector]:
+    """
+    Compute forward dynamics using a hybrid parallel ABA.
+
+    Passes 1 and 3 use pointer jumping in O(log D) parallel steps.
+    Pass 2 uses level-parallel processing in O(D) steps because the backward
+    inertia accumulation is not associative.
+
+    The interface and semantics are identical to :func:`aba`.
+    """
+
+    W_p_B, W_Q_B, s, W_v_WB, ṡ, _, _, τ, W_f, W_g = utils.process_inputs(
+        model=model,
+        base_position=base_position,
+        base_quaternion=base_quaternion,
+        joint_positions=joint_positions,
+        base_linear_velocity=base_linear_velocity,
+        base_angular_velocity=base_angular_velocity,
+        joint_velocities=joint_velocities,
+        base_linear_acceleration=None,
+        base_angular_acceleration=None,
+        joint_accelerations=None,
+        joint_forces=joint_forces,
+        link_forces=link_forces,
+        standard_gravity=standard_gravity,
+    )
+
+    W_g = jnp.atleast_2d(W_g).T
+    W_v_WB = jnp.atleast_2d(W_v_WB).T
+
+    # Get the 6D spatial inertia matrices of all links.
+    M = js.model.link_spatial_inertia_matrices(model=model)
+
+    # Get the parent array λ(i).
+    λ = model.kin_dyn_parameters.parent_array
+
+    # Get the tree level structure for level-parallel processing.
+    level_nodes = jnp.asarray(model.kin_dyn_parameters.level_nodes)
+    level_mask = jnp.asarray(model.kin_dyn_parameters.level_mask)
+    n_levels = level_nodes.shape[0]
+    max_width = level_nodes.shape[1]
+
+    # Compute the base transform.
+    W_H_B = jaxlie.SE3.from_rotation_and_translation(
+        rotation=jaxlie.SO3(wxyz=W_Q_B),
+        translation=W_p_B,
+    )
+
+    # Compute 6D transforms of the base velocity.
+    W_X_B = W_H_B.adjoint()
+    B_X_W = W_H_B.inverse().adjoint()
+
+    # Extract the parent-to-child adjoints of the joints.
+    i_X_λi = jnp.asarray(joint_transforms)
+
+    # Extract the joint motion subspaces.
+    S = model.kin_dyn_parameters.motion_subspaces
+
+    n = model.number_of_links()
+
+    # Parent array with root self-loop.
+    # Note: λ(0) is set to 0 to enable root self-referencing.
+    ptr0 = jnp.asarray(λ).at[0].set(0)
+
+    # Number of pointer-jumping rounds.
+    n_rounds = max(1, math.ceil(math.log2(max(n_levels, 2))))
+
+    # ======
+    # Pass 1
+    # ======
+
+    # Two coupled affine recurrences propagated via pointer jumping:
+    #   v_i = i_X_λi[i] @ v_parent + vJ_i
+    #   T_i = i_X_λi[i] @ T_parent
+    #
+    # Associative operator on (A, b, T):
+    #   compose(parent, child) = (A @ A_p, A @ b_p + b, A @ T_p)
+
+    # Local transforms and joint velocities.
+    ṡ_col = jnp.atleast_1d(ṡ).reshape(-1, 1)  # (n_joints, 1)
+    ṡ_padded = jnp.concatenate([jnp.zeros((1, 1)), ṡ_col])  # (n, 1)
+    vJ = S * ṡ_padded[:, :, None]  # (n, 6, 1)
+
+    # Initialize pointer-jumping state for each node.
+    A = i_X_λi.copy()  # (n, 6, 6)
+    b = vJ.copy()  # (n, 6, 1)
+    T = i_X_λi.copy()  # (n, 6, 6)
+
+    # Root initial values.
+    if model.floating_base():
+        v_0 = B_X_W @ W_v_WB
+        A = A.at[0].set(jnp.eye(6))
+        b = b.at[0].set(v_0)
+        T = T.at[0].set(jnp.eye(6))
+    else:
+        A = A.at[0].set(jnp.eye(6))
+        b = b.at[0].set(jnp.zeros((6, 1)))
+        T = T.at[0].set(jnp.eye(6))
+
+    ptr = ptr0.copy()
+    done = jnp.arange(n) == 0
+
+    def _pass1_jump(carry, _):
+        A, b, T, ptr, done = carry
+        need = ~done
+
+        A_par = A[ptr]
+        b_par = b[ptr]
+        T_par = T[ptr]
+
+        # Associative compose.
+        A_new = jnp.where(need[:, None, None], A @ A_par, A)
+        b_new = jnp.where(need[:, None, None], A @ b_par + b, b)
+        T_new = jnp.where(need[:, None, None], A @ T_par, T)
+
+        ptr_new = jnp.where(need, ptr[ptr], ptr)
+        done_new = done | done[ptr]
+
+        return (A_new, b_new, T_new, ptr_new, done_new), None
+
+    (_, v, i_X_0, _, _), _ = (
+        jax.lax.scan(
+            f=_pass1_jump,
+            init=(A, b, T, ptr, done),
+            xs=jnp.arange(n_rounds),
+        )
+        if n > 1
+        else ((A, b, T, ptr, done), None)
+    )
+
+    # v now contains the 6D body velocity of every link.
+    # i_X_0 contains the body-to-base transform for every link.
+
+    # Compute c, MA, pA for all nodes in parallel.
+    def _init_node(node_i):
+        ii = node_i - 1
+        vJ_i = S[node_i] * ṡ_padded[node_i]
+        c_i = Cross.vx(v[node_i]) @ vJ_i
+        MA_i = M[node_i]
+        i_Xf_W = Adjoint.inverse(i_X_0[node_i] @ B_X_W).T
+        pA_i = Cross.vx_star(v[node_i]) @ M[node_i] @ v[node_i] - i_Xf_W @ jnp.vstack(
+            W_f[node_i]
+        )
+        return c_i, MA_i, pA_i
+
+    c, MA, pA = jax.vmap(_init_node)(jnp.arange(n))
+
+    # Override base MA and pA if floating base.
+    if model.floating_base():
+        MA = MA.at[0].set(M[0])
+        pA_0 = Cross.vx_star(v[0]) @ M[0] @ v[0] - W_X_B.T @ jnp.vstack(W_f[0])
+        pA = pA.at[0].set(pA_0)
+
+    # ======
+    # Pass 2
+    # ======
+
+    # The Schur complement and multi-child scatter-add make this pass
+    # non-associative, so it remains level-parallel.
+
+    U = jnp.zeros_like(S)
+    d = jnp.ones(shape=(n, 1))  # Ones to avoid NaN for the base node.
+    u = jnp.zeros(shape=(n, 1))
+
+    def _masked_scatter_add(arr, indices, values, m):
+        """Add values[j] to arr[indices[j]] only where m[j] is True."""
+        for j in range(max_width):
+            arr = jnp.where(m[j], arr.at[indices[j]].add(values[j]), arr)
+        return arr
+
+    def _pass2_level(carry, level_idx):
+        U, d, u, MA, pA = carry
+        actual_level = n_levels - 1 - level_idx
+        nodes = level_nodes[actual_level]
+        mask = level_mask[actual_level]
+
+        def _process_node_pass2(node_i):
+            ii = node_i - 1
+            parent = λ[node_i]
+
+            U_i = MA[node_i] @ S[node_i]
+            d_i = (S[node_i].T @ U_i).squeeze()
+            u_i = (τ[ii] - S[node_i].T @ pA[node_i]).squeeze()
+
+            Ma_i = MA[node_i] - U_i / d_i @ U_i.T
+            pa_i = pA[node_i] + Ma_i @ c[node_i] + U_i * (u_i / d_i)
+
+            Ma_parent = i_X_λi[node_i].T @ Ma_i @ i_X_λi[node_i]
+            pa_parent = i_X_λi[node_i].T @ pa_i
+
+            return U_i, d_i, u_i, Ma_parent, pa_parent, parent
+
+        U_lev, d_lev, u_lev, Ma_par, pa_par, parents = jax.vmap(_process_node_pass2)(
+            nodes
+        )
+
+        mask_6x1 = mask[:, None, None]
+        mask_1 = mask[:, None]
+
+        U = carry[0].at[nodes].set(jnp.where(mask_6x1, U_lev, carry[0][nodes]))
+        d = carry[1].at[nodes].set(jnp.where(mask_1, d_lev[:, None], carry[1][nodes]))
+        u = carry[2].at[nodes].set(jnp.where(mask_1, u_lev[:, None], carry[2][nodes]))
+
+        should_propagate = jnp.where(
+            model.floating_base(),
+            mask,
+            jnp.logical_and(mask, parents != 0),
+        )
+
+        MA = _masked_scatter_add(carry[3], parents, Ma_par, should_propagate)
+        pA = _masked_scatter_add(carry[4], parents, pa_par, should_propagate)
+
+        return (U, d, u, MA, pA), None
+
+    n_backward_levels = n_levels - 1
+    (U, d, u, MA, pA), _ = (
+        jax.lax.scan(
+            f=_pass2_level,
+            init=(U, d, u, MA, pA),
+            xs=jnp.arange(n_backward_levels),
+        )
+        if n_backward_levels > 0
+        else ((U, d, u, MA, pA), None)
+    )
+
+    # ======
+    # Pass 3
+    # ======
+
+    # The acceleration recurrence is an affine recurrence:
+    #   a_i = P_i @ i_X_λi[i] @ a_parent + P_i @ c_i + S_i * u_i / d_i
+    # where P_i = I - S_i @ U_i^T / d_i is the 6x6 projection matrix.
+
+    if model.floating_base():
+        a0 = jnp.linalg.solve(-MA[0], pA[0])
+    else:
+        a0 = -B_X_W @ W_g
+
+    # Pre-compute the affine recurrence coefficients for all nodes.
+    def _init_pass3(node_i):
+        P_i = jnp.eye(6) - S[node_i] @ U[node_i].T / d[node_i]
+        A_i = P_i @ i_X_λi[node_i]
+        b_i = P_i @ c[node_i] + S[node_i] * (u[node_i] / d[node_i])
+        return A_i, b_i
+
+    A, b = jax.vmap(_init_pass3)(jnp.arange(n))
+
+    # Root acceleration is known.
+    A = A.at[0].set(jnp.eye(6))
+    b = b.at[0].set(a0)
+
+    # Pointer jumping for the affine recurrence.
+    ptr = ptr0.copy()
+    done = jnp.arange(n) == 0
+
+    def _pass3_jump(carry, _):
+        A, b, ptr, done = carry
+        need = ~done
+
+        A_par = A[ptr]
+        b_par = b[ptr]
+
+        # Associative compose.
+        A_new = jnp.where(need[:, None, None], A @ A_par, A)
+        b_new = jnp.where(need[:, None, None], A @ b_par + b, b)
+
+        ptr_new = jnp.where(need, ptr[ptr], ptr)
+        done_new = done | done[ptr]
+
+        return (A_new, b_new, ptr_new, done_new), None
+
+    (_, a, _, _), _ = (
+        jax.lax.scan(
+            f=_pass3_jump,
+            init=(A, b, ptr, done),
+            xs=jnp.arange(n_rounds),
+        )
+        if n > 1
+        else ((A, b, ptr, done), None)
+    )
+
+    # Recover joint accelerations: s̈_i = (u_i - U_i^T @ a_before_i) / d_i
+    # where a_before_i = i_X_λi[i] @ a_parent + c_i.
+    a_λi = a[ptr0]
+    a_before = i_X_λi @ a_λi + c
+    Ut_a = (U.transpose(0, 2, 1) @ a_before).squeeze(-1)  # (n, 1)
+    s̈ = (u - Ut_a) / d  # (n, 1)
+
+    # ==============
+    # Adjust outputs
+    # ==============
+
+    if model.floating_base():
+        B_a_WB = a[0]
+        W_a_WB = W_X_B @ B_a_WB + W_g
+    else:
+        W_a_WB = jnp.zeros(6)
+
+    # Joint accelerations: skip base index, take indices 1..n-1.
+    s̈_out = s̈[1:]
+
+    return W_a_WB.squeeze(), jnp.atleast_1d(s̈_out.squeeze())

--- a/src/jaxsim/rbda/aba_parallel.py
+++ b/src/jaxsim/rbda/aba_parallel.py
@@ -32,10 +32,11 @@ def aba_parallel(
     Pass 2 uses level-parallel processing in O(D) steps because the backward
     inertia accumulation is not associative.
 
-    The interface and semantics are identical to :func:`aba`.
+    The interface and semantics are identical to :func:`aba`,
+    but passes 1 and 3 are parallelized via pointer jumping.
     """
 
-    W_p_B, W_Q_B, s, W_v_WB, ṡ, _, _, τ, W_f, W_g = utils.process_inputs(
+    W_p_B, W_Q_B, _, W_v_WB, ṡ, _, _, τ, W_f, W_g = utils.process_inputs(
         model=model,
         base_position=base_position,
         base_quaternion=base_quaternion,
@@ -64,7 +65,6 @@ def aba_parallel(
     level_nodes = jnp.asarray(model.kin_dyn_parameters.level_nodes)
     level_mask = jnp.asarray(model.kin_dyn_parameters.level_mask)
     n_levels = level_nodes.shape[0]
-    max_width = level_nodes.shape[1]
 
     # Compute the base transform.
     W_H_B = jaxlie.SE3.from_rotation_and_translation(
@@ -159,7 +159,6 @@ def aba_parallel(
 
     # Compute c, MA, pA for all nodes in parallel.
     def _init_node(node_i):
-        ii = node_i - 1
         vJ_i = S[node_i] * ṡ_padded[node_i]
         c_i = Cross.vx(v[node_i]) @ vJ_i
         MA_i = M[node_i]
@@ -190,9 +189,9 @@ def aba_parallel(
 
     def _masked_scatter_add(arr, indices, values, m):
         """Add values[j] to arr[indices[j]] only where m[j] is True."""
-        for j in range(max_width):
-            arr = jnp.where(m[j], arr.at[indices[j]].add(values[j]), arr)
-        return arr
+        mask = jnp.reshape(m, m.shape + (1,) * (values.ndim - 1))
+        masked_values = jnp.where(mask, values, jnp.zeros_like(values))
+        return arr.at[indices].add(masked_values)
 
     def _pass2_level(carry, level_idx):
         U, d, u, MA, pA = carry
@@ -201,7 +200,8 @@ def aba_parallel(
         mask = level_mask[actual_level]
 
         def _process_node_pass2(node_i):
-            ii = node_i - 1
+            # Clamp index to avoid out-of-bounds for padded entries.
+            ii = jnp.maximum(node_i, 1) - 1
             parent = λ[node_i]
 
             U_i = MA[node_i] @ S[node_i]

--- a/src/jaxsim/rbda/forward_kinematics.py
+++ b/src/jaxsim/rbda/forward_kinematics.py
@@ -18,7 +18,7 @@ def forward_kinematics_model(
     base_angular_velocity_inertial: jtp.VectorLike,
     joint_velocities: jtp.VectorLike,
     joint_transforms: jtp.MatrixLike,
-) -> jtp.Array:
+) -> tuple[jtp.Array, jtp.Array]:
     """
     Compute the forward kinematics.
 
@@ -33,7 +33,7 @@ def forward_kinematics_model(
         joint_transforms: The parent-to-child transforms of the joints.
 
     Returns:
-        A 3D array containing the SE(3) transforms of all links belonging to the model.
+        A tuple containing the SE(3) transforms and the 6D velocities of all links.
     """
 
     _, _, _, W_v_WB, ṡ, _, _, _, _, _ = utils.process_inputs(
@@ -51,8 +51,6 @@ def forward_kinematics_model(
     λ = model.kin_dyn_parameters.parent_array
 
     # Extract the parent-to-child adjoints of the joints.
-    # These transforms define the relative kinematics of the entire model, including
-    # the base transform for both floating-base and fixed-base models.
     i_X_λi = jnp.asarray(joint_transforms)
 
     # Allocate the buffer of transforms world -> link and initialize the base pose.

--- a/src/jaxsim/rbda/forward_kinematics_parallel.py
+++ b/src/jaxsim/rbda/forward_kinematics_parallel.py
@@ -20,7 +20,7 @@ def forward_kinematics_model_parallel(
     base_angular_velocity_inertial: jtp.VectorLike,
     joint_velocities: jtp.VectorLike,
     joint_transforms: jtp.MatrixLike,
-) -> jtp.Array:
+) -> tuple[jtp.Array, jtp.Array]:
     """
     Compute forward kinematics using pointer jumping on the kinematic tree.
 
@@ -29,7 +29,7 @@ def forward_kinematics_model_parallel(
     steps, where D is the tree depth.
 
     The interface and semantics are identical to
-    :func:`forward_kinematics_model`.
+    :func:`forward_kinematics_model`, but parallelized via pointer jumping.
     """
 
     _, _, _, W_v_WB, ṡ, _, _, _, _, _ = utils.process_inputs(

--- a/src/jaxsim/rbda/forward_kinematics_parallel.py
+++ b/src/jaxsim/rbda/forward_kinematics_parallel.py
@@ -1,0 +1,109 @@
+import math
+
+import jax
+import jax.numpy as jnp
+
+import jaxsim.api as js
+import jaxsim.typing as jtp
+from jaxsim.math import Adjoint
+
+from . import utils
+
+
+def forward_kinematics_model_parallel(
+    model: js.model.JaxSimModel,
+    *,
+    base_position: jtp.VectorLike,
+    base_quaternion: jtp.VectorLike,
+    joint_positions: jtp.VectorLike,
+    base_linear_velocity_inertial: jtp.VectorLike,
+    base_angular_velocity_inertial: jtp.VectorLike,
+    joint_velocities: jtp.VectorLike,
+    joint_transforms: jtp.MatrixLike,
+) -> jtp.Array:
+    """
+    Compute forward kinematics using pointer jumping on the kinematic tree.
+
+    Uses an associative binary operator on transform-velocity pairs to
+    compute all world-frame transforms and velocities in O(log D) parallel
+    steps, where D is the tree depth.
+
+    The interface and semantics are identical to
+    :func:`forward_kinematics_model`.
+    """
+
+    _, _, _, W_v_WB, ṡ, _, _, _, _, _ = utils.process_inputs(
+        model=model,
+        base_position=base_position,
+        base_quaternion=base_quaternion,
+        joint_positions=joint_positions,
+        base_linear_velocity=base_linear_velocity_inertial,
+        base_angular_velocity=base_angular_velocity_inertial,
+        joint_velocities=joint_velocities,
+    )
+
+    # Extract the parent-to-child adjoints of the joints.
+    i_X_λi = jnp.asarray(joint_transforms)
+
+    # Extract the joint motion subspaces.
+    S = model.kin_dyn_parameters.motion_subspaces
+
+    n = model.number_of_links()
+
+    # Compute local transforms λ(i)_X_i by inverting the child-to-parent adjoints.
+    L = jax.vmap(Adjoint.inverse)(i_X_λi)  # (n, 6, 6)
+
+    # Compute local velocity contributions.
+    ṡ_padded = jnp.concatenate([jnp.zeros(1), jnp.atleast_1d(ṡ.squeeze())])  # (n,)
+    vJ = (S * ṡ_padded[:, None, None]).squeeze(-1)  # (n, 6)
+    u = jnp.einsum("nij,nj->ni", L, vJ)  # (n, 6)
+    u = u.at[0].set(W_v_WB)
+
+    # Get the parent array λ(i) with root self-loop.
+    # Note: λ(0) is set to 0 to enable root self-referencing.
+    ptr = jnp.asarray(model.kin_dyn_parameters.parent_array).at[0].set(0)
+    done = jnp.arange(n) == 0
+
+    # Number of pointer-jumping rounds.
+    n_levels = model.kin_dyn_parameters.level_nodes.shape[0]
+    n_rounds = max(1, math.ceil(math.log2(max(n_levels, 2))))
+
+    # ===============
+    # Pointer jumping
+    # ===============
+
+    # Each round composes the node state with its current pointer target,
+    # then doubles the jump distance. After ceil(log2 D) rounds every node
+    # has accumulated the full root-to-node transform and velocity.
+
+    def _pointer_jump(carry, _):
+        L, u, ptr, done = carry
+        need = ~done
+
+        L_par = L[ptr]
+        u_par = u[ptr]
+
+        # Associative compose.
+        L_new = jnp.where(need[:, None, None], L_par @ L, L)
+        u_new = jnp.where(
+            need[:, None],
+            u_par + jnp.einsum("nij,nj->ni", L_par, u),
+            u,
+        )
+
+        ptr_new = jnp.where(need, ptr[ptr], ptr)
+        done_new = done | done[ptr]
+
+        return (L_new, u_new, ptr_new, done_new), None
+
+    (W_X_i, W_v_Wi, _, _), _ = (
+        jax.lax.scan(
+            f=_pointer_jump,
+            init=(L, u, ptr, done),
+            xs=jnp.arange(n_rounds),
+        )
+        if n > 1
+        else ((L, u, ptr, done), None)
+    )
+
+    return jax.vmap(Adjoint.to_transform)(W_X_i), W_v_Wi

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -575,3 +575,101 @@ def test_model_fd_id_consistency(
 
         assert_allclose(τ_id, references.joint_force_references(model=model))
         assert_allclose(fB_id, references.link_forces(model=model, data=data)[0])
+
+
+def test_aba_vs_aba_parallel(
+    jaxsim_models_all: js.model.JaxSimModel,
+    velocity_representation: VelRepr,
+    prng_key: jax.Array,
+):
+    """Verify that the level-parallel ABA produces identical results to
+    the sequential ABA, both at the low-level RBDA and at the high-level
+    model API."""
+
+    model = jaxsim_models_all
+
+    key, subkey = jax.random.split(prng_key, num=2)
+    data = js.data.random_model_data(
+        model=model, key=subkey, velocity_representation=velocity_representation
+    )
+
+    # Create random references.
+    _, subkey1, subkey2 = jax.random.split(key, num=3)
+    references = js.references.JaxSimModelReferences.build(
+        model=model,
+        joint_force_references=10 * jax.random.uniform(subkey1, shape=(model.dofs(),)),
+        link_forces=jax.random.uniform(subkey2, shape=(model.number_of_links(), 6)),
+        data=data,
+        velocity_representation=data.velocity_representation,
+    )
+
+    if not model.floating_base():
+        references = references.apply_link_forces(
+            forces=jnp.atleast_2d(jnp.zeros(6)),
+            model=model,
+            data=data,
+            link_names=(model.base_link(),),
+            additive=False,
+        )
+
+    # ==========================================
+    # Test 1: High-level API (forward_dynamics_aba)
+    # ==========================================
+
+    joint_forces = references.joint_force_references()
+    link_forces = references.link_forces(model=model, data=data)
+
+    v̇_WB_seq, s̈_seq = js.model.forward_dynamics_aba(
+        model=model,
+        data=data,
+        joint_forces=joint_forces,
+        link_forces=link_forces,
+        parallel=False,
+    )
+
+    v̇_WB_par, s̈_par = js.model.forward_dynamics_aba(
+        model=model,
+        data=data,
+        joint_forces=joint_forces,
+        link_forces=link_forces,
+        parallel=True,
+    )
+
+    assert_allclose(v̇_WB_seq, v̇_WB_par, atol=1e-9)
+    assert_allclose(s̈_seq, s̈_par, atol=1e-9)
+
+    # ==========================================
+    # Test 2: Low-level RBDA (aba vs aba_parallel)
+    # ==========================================
+
+    with data.switch_velocity_representation(VelRepr.Inertial):
+        W_p_B = data.base_position
+        W_Q_B = data.base_orientation
+        s = data.joint_positions
+        W_v_WB = data.base_velocity
+        ṡ = data.joint_velocities
+
+    W_f_L = references._link_forces
+    τ = references._joint_force_references
+
+    rbda_kwargs = dict(
+        model=model,
+        base_position=W_p_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+        joint_positions=s,
+        base_linear_velocity=W_v_WB[0:3],
+        base_angular_velocity=W_v_WB[3:6],
+        joint_velocities=ṡ,
+        joint_forces=τ,
+        joint_transforms=data._joint_transforms,
+        link_forces=W_f_L,
+        standard_gravity=model.gravity,
+    )
+
+    import jaxsim.rbda
+
+    result_seq = jaxsim.rbda.aba(**rbda_kwargs)
+    result_par = jaxsim.rbda.aba_parallel(**rbda_kwargs)
+
+    assert_allclose(result_seq[0], result_par[0], atol=1e-9)
+    assert_allclose(result_seq[1], result_par[1], atol=1e-9)

--- a/tests/test_api_model.py
+++ b/tests/test_api_model.py
@@ -582,9 +582,11 @@ def test_aba_vs_aba_parallel(
     velocity_representation: VelRepr,
     prng_key: jax.Array,
 ):
-    """Verify that the level-parallel ABA produces identical results to
+    """
+    Verify that the level-parallel ABA produces identical results to
     the sequential ABA, both at the low-level RBDA and at the high-level
-    model API."""
+    model API.
+    """
 
     model = jaxsim_models_all
 
@@ -612,10 +614,6 @@ def test_aba_vs_aba_parallel(
             additive=False,
         )
 
-    # ==========================================
-    # Test 1: High-level API (forward_dynamics_aba)
-    # ==========================================
-
     joint_forces = references.joint_force_references()
     link_forces = references.link_forces(model=model, data=data)
 
@@ -638,38 +636,25 @@ def test_aba_vs_aba_parallel(
     assert_allclose(v̇_WB_seq, v̇_WB_par, atol=1e-9)
     assert_allclose(s̈_seq, s̈_par, atol=1e-9)
 
-    # ==========================================
-    # Test 2: Low-level RBDA (aba vs aba_parallel)
-    # ==========================================
 
-    with data.switch_velocity_representation(VelRepr.Inertial):
-        W_p_B = data.base_position
-        W_Q_B = data.base_orientation
-        s = data.joint_positions
-        W_v_WB = data.base_velocity
-        ṡ = data.joint_velocities
+def test_fk_vs_fk_parallel(
+    jaxsim_models_all: js.model.JaxSimModel,
+    velocity_representation: VelRepr,
+    prng_key: jax.Array,
+):
+    """
+    Verify that the level-parallel FK produces identical results to
+    the sequential FK.
+    """
 
-    W_f_L = references._link_forces
-    τ = references._joint_force_references
+    model = jaxsim_models_all
 
-    rbda_kwargs = dict(
-        model=model,
-        base_position=W_p_B,
-        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
-        joint_positions=s,
-        base_linear_velocity=W_v_WB[0:3],
-        base_angular_velocity=W_v_WB[3:6],
-        joint_velocities=ṡ,
-        joint_forces=τ,
-        joint_transforms=data._joint_transforms,
-        link_forces=W_f_L,
-        standard_gravity=model.gravity,
+    _, subkey = jax.random.split(prng_key, num=2)
+    data = js.data.random_model_data(
+        model=model, key=subkey, velocity_representation=velocity_representation
     )
 
-    import jaxsim.rbda
+    W_H_seq = js.model.forward_kinematics(model=model, data=data, parallel=False)
+    W_H_par = js.model.forward_kinematics(model=model, data=data, parallel=True)
 
-    result_seq = jaxsim.rbda.aba(**rbda_kwargs)
-    result_par = jaxsim.rbda.aba_parallel(**rbda_kwargs)
-
-    assert_allclose(result_seq[0], result_par[0], atol=1e-9)
-    assert_allclose(result_seq[1], result_par[1], atol=1e-9)
+    assert_allclose(W_H_seq, W_H_par, atol=1e-9)

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -84,7 +84,6 @@ def test_ad_aba(
     s = data.joint_positions
     W_v_WB = data.base_velocity
     ṡ = data.joint_velocities
-    i_X_λi = data._joint_transforms
 
     # Inputs.
     W_f_L = references.link_forces(model=model)
@@ -95,24 +94,34 @@ def test_ad_aba(
     # ====
 
     # Get a closure exposing only the parameters to be differentiated.
-    aba = lambda W_p_B, W_Q_B, s, W_v_WB, ṡ, i_X_λi, τ, W_f_L, g: jaxsim.rbda.aba(
-        model=model,
-        base_position=W_p_B,
-        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
-        joint_positions=s,
-        base_linear_velocity=W_v_WB[0:3],
-        base_angular_velocity=W_v_WB[3:6],
-        joint_velocities=ṡ,
-        joint_forces=τ,
-        joint_transforms=i_X_λi,
-        link_forces=W_f_L,
-        standard_gravity=g,
-    )
+    def aba(W_p_B, W_Q_B, s, W_v_WB, ṡ, τ, W_f_L, g):
+        import jaxlie
+
+        W_H_B = jaxlie.SE3.from_rotation_and_translation(
+            rotation=jaxlie.SO3(wxyz=W_Q_B / jnp.linalg.norm(W_Q_B)),
+            translation=W_p_B,
+        ).as_matrix()
+        joint_transforms = model.kin_dyn_parameters.joint_transforms(
+            joint_positions=s, base_transform=W_H_B
+        )
+        return jaxsim.rbda.aba(
+            model=model,
+            base_position=W_p_B,
+            base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+            joint_positions=s,
+            base_linear_velocity=W_v_WB[0:3],
+            base_angular_velocity=W_v_WB[3:6],
+            joint_velocities=ṡ,
+            joint_transforms=joint_transforms,
+            joint_forces=τ,
+            link_forces=W_f_L,
+            standard_gravity=g,
+        )
 
     # Check derivatives against finite differences.
     check_grads(
         f=aba,
-        args=(W_p_B, W_Q_B, s, W_v_WB, ṡ, i_X_λi, τ, W_f_L, g),
+        args=(W_p_B, W_Q_B, s, W_v_WB, ṡ, τ, W_f_L, g),
         order=AD_ORDER,
         modes=["rev", "fwd"],
         eps=ε,
@@ -152,6 +161,7 @@ def test_ad_aba_parallel(
         base_linear_velocity=W_v_WB[0:3],
         base_angular_velocity=W_v_WB[3:6],
         joint_velocities=ṡ,
+        joint_transforms=i_X_λi,
         joint_forces=τ,
         link_forces=W_f_L,
         standard_gravity=g,
@@ -316,22 +326,26 @@ def test_ad_fk(
     # ====
 
     # Get a closure exposing only the parameters to be differentiated.
-    fk = lambda W_p_B, W_Q_B, s, W_v_lin, W_v_ang, ṡ: jaxsim.rbda.forward_kinematics_model(
-        model=model,
-        base_position=W_p_B,
-        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
-        joint_positions=s,
-        base_linear_velocity_inertial=W_v_lin,
-        base_angular_velocity_inertial=W_v_ang,
-        joint_velocities=ṡ,
-        joint_transforms=model.kin_dyn_parameters.joint_transforms(
+    def fk(W_p_B, W_Q_B, s, W_v_lin, W_v_ang, ṡ):
+        import jaxlie
+
+        W_H_B = jaxlie.SE3.from_rotation_and_translation(
+            rotation=jaxlie.SO3(wxyz=W_Q_B / jnp.linalg.norm(W_Q_B)),
+            translation=W_p_B,
+        ).as_matrix()
+        joint_transforms = model.kin_dyn_parameters.joint_transforms(
+            joint_positions=s, base_transform=W_H_B
+        )
+        return jaxsim.rbda.forward_kinematics_model(
+            model=model,
+            base_position=W_p_B,
+            base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
             joint_positions=s,
-            base_transform=jaxsim.math.Transform.from_quaternion_and_translation(
-                translation=W_p_B,
-                quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
-            ),
-        ),
-    )
+            base_linear_velocity_inertial=W_v_lin,
+            base_angular_velocity_inertial=W_v_ang,
+            joint_velocities=ṡ,
+            joint_transforms=joint_transforms,
+        )
 
     # Check derivatives against finite differences.
     check_grads(

--- a/tests/test_automatic_differentiation.py
+++ b/tests/test_automatic_differentiation.py
@@ -119,6 +119,85 @@ def test_ad_aba(
     )
 
 
+def test_ad_aba_parallel(
+    jaxsim_models_types: js.model.JaxSimModel,
+    prng_key: jax.Array,
+):
+
+    model = jaxsim_models_types
+
+    _, subkey = jax.random.split(prng_key, num=2)
+    data, references = get_random_data_and_references(
+        model=model, velocity_representation=VelRepr.Inertial, key=subkey
+    )
+
+    g = jaxsim.math.STANDARD_GRAVITY
+
+    W_p_B = data.base_position
+    W_Q_B = data.base_orientation
+    s = data.joint_positions
+    W_v_WB = data.base_velocity
+    ṡ = data.joint_velocities
+    i_X_λi = data._joint_transforms
+
+    W_f_L = references.link_forces(model=model)
+    τ = references.joint_force_references(model=model)
+
+    # Verify parallel ABA matches sequential ABA.
+    result_seq = jaxsim.rbda.aba(
+        model=model,
+        base_position=W_p_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+        joint_positions=s,
+        base_linear_velocity=W_v_WB[0:3],
+        base_angular_velocity=W_v_WB[3:6],
+        joint_velocities=ṡ,
+        joint_forces=τ,
+        link_forces=W_f_L,
+        standard_gravity=g,
+    )
+
+    result_par = jaxsim.rbda.aba_parallel(
+        model=model,
+        base_position=W_p_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+        joint_positions=s,
+        base_linear_velocity=W_v_WB[0:3],
+        base_angular_velocity=W_v_WB[3:6],
+        joint_velocities=ṡ,
+        joint_forces=τ,
+        joint_transforms=i_X_λi,
+        link_forces=W_f_L,
+        standard_gravity=g,
+    )
+
+    assert_allclose(result_seq[0], result_par[0], atol=1e-10)
+    assert_allclose(result_seq[1], result_par[1], atol=1e-10)
+
+    # Check derivatives against finite differences.
+    aba_par = lambda W_p_B, W_Q_B, s, W_v_WB, ṡ, i_X_λi, τ, W_f_L, g: jaxsim.rbda.aba_parallel(
+        model=model,
+        base_position=W_p_B,
+        base_quaternion=W_Q_B / jnp.linalg.norm(W_Q_B),
+        joint_positions=s,
+        base_linear_velocity=W_v_WB[0:3],
+        base_angular_velocity=W_v_WB[3:6],
+        joint_velocities=ṡ,
+        joint_forces=τ,
+        joint_transforms=i_X_λi,
+        link_forces=W_f_L,
+        standard_gravity=g,
+    )
+
+    check_grads(
+        f=aba_par,
+        args=(W_p_B, W_Q_B, s, W_v_WB, ṡ, i_X_λi, τ, W_f_L, g),
+        order=AD_ORDER,
+        modes=["rev", "fwd"],
+        eps=ε,
+    )
+
+
 def test_ad_rnea(
     jaxsim_models_types: js.model.JaxSimModel,
     prng_key: jax.Array,


### PR DESCRIPTION
This PR adds parallel implementations of ABA and forward kinematics, which can be enabled via `parallel=True`.

The FK `W_H_i = W_H_{parent} @ λ_H_i` is an associative composition of SE(3) transforms. Pointer jumping resolves all link poses in O(log_2 D) parallel rounds across all N nodes, instead of O(D) sequential levels.

Normally ABA has three sequential passes over the kinematic tree:

| Pass | Direction | Method | Complexity |
|------|-----------|--------|------------|
| 1: Velocity propagation | root to leaves | Pointer jumping | O(log D) |
| 2: Inertia accumulation | leaves to root | Level-parallel | O(D) |
| 3: Acceleration propagation | root to leaves | Pointer jumping | O(log D) |

Passes 1 and 3 exploit the fact that the velocity and acceleration recurrences are affine: `x_i = A_i @ x_{parent} + b_i`. This admits an associative binary operator, enabling parallel prefix computation via pointer jumping.

Pass 2 remains level-parallel because the Schur complement is not associative.

### Benchmarks (float64)

#### FK: GPU (RTX 5090)

**Single-state**

| Model | Links | Sequential | Parallel | Speedup |
|-------|-------|-----------|----------|---------|
| ur10 | 7 | 180 µs | 91 µs | 2.0x |
| ergocub_reduced | 13 | 321 µs | 109 µs | 2.9x |
| ergocub | 58 | 1318 µs | 121 µs | **10.9x** |

**Batched - ergocub**

| Batch | Sequential | Parallel | Speedup |
|-------|-----------|----------|---------|
| 1 | 1733 µs | 101 µs | **17.1x** |
| 16 | 1495 µs | 191 µs | **7.8x** |
| 64 | 1502 µs | 688 µs | 2.2x |
| 256 | 3004 µs | 1757 µs | 1.7x |
| 1024 | 8287 µs | 6487 µs | 1.3x |

#### ABA: GPU (RTX 5090)

**Single-state**

| Model | Links | Sequential | Parallel | Speedup |
|-------|-------|-----------|----------|---------|
| ur10 | 7 | 580 µs | 715 µs | 0.8× |
| ergocub_reduced | 13 | 1501 µs | 906 µs | 1.7× |
| ergocub | 58 | 4311 µs | 1316 µs | **3.3×** |

**Batched-ergocub**

| Batch | Sequential | Parallel | Speedup |
|-------|-----------|----------|---------|
| 1 | 4467 µs | 1243 µs | **3.6×** |
| 16 | 5142 µs | 1569 µs | **3.3×** |
| 64 | 5223 µs | 2525 µs | 2.1× |
| 256 | 7236 µs | 6214 µs | 1.2× |
| 1024 | 14466 µs | 23225 µs | 0.6× |

On CPU, XLA schedules operations sequentially so the pointer-jumping overhead yields almost no benefit. At large GPU batch sizes (>256 for ABA on RTX5090 Max-Q), `vmap` already saturates compute and sequential becomes faster.

### References

- Hillis, W.D. and Steele, G.L., 1986. *Data parallel algorithms*. Communications of the ACM, 29(12), pp.1170-1183.
- Blelloch, G.E., 1990. *Prefix sums and their applications*. Technical Report CMU-CS-90-190, Carnegie Mellon University.
- Featherstone, R., 2008. *Rigid Body Dynamics Algorithms*. Springer. (ABA formulation, Chapter 7)

fyi @traversaro 

<!-- readthedocs-preview jaxsim start -->
----
📚 Documentation preview 📚: https://jaxsim--514.org.readthedocs.build//514/

<!-- readthedocs-preview jaxsim end -->